### PR TITLE
Introduce Test 1-24 functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ celerybeat.pid
 .venv
 env/
 venv/
+ocp-venv/
+tft-venv/
 ENV/
 env.bak/
 venv.bak/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains the yaml files, docker files, and test scripts to test 
 ```
 python -m venv tft-venv
 source tft-venv/bin/activate
-cat requirements.txt  | xargs -n1 pip3 install
+pip3 install --upgrade pip
+pip3 install -r requirements.txt
 ```
 
 ## Creating the docker pods

--- a/common.py
+++ b/common.py
@@ -7,6 +7,40 @@ class PodType(Enum):
     SRIOV      = 2
     HOSTBACKED = 3
 
+class TestCaseType(Enum):
+    POD_TO_POD_SAME_NODE                 = 1
+    POD_TO_POD_DIFF_NODE                 = 2
+    POD_TO_HOST_SAME_NODE                = 3
+    POD_TO_HOST_DIFF_NODE                = 4
+    POD_TO_CLUSTER_IP_TO_POD_SAME_NODE   = 5
+    POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE   = 6
+    POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE  = 7
+    POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE  = 8
+    POD_TO_NODE_PORT_TO_POD_SAME_NODE    = 9
+    POD_TO_NODE_PORT_TO_POD_DIFF_NODE    = 10
+    POD_TO_NODE_PORT_TO_HOST_SAME_NODE   = 11
+    POD_TO_NODE_PORT_TO_HOST_DIFF_NODE   = 12
+    HOST_TO_HOST_SAME_NODE               = 13
+    HOST_TO_HOST_DIFF_NODE               = 14
+    HOST_TO_POD_SAME_NODE                = 15
+    HOST_TO_POD_DIFF_NODE                = 16
+    HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE  = 17
+    HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE  = 18
+    HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE = 19
+    HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE = 20
+    HOST_TO_NODE_PORT_TO_POD_SAME_NODE   = 21
+    HOST_TO_NODE_PORT_TO_POD_DIFF_NODE   = 22
+    HOST_TO_NODE_PORT_TO_HOST_SAME_NODE  = 23
+    HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE  = 24
+    POD_TO_EXTERNAL                      = 25
+    HOST_TO_EXTERNAL                     = 26
+
+class ConnectionMode(Enum):
+    POD_IP                               = 1
+    CLUSTER_IP                           = 2
+    NODE_PORT_IP                         = 3
+    EXTERNAL_IP                          = 4
+
 
 def j2_render(in_file_name, out_file_name, kwargs):
     with open(in_file_name) as inFile:

--- a/common.py
+++ b/common.py
@@ -41,6 +41,9 @@ class ConnectionMode(Enum):
     NODE_PORT_IP                         = 3
     EXTERNAL_IP                          = 4
 
+class NodeLocation(Enum):
+    SAME_NODE                            = 1
+    DIFF_NODE                            = 2
 
 def j2_render(in_file_name, out_file_name, kwargs):
     with open(in_file_name) as inFile:

--- a/iperf.py
+++ b/iperf.py
@@ -1,31 +1,32 @@
 import common
-from common import PodType
+from common import PodType, ConnectionMode
 from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
 from task import Task
 from host import Result
+from testSettings import TestSettings
 import sys
 import yaml
 import json
 
 
 class IperfServer(Task):
-    def __init__(self, tft: TestConfig, index: int, node_name: str, exec_persistent: bool, pod_type: PodType, tenant: bool):
-        super().__init__(tft, index, node_name, tenant)
-        self.exec_persistent = exec_persistent
+    def __init__(self, tft: TestConfig, ts: TestSettings):
+        super().__init__(tft, ts.server_index, ts.node_server_name, ts.server_is_tenant)
+        self.exec_persistent = ts.server_is_persistent
         self.port = 5201 + self.index
-        self.pod_type = pod_type
+        self.pod_type = ts.server_pod_type
 
-        if pod_type == PodType.SRIOV:
+        if self.pod_type == PodType.SRIOV:
             self.in_file_template = "./manifests/sriov-pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/sriov-pod-{self.node_name}-server.yaml"
             self.template_args["pod_name"] = f"sriov-pod-{self.node_name}-server-{self.port}"
-        elif pod_type == PodType.NORMAL:
+        elif self.pod_type == PodType.NORMAL:
             self.in_file_template = "./manifests/pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/pod-{self.node_name}-server.yaml"
             self.template_args["pod_name"] = f"normal-pod-{self.node_name}-server-{self.port}"
-        elif pod_type == PodType.HOSTBACKED:
+        elif self.pod_type == PodType.HOSTBACKED:
             self.in_file_template = "./manifests/host-pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/host-pod-{self.node_name}-server.yaml"
             self.template_args["pod_name"] = f"host-pod-{self.node_name}-server-{self.port}"
