### PR TITLE
Add Flow Test result evaluator

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -7,6 +7,7 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description='Build a custom image and store in the specified repository')
     parser.add_argument('config', metavar='config', type=str, help='Yaml file with test configuration (see config.yaml)')
+    parser.add_argument('evaluator_config', metavar='evaluator_config', type=str, help="Yaml file with configuration for scoring test results (see eval-config.yaml)")
     parser.add_argument('-v', '--verbosity', choices=['debug', 'info', 'warning', 'error', 'critical'], default='info', help='Set the logging level (default: info)')
 
     args = parser.parse_args()
@@ -23,5 +24,7 @@ def parse_args() -> argparse.Namespace:
 
     if not os.path.exists(args.config):
         raise ValueError("Must provide a valid config.yaml file (see config.yaml)")
+    if not os.path.exists(args.evaluator_config):
+        raise ValueError("Must provide a valid config file to evaluate results (see eval-config.yaml)")
 
     return args

--- a/arguments.py
+++ b/arguments.py
@@ -2,6 +2,7 @@ import os
 from logger import logger, configure_logger
 import logging
 import argparse
+from pathlib import Path
 
 def parse_args() -> argparse.Namespace:
 
@@ -22,9 +23,9 @@ def parse_args() -> argparse.Namespace:
     args.verbosity = log_levels[args.verbosity]
     configure_logger(args.verbosity)
 
-    if not os.path.exists(args.config):
+    if not Path(args.config).exists():
         raise ValueError("Must provide a valid config.yaml file (see config.yaml)")
-    if not os.path.exists(args.evaluator_config):
+    if not Path(args.evaluator_config).exists():
         raise ValueError("Must provide a valid config file to evaluate results (see eval-config.yaml)")
 
     return args

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ tft:
     # Location of artifacts from run can be specified: default <working-dir>/ft-logs/
     # logs: "/tmp/ft-logs"
     connections:
-      - name: "Connection 1"
+      - name: "Connection_1"
         # supported types: iperf-tcp, iperf-udp
         type: "iperf-tcp"
         instances: 1

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -1,0 +1,106 @@
+IPERF_TCP:
+  - id: 1 # POD_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 2 # POD_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 3 # POD_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 4 # POD_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 13 # HOST_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 14 # HOST_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 15 # HOST_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 16 # HOST_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    threshold: 18
+  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    threshold: 18
+  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    threshold: 18
+  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    threshold: 18
+  - id: 25 # POD_TO_EXTERNAL
+    threshold: 18
+  - id: 26 # HOST_TO_EXTERNAL
+    threshold: 18
+IPERF_UDP:
+  - id: 1 # POD_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 2 # POD_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 3 # POD_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 4 # POD_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 13 # HOST_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 14 # HOST_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 15 # HOST_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 16 # HOST_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    threshold: 5
+  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    threshold: 5
+  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    threshold: 5
+  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    threshold: 5
+  - id: 25 # POD_TO_EXTERNAL
+    threshold: 5
+  - id: 26 # HOST_TO_EXTERNAL
+    threshold: 5

