### PR TITLE
Add reverse iperf testing

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,4 +1,5 @@
 import jinja2
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -52,6 +53,29 @@ class ConnectionMode(Enum):
 class NodeLocation(Enum):
     SAME_NODE                            = 1
     DIFF_NODE                            = 2
+
+
+@dataclass
+class PodInfo():
+    name: str
+    pod_type: str
+    is_tenant: bool
+    index: int
+
+@dataclass
+class TestMetadata():
+    test_case_id: str
+    test_type: str
+    reverse: bool
+    server: PodInfo
+    client: PodInfo
+
+@dataclass
+class IperfOutput():
+    tft_metadata: TestMetadata
+    command: str
+    result: dict
+
 
 def j2_render(in_file_name, out_file_name, kwargs):
     with open(in_file_name) as inFile:


### PR DESCRIPTION
This commit adds reverse testing. As a side effect it also allows multiple connections be run in a single test.

Additional type safety is added by using dataclass for all instances of json / dict data.