@@ -35,14 +36,14 @@ class IperfServer(Task):
         self.pod_name = self.template_args["pod_name"]
 
         if self.exec_persistent:
-            self.template_args["command"] = "iperf"
-            self.template_args["args"] = f"-s -p {self.port}"
+            self.template_args["command"] = "iperf3"
+            self.template_args["args"] = ["-s", "-p", f"{self.port}"]
 
         common.j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
         logger.info(f"Generated Server Pod Yaml {self.out_file_yaml}")
 
-        self.create_cluster_ip_service()
-        self.create_node_port_service(self.port + 25000)
+        self.cluster_ip_addr = self.create_cluster_ip_service()
+        self.nodeport_ip_addr = self.create_node_port_service(self.port + 25000)
 
     def setup(self):
         super().setup()
@@ -68,20 +69,22 @@ class IperfServer(Task):
         #logger.info(r.out)
 
 class IperfClient(Task):
-    def __init__(self, tft: TestConfig, server: IperfServer, index: int, node_name: str, pod_type: PodType, tenant: bool):
-        super().__init__(tft, index, node_name, tenant)
+    def __init__(self, tft: TestConfig, ts: TestSettings, server: IperfServer):
+        super().__init__(tft, ts.client_index, ts.node_client_name, ts.client_is_tenant)
         self.server = server
         self.port = self.server.port
+        self.pod_type = ts.client_pod_type
+        self.connection_mode = ts.connection_mode
 
-        if pod_type == PodType.SRIOV:
+        if self.pod_type  == PodType.SRIOV:
             self.in_file_template = "./manifests/sriov-pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/sriov-pod-{self.node_name}-client.yaml"
             self.template_args["pod_name"] = f"sriov-pod-{self.node_name}-client-{self.port}"
-        elif pod_type == PodType.NORMAL:
+        elif self.pod_type  == PodType.NORMAL:
             self.in_file_template = "./manifests/pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/pod-{self.node_name}-client.yaml"
             self.template_args["pod_name"] = f"normal-pod-{self.node_name}-client-{self.port}"
-        elif pod_type == PodType.HOSTBACKED:
+        elif self.pod_type  == PodType.HOSTBACKED:
             self.in_file_template = "./manifests/host-pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/host-pod-{self.node_name}-client.yaml"
             self.template_args["pod_name"] = f"host-pod-{self.node_name}-client-{self.port}"
@@ -95,7 +98,7 @@ class IperfClient(Task):
         def client(self, cmd: str):
             return self.run_oc(cmd)
 
-        server_ip = self.server.get_pod_ip()
+        server_ip = self.get_target_ip()
         cmd = f"exec -t {self.pod_name} -- iperf3 -c {server_ip} -p {self.port} --json -t {duration}"
         self.exec_thread = ReturnValueThread(target=client, args=(self, cmd))
         self.exec_thread.start()
@@ -113,3 +116,17 @@ class IperfClient(Task):
         gbps = data['end']['sum_received']['bits_per_second']/1e9
         logger.info(f"GBPS = {gbps}")
         #logger.info(r.out)
+
+    def get_target_ip(self) -> str:
+        if self.connection_mode == ConnectionMode.CLUSTER_IP:
+            logger.debug(f"get_target_ip() ClusterIP connection to {self.server.cluster_ip_addr}")
+            return self.server.cluster_ip_addr
+        elif self.connection_mode == ConnectionMode.NODE_PORT_IP:
+            logger.debug(f"get_target_ip() NodePortIP connection to {self.server.nodeport_ip_addr}")
+            return self.server.nodeport_ip_addr
+        elif self.connection_mode == ConnectionMode.EXTERNAL_IP:
+            logger.error("Pod to External not yet supported")
+            sys.exit(-1)
+        server_ip = self.server.get_pod_ip()
+        logger.debug(f"get_target_ip() Connection to server at {server_ip}")
+        return server_ip

--- a/logger.py
+++ b/logger.py
@@ -23,4 +23,4 @@ def configure_logger(lvl):
 
 prev_handler = None
 logger = None
-configure_logger(logging.INFO)
+configure_logger(logging.DEBUG)

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -14,5 +14,5 @@ spec:
     image: {{ test_image }}
     command:
       - "{{ command }}"
-    args: ["{{ args }}"]
+    args: {{ args }}
     imagePullPolicy: IfNotPresent

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -16,5 +16,5 @@ spec:
     image: {{ test_image }}
     command:
       - "{{ command }}"
-    args: ["{{ args }}"]
+    args: {{ args }}
     imagePullPolicy: IfNotPresent