--- a/evaluator.py
+++ b/evaluator.py
@@ -1,0 +1,186 @@
+import argparse
+import os
+import sys
+import yaml
+import json
+from collections import namedtuple
+from common import TestCaseType, TestType
+from logger import logger
+
+
+Bitrate = namedtuple("Bitrate", "tx rx")
+
+#TODO: We made need to extend this to include results from other plugins (i.e. is HWOL working) such that
+# we can return a single "Status" from a test
+Status = namedtuple("Status", "result num_passed num_failed")
+
+class Result():
+    def __init__(self, test_id: TestCaseType, test_type: TestType, success: bool, bitrate_gbps: Bitrate):
+        self.test_id = test_id
+        self.test_type = test_type
+        self.success = success
+        self.bitrate_gbps = bitrate_gbps
+
+    def dump_to_json(self) -> dict:
+        return {"test_id": self.test_id,
+                "test_type": self.test_type,
+                "success": self.success,
+                "Bitrate_Gbps_Tx": self.bitrate_gbps.tx,
+                "Bitrate_Gbps_Rx": self.bitrate_gbps.rx}
+
+
+class Evaluator():
+    def __init__(self, config_path: str):
+        with open(config_path, encoding='utf-8') as file:
+            c = yaml.safe_load(file)
+
+        self.config = c
+        self.results = []
+
+    def eval_log(self, log_path):
+        with open(log_path, encoding='utf8') as file:
+            self.log = yaml.safe_load(file)
+
+        try:
+            metadata = self.log["tft-metadata"]
+            test_case_id = metadata["test_case_id"]
+            test_type = metadata["test_type"]
+            ft_result = self.log["result"]
+        except KeyError as e:
+            logger.error(f"KeyError: {e}. Malformed log handed to eval_log()")
+            raise Exception(f"eval_log(): error parsing {log_path} for expected fields")
+
+        bitrate_threshold = self.get_threshold(test_case_id, test_type)
+        bitrate_gbps = self.calculate_gbps(ft_result, test_type)
+
+        result = Result(
+            test_id = test_case_id,
+            test_type = test_type,
+            success = self.is_passing(bitrate_threshold, bitrate_gbps),
+            bitrate_gbps = bitrate_gbps)
+
+        self.results.append(result)
+
+    def is_passing(self, threshold: int, bitrate_gbps: Bitrate) -> bool:
+        return bitrate_gbps.tx >= threshold and bitrate_gbps.rx >= threshold
+
+    def get_threshold(self, test_case_id: TestCaseType, test_type: TestType) -> int:
+        try:
+            return self.config[test_type][TestCaseType[test_case_id].value]["threshold"]
+        except KeyError as e:
+            logger.error(f"KeyError: {e}. Config does not contain valid config for test case {test_type.name} id {test_case_id}")
+            raise Exception(f"get_threshold(): Failed to parse evaluator config")
+
+    def calculate_gbps(self, result: dict, test_type: TestType) -> Bitrate:
+        if test_type == TestType.IPERF_TCP.name:
+            return self.calculate_gbps_iperf_tcp(result)
+        elif test_type == TestType.IPERF_UDP.name:
+            return self.calculate_gbps_iperf_udp(result)
+        elif test_type == TestType.HTTP.name:
+            return self.calculate_gbps_http(result)
+        else:
+            logger.error(f"Error calculating bitrate, Test of type {test_type} is not supported")
+            raise Exception(f"calculate_gbps(): Invalid test_type {test_type} provided")
+
+    def dump_to_json(self) -> dict:
+        passing = []
+        failing = []
+        for result in self.results:
+            output = {"test_case_id": result.test_id,
+                      "test_type": result.test_type,
+                      "Bitrate_Gbps_rx": result.bitrate_gbps.rx,
+                      "Bitrate_Gbps_tx": result.bitrate_gbps.tx}
+            if result.success == True:
+                passing.append(output)
+            else:
+                failing.append(output)
+        return {"passing": passing, "failing": failing}
+
+    def calculate_gbps_iperf_tcp(self, result: dict) -> Bitrate:
+        # If an error occured, bitrate = 0
+        if "error" in result:
+            logger.error(f"An error occured during iperf test: {result['error']}")
+            return Bitrate(0,0)
+
+        try:
+            sum_sent = result["end"]["sum_sent"]
+            sum_received = result["end"]["sum_received"]
+        except KeyError as e:
+            logger.error(f"KeyError: {e}. Malformed results when parsing iperf tcp for sum_sent/received")
+            raise Exception(f"calculate_gbps_iperf_tcp(): failed to parse iperf test results")
+
+        bitrate_sent = sum_sent["bits_per_second"] / 1e9
+        bitrate_received = sum_received["bits_per_second"] / 1e9
+
+        return Bitrate(float(f"{bitrate_sent:.5g}"), float(f"{bitrate_received:.5g}"))
+
+
+    def calculate_gbps_iperf_udp(self, result: dict) -> Bitrate:
+        # If an error occured, bitrate = 0
+        if "error" in result:
+            logger.error(f"An error occured during iperf test: {result['error']}")
+            return Bitrate(0,0)
+
+        sum_data = result["end"]["sum"]
+
+        # UDP tests only have sender traffic
+        bitrate_sent = sum_data["bits_per_second"] / 1e9
+        return Bitrate(float(f"{bitrate_sent:.5g}"), float(f"{bitrate_sent:.5g}"))
+
+
+    def calculate_gbps_http(self, result: dict) -> Bitrate:
+        #TODO: Add http traffic testing
+        return -1
+
+    def evaluate_pass_fail_status(self) -> Status:
+        total_passing = 0
+        total_failing = 0
+        for result in self.results:
+            if result.success:
+                total_passing += 1
+            else:
+                total_failing += 1
+        return Status(total_failing == 0, total_passing, total_failing)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Tool to evaluate TFT Flow test results')
+    parser.add_argument('config', metavar='config', type=str, help='Yaml file with tft test threshholds')
+    parser.add_argument('--logs', type=str, help='Directory containing TFT log files to evaluate')
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.config):
+        logger.error(f"No config file found at {args.config}, exiting")
+        sys.exit(-1)
+
+    if args.logs:
+        if not os.path.exists(args.logs):
+            logger.error(f"Log directory {args.logs} does not exist")
+            sys.exit(-1)
+
+    return args
+
+def main():
+    args = parse_args()
+    evaluator = Evaluator(args.config)
+
+    # Hand evaluator files to evaluate
+    for file in os.listdir(args.logs):
+        log = os.path.join(args.logs, file)
+
+        if os.path.isfile(log):
+            evaluator.eval_log(log)
+
+    # Generate Resulting Json
+    data = evaluator.dump_to_json()
+    file_path = "/tmp/test.json"
+    with open(file_path, "w") as json_file:
+        json.dump(data, json_file)
+    logger.info(data)
+
+    res = evaluator.evaluate_pass_fail_status()
+    logger.info(f"RESULT OF TEST: Success = {res.result}. Passed {res.num_passed}/{res.num_passed + res.num_failed}")
+
+if __name__ == "__main__":
+    main()

