### PR TITLE
Add output functionality to FT Tool

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,9 +2,8 @@ name: Build and Push
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
 
@@ -27,16 +26,14 @@ jobs:
     - name: Build and Push TFT-x86 image
       uses: docker/build-push-action@v2
       with:
-        context: ./images/
-        file: Containerfile
+        file: ./images/Containerfile
         push: true
         tags: |
           quay.io/wizhao/tft-tools:${{ steps.date.outputs.date }}-x86_64
     - name: Build and Push TFT-ARM64 image
       uses: docker/build-push-action@v2
       with:
-        context: ./images/
-        file: Containerfile
+        file: ./images/Containerfile
         push: true
         platforms: linux/arm64
         tags: |

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+ft-logs

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ tft:
     namespace: "default"
     test_cases: "1"
     duration: "10"
+    #logs: "/tmp/ft-logs" # default ft-logs/
     connections:
       - name: "Connection 1"
         type: "iperf-tcp"

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -3,6 +3,7 @@ from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
 from task import Task
+from host import Result
 import sys
 import yaml
 import json
@@ -42,3 +43,7 @@ class MeasureCPU(Task):
         #logger.info(data)
         p_idle = data[0]['percent_idle']
         logger.info(f"Idle on {self.node_name} = {p_idle}%")
+
+    def output(self):
+        #TODO: handle printing/storing output here
+        pass

--- a/measurePower.py
+++ b/measurePower.py
@@ -66,3 +66,7 @@ class MeasurePower(Task):
         if r.returncode != 0:
             logger.info(r)
         logger.info(f"measurePower results: {r.out}")
+
+    def output(self):
+        #TODO: handle printing/storing output here
+        pass

--- a/task.py
+++ b/task.py
@@ -107,3 +107,12 @@ class Task(ABC):
     @abstractmethod
     def stop(self):
         raise NotImplementedError('Must implement stop()')
+    
+    """
+    output() should be called to store the results of this task in a machine readable format (i.e. json) in the log location specified by the user,
+    as well as print any required info/debug to the console. The results should be formatted such that other modules can easily consume the output, such
+    as a module to determine the success/failure/performance of a given run.
+    """
+    @abstractmethod
+    def output(self):
+        raise NotImplementedError('Must implement output()')


### PR DESCRIPTION
This commit introduces a new abstract method for tasks. Tasks will have an "output()" function which saves the results of the run in a machine readable format such that it may be consumed by other modules (i.e. scoring component to determine the pass/failure rate of the tests, dashboard to display results).

Additionally output() should handle printing any human-read friendly output to the stdout logs.