--- a/task.py
+++ b/task.py
@@ -51,7 +51,7 @@ class Task(ABC):
         y = yaml.safe_load(r.out)
         return y["status"]["podIP"]
 
-    def create_cluster_ip_service(self):
+    def create_cluster_ip_service(self) -> str:
         in_file_template = "./manifests/svc-cluster-ip.yaml.j2"
         out_file_yaml = f"./manifests/yamls/svc-cluster-ip.yaml"
 
@@ -63,7 +63,9 @@ class Task(ABC):
                 logger.info(r)
                 sys.exit(-1)
 
-    def create_node_port_service(self, nodeport: int):
+        return self.run_oc("get service tft-clusterip-service -o=jsonpath='{.spec.clusterIP}'").out
+
+    def create_node_port_service(self, nodeport: int) -> str:
         in_file_template = "./manifests/svc-node-port.yaml.j2"
         out_file_yaml = f"./manifests/yamls/svc-node-port.yaml"
         self.template_args["nodeport_svc_port"] = f"{nodeport}"
@@ -75,6 +77,8 @@ class Task(ABC):
             if "already exists" not in r.err:
                 logger.info(r)
                 sys.exit(-1)
+
+        return self.run_oc("get service tft-nodeport-service -o=jsonpath='{.spec.clusterIP}'").out
 
     def setup(self):
         # Check if pod already exists

--- a/testSettings.py
+++ b/testSettings.py
@@ -1,30 +1,34 @@
-from common import TestCaseType, PodType, ConnectionMode
+from common import TestCaseType, PodType, ConnectionMode, NodeLocation
 
 class TestSettings():
     """TestSettings will handle determining the logic require to configure the client/server for a given test"""
-    def __init__(self, test_case_id: TestCaseType, node_server_name: str, node_client_name: str, server_pod_type: PodType, client_pod_type: PodType):
+    def __init__(self, test_case_id: TestCaseType, node_server_name: str, node_client_name: str, server_pod_type: str, client_pod_type: str):
         self.test_ip = test_case_id
         self.node_server_name = self._determine_server_name(test_case_id, node_server_name, node_client_name)
         self.node_client_name = node_client_name
-        self.server_pod_type = server_pod_type
-        self.client_pod_type = client_pod_type
-        self.connection_mode = self._test_id_to_connection_mode(test_case_id)
-        self.server_is_persistent = self._server_test_to_persistent(test_case_id)
+        self.server_pod_type = self.server_test_to_pod_type(test_case_id, server_pod_type)
+        self.client_pod_type = self.client_test_to_pod_type(test_case_id, client_pod_type)
+        #TODO: Handle Case when client is not tenant
         self.client_is_tenant = True
         self.server_is_tenant = True
         #TODO: Add task indexing
         self.server_index = 0
         self.client_index = 0
 
-    def get_test_info(self) -> str:
-        test_type = ""
-        if self.node_server_name == self.node_client_name:
-            test_type = "SAME NODE"
-        else:
-            test_type = "DIFF NODE"
+        # Derive params from test_case_id
+        self.set_all_params_from_test_case_id(test_case_id)
 