--- a/evaluator.py
+++ b/evaluator.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from dataclasses import dataclass
 from common import TestCaseType, TestType
 from logger import logger
+from pathlib import Path
 
 
 Bitrate = namedtuple("Bitrate", "tx rx")
@@ -40,7 +41,7 @@ class TestResult():
         self.success = success
         self.bitrate_gbps = bitrate_gbps
 
-    def dump_to_json(self) -> dict:
+    def dump_to_json(self) -> str:
         return json.dumps({"test_id": self.test_id,
                 "test_type": self.test_type,
                 "success": self.success,
@@ -56,7 +57,7 @@ class Evaluator():
         self.config = c
         self.results = []
 
-    def eval_log(self, log_path):
+    def eval_log(self, log_path: Path):
         with open(log_path, encoding='utf8') as file:
             self.log = json.load(file)
 
@@ -172,12 +173,12 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    if not os.path.exists(args.config):
+    if not Path(args.config).exists():
         logger.error(f"No config file found at {args.config}, exiting")
         sys.exit(-1)
 
     if args.logs:
-        if not os.path.exists(args.logs):
+        if not Path(args.logs).exists():
             logger.error(f"Log directory {args.logs} does not exist")
             sys.exit(-1)
 
@@ -188,11 +189,10 @@ def main():
     evaluator = Evaluator(args.config)
 
     # Hand evaluator files to evaluate
-    for file in os.listdir(args.logs):
-        log = os.path.join(args.logs, file)
-
-        if os.path.isfile(log):
-            evaluator.eval_log(log)
+    for file in Path(args.logs).iterdir():
+        if file.is_file():
+            print(file)
+            evaluator.eval_log(file)
 
     # Generate Resulting Json
     data = evaluator.dump_to_json()

--- a/iperf.py
+++ b/iperf.py
@@ -16,8 +16,8 @@ IPERF_REV_OPT = "-R"
 EXTERNAL_IPERF3_SERVER = "external-iperf3-server"
 
 class IperfServer(Task):
-    def __init__(self, tft: TestConfig, ts: TestSettings):
-        super().__init__(tft, ts.server_index, ts.node_server_name, ts.server_is_tenant)
+    def __init__(self, cc: TestConfig, ts: TestSettings):
+        super().__init__(cc, ts.server_index, ts.node_server_name, ts.server_is_tenant)
         self.exec_persistent = ts.server_is_persistent
         self.port = 5201 + self.index
         self.pod_type = ts.server_pod_type
@@ -88,8 +88,8 @@ class IperfServer(Task):
         pass
 
 class IperfClient(Task):
-    def __init__(self, tft: TestConfig, ts: TestSettings, server: IperfServer):
-        super().__init__(tft, ts.client_index, ts.node_client_name, ts.client_is_tenant)
+    def __init__(self, cc: TestConfig, ts: TestSettings, server: IperfServer):
+        super().__init__(cc, ts.client_index, ts.node_client_name, ts.client_is_tenant)
         self.server = server
         self.port = self.server.port
         self.pod_type = ts.client_pod_type

--- a/iperf.py
+++ b/iperf.py
@@ -148,7 +148,8 @@ class IperfClient(Task):
 
     def output(self):
         # Store json output as run logs
-        with open(self.log_path + self.ts.get_test_str() + ".json", "w") as output_file:
+        log = self.log_path / (self.ts.get_test_str() + ".json")
+        with open(log, "w") as output_file:
             json.dump(self._output, output_file, indent=4)
 
         # Print summary to console logs

--- a/iperf.py
+++ b/iperf.py
@@ -218,7 +218,7 @@ class IperfClient(Task):
         logger.debug(f"get_podman_ip(): {ret.out}")
         if ret.returncode != 0:
             logger.error(f"Failed to inspect pod {pod_name} for IPAddress: {ret.err}")
-            sys.exit(-1)
+            raise Exception(f"get_podman_ip(): failed to get podman ip")
         return ret.out.strip()
 
     def iperf_error_occured(self, data: dict) -> bool:

--- a/iperf.py
+++ b/iperf.py
@@ -81,7 +81,7 @@ class IperfServer(Task):
         logger.info(f"Stopping execution on {self.pod_name}")
         r = self.exec_thread.join()
         if r.returncode != 0:
-            logger.error(f"Error occured while stopping Iperf server: errcode: {r.returncode} err {r.error}")
+            logger.error(f"Error occured while stopping Iperf server: errcode: {r.returncode} err {r.err}")
         logger.debug(f"IperfServer.stop(): {r.out}")
 
     def output(self):

--- a/main.py
+++ b/main.py
@@ -2,32 +2,21 @@ from testConfig import TestConfig
 from trafficFlowTests import TrafficFlowTests
 import arguments
 import sys
-from evaluator import Status
 
 
 def main():
-    print("START HERE")
     args = arguments.parse_args()
     cc = TestConfig(args.config)
     tft = TrafficFlowTests(cc)
 
     results = []
-    for test in tft._tft.GetConfig():
-        try:
-            results.append(tft.run(test, args.evaluator_config))
-        except Exception as e:
-            print(f"Error occured while running following test:\n {test}")
-            print(f"Test failed with exception: {e}")
-            results.append(Status(False, 0, 0))
+    for test in tft._cc.GetConfig():
+        tft.run(test, args.evaluator_config)
 
-    all_passing = True
-    for status in results:
-        print(f"RESULT: Success = {status.result}. Passed {status.num_passed}/{status.num_passed + status.num_failed}")
-        if not status.result:
-            all_passing = False
-
-    if not all_passing:
-        sys.exit(-1)
+        
+        if not tft.evaluate_run_success():
+            print(f"Failure detected in {test.name} results")
+            sys.exit(-1)
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def main():
 
         
         if not tft.evaluate_run_success():
-            print(f"Failure detected in {test.name} results")
+            print(f"Failure detected in {test['name']} results")
             sys.exit(-1)
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from testConfig import TestConfig
 from trafficFlowTests import TrafficFlowTests
 import arguments
+import sys
+from evaluator import Status
 
 
 def main():
@@ -8,9 +10,24 @@ def main():
     args = arguments.parse_args()
     cc = TestConfig(args.config)
     tft = TrafficFlowTests(cc)
-    tft.run()
 
-    print("END HERE")
+    results = []
+    for test in tft._tft.GetConfig():
+        try:
+            results.append(tft.run(test, args.evaluator_config))
+        except Exception as e:
+            print(f"Error occured while running following test:\n {test}")
+            print(f"Test failed with exception: {e}")
+            results.append(Status(False, 0, 0))
+
+    all_passing = True
+    for status in results:
+        print(f"RESULT: Success = {status.result}. Passed {status.num_passed}/{status.num_passed + status.num_failed}")
+        if not status.result:
+            all_passing = False
+
+    if not all_passing:
+        sys.exit(-1)
 
 if __name__ == "__main__":
     main()

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -10,8 +10,8 @@ import json
 import jc
 
 class MeasureCPU(Task):
-    def __init__(self, tft: TestConfig, node_name: str, tenant: bool):
-        super().__init__(tft, 0, node_name, tenant)
+    def __init__(self, cc: TestConfig, node_name: str, tenant: bool):
+        super().__init__(cc, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"

--- a/measurePower.py
+++ b/measurePower.py
@@ -12,8 +12,8 @@ import re
 import time
 
 class MeasurePower(Task):
-    def __init__(self, tft: TestConfig, node_name: str, tenant: bool):
-        super().__init__(tft, 0, node_name, tenant)
+    def __init__(self, cc: TestConfig, node_name: str, tenant: bool):
+        super().__init__(cc, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==5.4.1
 jinja2
 kubernetes
 jc
+dataclasses

--- a/task.py
+++ b/task.py
@@ -11,7 +11,7 @@ from thread import ReturnValueThread
 import host
 
 class Task(ABC):
-    def __init__(self, tft: TestConfig, index: int, node_name: str, tenant: bool):
+    def __init__(self, cc: TestConfig, index: int, node_name: str, tenant: bool):
         self.template_args = {}
         self.in_file_template = ""
         self.out_file_yaml = ""
@@ -29,18 +29,18 @@ class Task(ABC):
         self.index = index
         self.node_name = node_name
         self.tenant = tenant
-        if not self.tenant and tft.mode == ClusterMode.SINGLE:
+        if not self.tenant and cc.mode == ClusterMode.SINGLE:
             logger.error("Cannot have non-tenant Task when cluster mode is single.")
             sys.exit(-1)
 
         self.template_args["node_name"] = self.node_name
-        self.tft = tft
+        self.cc = cc
 
     def run_oc(self, cmd: str) -> host.Result:
         if self.tenant:
-            r = self.tft.client_tenant.oc(cmd)
+            r = self.cc.client_tenant.oc(cmd)
         else:
-            r = self.tft.client_infra.oc(cmd)
+            r = self.cc.client_infra.oc(cmd)
         return r
 
     def get_pod_ip(self):

--- a/testSettings.py
+++ b/testSettings.py
@@ -2,7 +2,18 @@ from common import TestCaseType, PodType, ConnectionMode, NodeLocation, TestType
 
 class TestSettings():
     """TestSettings will handle determining the logic require to configure the client/server for a given test"""
-    def __init__(self, test_case_id: TestCaseType, node_server_name: str, node_client_name: str, server_pod_type: str, client_pod_type: str, index: int, test_type: TestType, log_path: str):
+    def __init__(
+            self, connection_name: str,
+            test_case_id: TestCaseType,
+            node_server_name: str,
+            node_client_name: str,
+            server_pod_type: str,
+            client_pod_type: str,
+            index: int,
+            test_type: TestType,
+            log_path: str
+        ):
+        self.connection_name = connection_name
         self.test_case_id = test_case_id
         self.node_server_name = self._determine_server_name(test_case_id, node_server_name, node_client_name)
         self.node_client_name = node_client_name
@@ -55,7 +66,7 @@ class TestSettings():
 
     def get_test_info_dict(self) -> dict:
         json_dump = {
-            "test_case_id": self.test_case_id,
+            "test_case_id": TestCaseType(self.test_case_id).name,
             "test_type": self.test_type.name,
             "server": {
                 "name": self.node_server_name,

--- a/testSettings.py
+++ b/testSettings.py
@@ -1,4 +1,5 @@
 from common import TestCaseType, PodType, ConnectionMode, NodeLocation, TestType
+from pathlib import Path
 
 class TestSettings():
     """TestSettings will handle determining the logic require to configure the client/server for a given test"""
@@ -11,7 +12,7 @@ class TestSettings():
             client_pod_type: str,
             index: int,
             test_type: TestType,
-            log_path: str
+            log_path: Path
         ):
         self.connection_name = connection_name
         self.test_case_id = test_case_id

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -11,7 +11,9 @@ from enum import Enum
 from host import LocalHost
 import sys
 import os
-import datetime
+import shutil
+import json
+from evaluator import Evaluator, Result, Status
 
 class TrafficFlowTests():
     def __init__(self, tft: TestConfig):
@@ -37,7 +39,7 @@ class TrafficFlowTests():
                                         security.openshift.io/scc.podSecurityLabelSync=false")
         if r.returncode != 0:
             logger.error(r)
-            sys.exit(-1)
+            raise Exception(f"configure_namespace(): Failed to label namespace {namespace}")
         logger.info(f"Configured namespace {namespace}")
 
     def cleanup_previous_testspace(self, namespace: str):
@@ -45,13 +47,13 @@ class TrafficFlowTests():
         r = self._tft.client_tenant.oc(f"delete pods -n {namespace} -l tft-tests")
         if r.returncode != 0:
             logger.error(r)
-            sys.exit(-1)
+            raise Exception(f"cleanup_previous_testspace(): Failed to delete pods")
         logger.info(f"Cleaned pods with label tft-tests in namespace {namespace}")
         logger.info(f"Cleaning services with label tft-tests in namespace {namespace}")
         r = self._tft.client_tenant.oc(f"delete services -n {namespace} -l tft-tests")
         if r.returncode != 0:
             logger.error(r)
-            sys.exit(-1)
+            raise Exception(f"cleanup_previous_testspace(): Failed to delete services")
         logger.info(f"Cleaned services with label tft-tests in namespace {namespace}")
         logger.info(f"Cleaning external containers {iperf.EXTERNAL_IPERF3_SERVER} (if present)")
         cmd = f"podman stop {iperf.EXTERNAL_IPERF3_SERVER}"
@@ -86,56 +88,86 @@ class TrafficFlowTests():
         log_path = self.log_path  
         # Create directory for logging
         if "logs" in tests:
-            log_path = tests['logs']
-        # We will create a subdirectory using the datetime to ensure each run has discrete logs
-        datetime_string = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        log_path = log_path + "/" + datetime_string + "/"
+            log_path = tests['logs'] + '/'
+        if os.path.exists(log_path):
+            shutil.rmtree(log_path)
         logger.info(f"Logs will be written to {log_path}")
         os.makedirs(log_path, exist_ok=False)
+        for connection in tests["connections"]:
+            os.makedirs(f"{log_path}/{connection['name']}-{self._tft.validate_test_type(connection).name}")
         return log_path
 
+    def evaluate_flow_tests(self, eval_config: str, *log_paths: str, ) -> Status:
+        evaluator = Evaluator(eval_config)
 
-    def run(self):
-        for tests in self._tft.GetConfig():
-            self.configure_namespace(tests['namespace'])
-            self.cleanup_previous_testspace(tests['namespace'])
-            self.log_path = self.create_log_path(tests)
-            duration = tests['duration']
-            logger.info(f"Running {tests['name']} for {duration} seconds")
-            test_cases = self._tft.parse_test_cases(tests['test_cases'])
-            for test_id in test_cases:
-                self.servers = []
-                self.clients = []
-                self.monitors = []
-                for connections in tests['connections']:
-                    logger.info(f"Starting {connections['name']}")
-                    logger.info(f"Number Of Simultaneous connections {connections['instances']}")
-                    for index in range(connections['instances']):
-                        node_server_name = connections['server'][0]['name']
-                        node_client_name = connections['client'][0]['name']
-                        test_type = self._tft.validate_test_type(connections)
-                        if test_type == TestType.IPERF_TCP or test_type == TestType.IPERF_UDP:
-                            self.test_settings = TestSettings(
-                                test_case_id=test_id,
-                                node_server_name=node_server_name,
-                                node_client_name=node_client_name,
-                                server_pod_type=self._tft.validate_pod_type(connections['server'][0]),
-                                client_pod_type=self._tft.validate_pod_type(connections['client'][0]),
-                                index=index,
-                                test_type=test_type,
-                                log_path=self.log_path,
-                            )
-                            s, c = self.create_iperf_server_client(self.test_settings)
-                            self.servers.append(s)
-                            self.clients.append(c)
-                        else:
-                            logger.error("http connections not currently supported")
-                        if connections['plugins']:
-                            for plugins in connections['plugins']:
-                                if plugins['name'] == "measure_cpu":
-                                    self.enable_measure_cpu_plugin(node_server_name, node_client_name, True)
-                                if plugins['name'] == "measure_power":
-                                    self.enable_measure_power_plugin(node_server_name, node_client_name, True)
+        for log_path in log_paths:
+            logger.info(f"Evaluating results of tests {log_path}*")
+            file_path = self.log_path + "/RESULTS/"
+            os.makedirs(file_path, exist_ok=True)
 
-                        self.run_tests(duration)
-                        self.cleanup_previous_testspace(tests['namespace'])
+            # Hand evaluator files to evaluate
+            for file in os.listdir(log_path):
+                log = os.path.join(log_path, file)
+
+                if os.path.isfile(log):
+                    logger.debug(f"Evaluating log {log}")
+                    evaluator.eval_log(log)
+
+            # Generate Resulting Json
+            file = file_path + "summary.json"
+            logger.info(f"Dumping results to {file}")
+            data = evaluator.dump_to_json()
+            with open(file, "w") as file:
+                json.dump(data, file)
+
+            # Return Status
+            return evaluator.evaluate_pass_fail_status()
+
+
+    def run(self, tests: dict, eval_config: str) -> Status:
+        self.configure_namespace(tests['namespace'])
+        self.cleanup_previous_testspace(tests['namespace'])
+        self.log_path = self.create_log_path(tests)
+        duration = tests['duration']
+        logger.info(f"Running {tests['name']} for {duration} seconds")
+        test_cases = self._tft.parse_test_cases(tests['test_cases'])
+        for test_id in test_cases:
+            self.servers = []
+            self.clients = []
+            self.monitors = []
+            #TODO Allow for multiple connections / instances and compile results into single log
+            for connections in tests['connections']:
+                logger.info(f"Starting {connections['name']}")
+                logger.info(f"Number Of Simultaneous connections {connections['instances']}")
+                for index in range(connections['instances']):
+                    node_server_name = connections['server'][0]['name']
+                    node_client_name = connections['client'][0]['name']
+                    test_type = self._tft.validate_test_type(connections)
+                    log_path=f"{self.log_path}/{connections['name']}-{test_type.name}/"
+                    if test_type == TestType.IPERF_TCP or test_type == TestType.IPERF_UDP:
+                        self.test_settings = TestSettings(
+                            connection_name=connections['name'],
+                            test_case_id=test_id,
+                            node_server_name=node_server_name,
+                            node_client_name=node_client_name,
+                            server_pod_type=self._tft.validate_pod_type(connections['server'][0]),
+                            client_pod_type=self._tft.validate_pod_type(connections['client'][0]),
+                            index=index,
+                            test_type=test_type,
+                            log_path=log_path,
+                        )
+                        s, c = self.create_iperf_server_client(self.test_settings)
+                        self.servers.append(s)
+                        self.clients.append(c)
+                    else:
+                        logger.error("http connections not currently supported")
+                    if connections['plugins']:
+                        for plugins in connections['plugins']:
+                            if plugins['name'] == "measure_cpu":
+                                self.enable_measure_cpu_plugin(node_server_name, node_client_name, True)
+                            if plugins['name'] == "measure_power":
+                                self.enable_measure_power_plugin(node_server_name, node_client_name, True)
+
+                    self.run_tests(duration)
+                    self.cleanup_previous_testspace(tests['namespace'])
+        return self.evaluate_flow_tests(eval_config, log_path)


### PR DESCRIPTION
This commit introduces a new module evaluator which takes a path to tft logs and evaluates performance. The threshold for pass/failure can be set via a config file (example provided). The class will generate a machine-readable file containing the results of the flow tests (pass/fail).

The main driver will now be resilant again errors that occur during runtime and return an error code if the flow tests are not completely green.