+    def set_all_params_from_test_case_id(self, test_case_id):
+        self.connection_mode = self._test_id_to_connection_mode(test_case_id)
+        self.server_is_persistent = self._server_test_to_persistent(test_case_id)
+        if self._is_same_node_test(test_case_id):
+            self.nodeLocation = NodeLocation.SAME_NODE
+        else:
+            self.nodeLocation = NodeLocation.DIFF_NODE
+
+    def get_test_info(self) -> str:
         return f"""TEST CONFIGURATION
-        Test Case {self.test_ip}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {test_type}
+        Test Case {self.test_ip}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.nodeLocation.name}
         Client Node: {self.node_client_name}
             Tenant={self.client_is_tenant}
             Index={self.client_index}
@@ -56,3 +60,21 @@ class TestSettings():
     def _server_test_to_persistent(self, test_id: int) -> bool:
         #TODO: add logic to determine when this is required
         return False
+
+    def server_test_to_pod_type(self, test_id: int, cfg_pod_type: str) -> PodType:
+        if test_id in (3, 4, 7, 8, 19, 20, 23, 24):
+            return PodType.HOSTBACKED
+
+        if cfg_pod_type == "sriov":
+            return PodType.SRIOV
+
+        return PodType.NORMAL
+
+    def client_test_to_pod_type(self, test_id: int, cfg_pod_type: str) -> PodType:
+        if test_id in range(13, 25) or test_id == 26:
+            return PodType.HOSTBACKED
+
+        if cfg_pod_type == "sriov":
+            return PodType.SRIOV
+
+        return PodType.NORMAL

--- a/testSettings.py
+++ b/testSettings.py
@@ -1,0 +1,58 @@
+from common import TestCaseType, PodType, ConnectionMode
+
+class TestSettings():
+    """TestSettings will handle determining the logic require to configure the client/server for a given test"""
+    def __init__(self, test_case_id: TestCaseType, node_server_name: str, node_client_name: str, server_pod_type: PodType, client_pod_type: PodType):
+        self.test_ip = test_case_id
+        self.node_server_name = self._determine_server_name(test_case_id, node_server_name, node_client_name)
+        self.node_client_name = node_client_name
+        self.server_pod_type = server_pod_type
+        self.client_pod_type = client_pod_type
+        self.connection_mode = self._test_id_to_connection_mode(test_case_id)
+        self.server_is_persistent = self._server_test_to_persistent(test_case_id)
+        self.client_is_tenant = True
+        self.server_is_tenant = True
+        #TODO: Add task indexing
+        self.server_index = 0
+        self.client_index = 0
+
+    def get_test_info(self) -> str:
+        test_type = ""
+        if self.node_server_name == self.node_client_name:
+            test_type = "SAME NODE"
+        else:
+            test_type = "DIFF NODE"
+
+        return f"""TEST CONFIGURATION
+        Test Case {self.test_ip}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {test_type}
+        Client Node: {self.node_client_name}
+            Tenant={self.client_is_tenant}
+            Index={self.client_index}
+        Server Node: {self.node_server_name}
+            Exec Persistence: {self.server_is_persistent}
+            Tenant={self.server_is_tenant}
+            Index={self.server_index}
+        """
+
+    def _test_id_to_connection_mode(self, test_case_id) -> ConnectionMode:
+        """The connection type will be used to determine what IP the client should direct traffic to"""
+        if test_case_id in (5, 6, 7, 8, 17, 18, 19, 20):
+            return ConnectionMode.CLUSTER_IP
+        if test_case_id in (9, 10, 11, 12, 21, 22, 23, 24):
+            return ConnectionMode.NODE_PORT_IP
+        if test_case_id in (25, 26):
+            return ConnectionMode.EXTERNAL_IP
+        return ConnectionMode.POD_IP
+
+    def _determine_server_name(self, test_case_id: TestCaseType, node_server_name: str, node_client_name: str):
+        """If conducting Same Node testing, the server node should be the client node"""
+        if self._is_same_node_test(test_case_id):
+            return node_client_name
+        return node_server_name
+
+    def _is_same_node_test(self, test_id: int) -> bool:
+        return test_id in (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23)
+
+    def _server_test_to_persistent(self, test_id: int) -> bool:
+        #TODO: add logic to determine when this is required
+        return False

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -22,24 +22,6 @@ class TrafficFlowTests():
         c = IperfClient(tft=self._tft, ts=self.test_settings, server=s)
         return (s, c)
 
-    def server_test_to_pod_type(self, test_id: int, cfg_pod_type: str) -> PodType:
-        if test_id in (3, 4, 7, 8, 19, 20, 23, 24):
-            return PodType.HOSTBACKED
-
-        if cfg_pod_type == "sriov":
-            return PodType.SRIOV
-
-        return PodType.NORMAL
-
-    def client_test_to_pod_type(self, test_id: int, cfg_pod_type: str) -> PodType:
-        if test_id in range(13, 25) or test_id == 26:
-            return PodType.HOSTBACKED
-
-        if cfg_pod_type == "sriov":
-            return PodType.SRIOV
-
-        return PodType.NORMAL
-
     def configure_namespace(self, namespace: str):
         logger.info(f"Configuring namespace {namespace}")
         r = self._tft.client_tenant.oc(f"label ns --overwrite {namespace} pod-security.kubernetes.io/enforce=privileged \
@@ -130,8 +112,8 @@ class TrafficFlowTests():
                 test_case_id=test_id,
                 node_server_name=node_server_name,
                 node_client_name=node_client_name,
-                server_pod_type=self.server_test_to_pod_type(test_id, pod_type),
-                client_pod_type=self.client_test_to_pod_type(test_id, pod_type),
+                server_pod_type=pod_type,
+                client_pod_type=pod_type
             )
             s, c = self.create_iperf_server_client(self.test_settings)
 


### PR DESCRIPTION
This commit includes some general refactoring to aid with organizing the various configurations and adds some logic to set reasonable defaults based on the test case ids.

With these changes discrete trials of tests 1 - 24 should work.

Still TODO to achieve basic parity with legacy FT tool:
- Pod to External Testing
- HWOL detection monitor
- Add basic driver to run program from user config rather than hardcoded values