### PR TITLE
Aggregate test results

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,10 +1,11 @@
 import jinja2
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict, field
 from enum import Enum
-
+from typing import List
 
 FT_BASE_IMG = "quay.io/wizhao/ft-base-image:0.9"
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:0.3"
+TFT_TESTS = "tft-tests"
 
 class TestType(Enum):
     IPERF_TCP  = 1
@@ -75,6 +76,27 @@ class IperfOutput():
     tft_metadata: TestMetadata
     command: str
     result: dict
+
+@dataclass
+class PluginOutput():
+    plugin_metadata: dict
+    command: str
+    result: dict
+    name: str
+
+@dataclass
+class TftAggregateOutput():
+    '''Aggregated output of a single tft run. A single run of a trafficFlowTests._run_tests() will
+    pass a reference to an instance of TftAggregateOutput to each task to which the task will append
+    it's respective output. A list of this class will be the expected format of input provided to
+    evaluator.py.
+
+    Attributes:
+        flow_test: an object of type IperfOutput containing the results of a flow test run
+        plugins: a list of objects derivated from type PluginOutput for each optional plugin to append
+        resulting output to.'''
+    flow_test: IperfOutput = None
+    plugins: List[PluginOutput] = field(default_factory=list)
 
 
 def j2_render(in_file_name, out_file_name, kwargs):

--- a/evaluator.py
+++ b/evaluator.py
@@ -60,8 +60,8 @@ class Evaluator():
             with open(log_path, 'r') as file:
                 data = IperfOutput(**json.load(file))
             md = TestMetadata(**data.tft_metadata)
-        except KeyError as e:
-            logger.error(f"KeyError: {e}. Malformed log handed to eval_log()")
+        except Exception as e:
+            logger.error(f"Exception: {e}. Malformed log handed to eval_log()")
             raise Exception(f"eval_log(): error parsing {log_path} for expected fields")
         bitrate_threshold = self.get_threshold(md.test_case_id, md.test_type)
         bitrate_gbps = self.calculate_gbps(data.result, md.test_type)

--- a/iperf.py
+++ b/iperf.py
@@ -26,7 +26,6 @@ class IperfServer(Task):
         self.port = 5201 + self.index
         self.pod_type = ts.server_pod_type
         self.connection_mode = ts.connection_mode
-        self.log_path = ts.log_path
 
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
             self.pod_name = EXTERNAL_IPERF3_SERVER
@@ -88,7 +87,7 @@ class IperfServer(Task):
             logger.error(f"Error occured while stopping Iperf server: errcode: {r.returncode} err {r.err}")
         logger.debug(f"IperfServer.stop(): {r.out}")
 
-    def output(self):
+    def output(self, out: common.TftAggregateOutput):
         pass
 
 class IperfClient(Task):
@@ -99,7 +98,6 @@ class IperfClient(Task):
         self.pod_type = ts.client_pod_type
         self.connection_mode = ts.connection_mode
         self.test_type = ts.test_type
-        self.log_path = ts.log_path
         self.test_case_id = ts.test_case_id
         self.ts = ts
         self.reverse = ts.reverse
@@ -153,12 +151,9 @@ class IperfClient(Task):
         )
         return json_dump
 
-    def output(self):
-        # Store json output as run logs
-        log = self.log_path / (self.ts.get_test_str() + ".json")
-        with open(log, "w") as output_file:
-            data = asdict(self._output)
-            json.dump(data, output_file)
+    def output(self, out: common.TftAggregateOutput):
+        # Return machine-readable output to top level
+        out.flow_test = self._output
 
         # Print summary to console logs
         logger.info(f"Results of {self.ts.get_test_str()}:")

--- a/iperf.py
+++ b/iperf.py
@@ -20,8 +20,8 @@ EXTERNAL_IPERF3_SERVER = "external-iperf3-server"
 
 
 class IperfServer(Task):
-    def __init__(self, cc: TestConfig, ts: TestSettings):
-        super().__init__(cc, ts.server_index, ts.node_server_name, ts.server_is_tenant)
+    def __init__(self, tc: TestConfig, ts: TestSettings):
+        super().__init__(tc, ts.server_index, ts.node_server_name, ts.server_is_tenant)
         self.exec_persistent = ts.server_is_persistent
         self.port = 5201 + self.index
         self.pod_type = ts.server_pod_type
@@ -92,8 +92,8 @@ class IperfServer(Task):
         pass
 
 class IperfClient(Task):
-    def __init__(self, cc: TestConfig, ts: TestSettings, server: IperfServer):
-        super().__init__(cc, ts.client_index, ts.node_client_name, ts.client_is_tenant)
+    def __init__(self, tc: TestConfig, ts: TestSettings, server: IperfServer):
+        super().__init__(tc, ts.client_index, ts.node_client_name, ts.client_is_tenant)
         self.server = server
         self.port = self.server.port
         self.pod_type = ts.client_pod_type
@@ -158,12 +158,10 @@ class IperfClient(Task):
         log = self.log_path / (self.ts.get_test_str() + ".json")
         with open(log, "w") as output_file:
             data = asdict(self._output)
-            print(data)
             json.dump(data, output_file)
 
         # Print summary to console logs
         logger.info(f"Results of {self.ts.get_test_str()}:")
-        print(self._output)
         if self.iperf_error_occured(self._output.result):
             logger.error("Encountered error while running test:\n"
                 f"  {self._output.result['error']}"

--- a/main.py
+++ b/main.py
@@ -6,11 +6,11 @@ import sys
 
 def main():
     args = arguments.parse_args()
-    cc = TestConfig(args.config)
-    tft = TrafficFlowTests(cc)
+    tc = TestConfig(args.config)
+    tft = TrafficFlowTests(tc)
 
     results = []
-    for test in tft._cc.GetConfig():
+    for test in tft._tc.GetConfig():
         tft.run(test, args.evaluator_config)
 
         

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ def main():
     tc = TestConfig(args.config)
     tft = TrafficFlowTests(tc)
 
-    results = []
     for test in tft._tc.GetConfig():
         tft.run(test, args.evaluator_config)
 

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -10,8 +10,8 @@ import json
 import jc
 
 class MeasureCPU(Task):
-    def __init__(self, cc: TestConfig, node_name: str, tenant: bool):
-        super().__init__(cc, 0, node_name, tenant)
+    def __init__(self, tc: TestConfig, node_name: str, tenant: bool):
+        super().__init__(tc, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -1,4 +1,4 @@
-import common
+from common import TFT_TOOLS_IMG, PluginOutput, j2_render, TftAggregateOutput
 from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
@@ -16,11 +16,13 @@ class MeasureCPU(Task):
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"
         self.template_args["pod_name"] = f"tools-pod-{self.node_name}-measure-cpu"
-        self.template_args["test_image"] = common.TFT_TOOLS_IMG
+        self.template_args["test_image"] = TFT_TOOLS_IMG
 
         self.pod_name = self.template_args["pod_name"]
+        self.node_name = node_name
+        self.cmd = ""
 
-        common.j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
+        j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
         logger.info(f"Generated Server Pod Yaml {self.out_file_yaml}")
 
     def run(self, duration: int):
@@ -28,10 +30,10 @@ class MeasureCPU(Task):
             return self.run_oc(cmd)
 
         # 1 report at intervals defined by the duration in seconds.
-        cmd = f"exec -t {self.pod_name} -- mpstat -P ALL {duration} 1"
-        self.exec_thread = ReturnValueThread(target=stat, args=(self, cmd))
+        self.cmd = f"exec -t {self.pod_name} -- mpstat -P ALL {duration} 1"
+        self.exec_thread = ReturnValueThread(target=stat, args=(self, self.cmd))
         self.exec_thread.start()
-        logger.info(f"Running {cmd}")
+        logger.info(f"Running {self.cmd}")
 
     def stop(self):
         logger.info(f"Stopping measureCPU execution on {self.pod_name}")
@@ -42,7 +44,25 @@ class MeasureCPU(Task):
         data = jc.parse('mpstat', r.out)
         p_idle = data[0]['percent_idle']
         logger.info(f"Idle on {self.node_name} = {p_idle}%")
+        self._output = self.generate_output(data)
 
-    def output(self):
-        #TODO: handle printing/storing output here
-        pass
+    def output(self, out: TftAggregateOutput):
+        # Return machine-readable output to top level
+        out.plugins.append(self._output)
+
+        # Print summary to console logs
+        p_idle = self._output.result['percent_idle']
+        logger.info(f"Idle on {self.node_name} = {p_idle}%")
+
+    #TODO: We are currently only storing the "cpu: all" data from mpstat
+    def generate_output(self, data) -> PluginOutput:
+        return PluginOutput(
+            plugin_metadata={
+                "name": "MeasureCPU",
+                "node_name": self.node_name,
+                "pod_name": self.pod_name,
+            },
+            command=self.cmd,
+            result=data[0],
+            name="measure_cpu"
+        )

--- a/measurePower.py
+++ b/measurePower.py
@@ -12,8 +12,8 @@ import re
 import time
 
 class MeasurePower(Task):
-    def __init__(self, cc: TestConfig, node_name: str, tenant: bool):
-        super().__init__(cc, 0, node_name, tenant)
+    def __init__(self, tc: TestConfig, node_name: str, tenant: bool):
+        super().__init__(tc, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = f"./manifests/yamls/tools-pod-{self.node_name}-measure-cpu.yaml"

--- a/task.py
+++ b/task.py
@@ -11,7 +11,7 @@ from thread import ReturnValueThread
 import host
 
 class Task(ABC):
-    def __init__(self, cc: TestConfig, index: int, node_name: str, tenant: bool):
+    def __init__(self, tc: TestConfig, index: int, node_name: str, tenant: bool):
         self.template_args = {}
         self.in_file_template = ""
         self.out_file_yaml = ""
@@ -29,18 +29,18 @@ class Task(ABC):
         self.index = index
         self.node_name = node_name
         self.tenant = tenant
-        if not self.tenant and cc.mode == ClusterMode.SINGLE:
+        if not self.tenant and tc.mode == ClusterMode.SINGLE:
             logger.error("Cannot have non-tenant Task when cluster mode is single.")
             sys.exit(-1)
 
         self.template_args["node_name"] = self.node_name
-        self.cc = cc
+        self.tc = tc
 
     def run_oc(self, cmd: str) -> host.Result:
         if self.tenant:
-            r = self.cc.client_tenant.oc(cmd)
+            r = self.tc.client_tenant.oc(cmd)
         else:
-            r = self.cc.client_infra.oc(cmd)
+            r = self.tc.client_infra.oc(cmd)
         return r
 
     def get_pod_ip(self):

--- a/task.py
+++ b/task.py
@@ -109,10 +109,10 @@ class Task(ABC):
         raise NotImplementedError('Must implement stop()')
     
     """
-    output() should be called to store the results of this task in a machine readable format (i.e. json) in the log location specified by the user,
-    as well as print any required info/debug to the console. The results should be formatted such that other modules can easily consume the output, such
-    as a module to determine the success/failure/performance of a given run.
+    output() should be called to store the results of this task in a PluginOutput class object, and return this by appending the instance to the
+    TftAggregateOutput Plugin fields. Additionally, this function should handle printing any required info/debug to the console. The results must
+    be formated such that other modules can easily consume the output, such as a module to determine the success/failure/performance of a given run.
     """
     @abstractmethod
-    def output(self):
+    def output(self, out: common.TftAggregateOutput):
         raise NotImplementedError('Must implement output()')

--- a/testSettings.py
+++ b/testSettings.py
@@ -12,7 +12,6 @@ class TestSettings():
             client_pod_type: str,
             index: int,
             test_type: TestType,
-            log_path: Path,
             reverse: bool = False
         ):
         self.connection_name = connection_name
@@ -28,7 +27,6 @@ class TestSettings():
         self.server_index = index
         self.client_index = index
         self.test_type = test_type
-        self.log_path = log_path
         self.reverse = reverse
 
         # Derive params from test_case_id

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -1,5 +1,5 @@
 import common
-from common import PodType, ConnectionMode, TestCaseType, TestType
+from common import PodType, ConnectionMode, TestCaseType, TestType, TftAggregateOutput, TFT_TESTS
 from testSettings import TestSettings
 from testConfig import TestConfig
 from logger import logger
@@ -15,6 +15,9 @@ import shutil
 import json
 from pathlib import Path
 from evaluator import Evaluator, PassFailStatus
+from typing import List
+import datetime
+from dataclasses import asdict
 
 class TrafficFlowTests():
     def __init__(self, tc: TestConfig):
@@ -22,20 +25,18 @@ class TrafficFlowTests():
         self.test_settings = None
         self.lh = LocalHost()
         self.log_path = Path("ft-logs")
-        self.paths_to_run_logs = []
-
-    def get_path_to_results(self) -> str:
-        return self.log_path + "/RESULTS/"
+        self.log_file = None
+        self.tft_output: List[TftAggregateOutput] = []
 
 
-    def create_iperf_server_client(self, test_settings: TestSettings) -> (IperfServer, IperfClient):
+    def _create_iperf_server_client(self, test_settings: TestSettings) -> (IperfServer, IperfClient):
         logger.info(f"Initializing iperf server/client for test:\n {test_settings.get_test_info()}")
 
         s = IperfServer(tc=self._tc, ts=self.test_settings)
         c = IperfClient(tc=self._tc, ts=self.test_settings, server=s)
         return (s, c)
 
-    def configure_namespace(self, namespace: str):
+    def _configure_namespace(self, namespace: str):
         logger.info(f"Configuring namespace {namespace}")
         r = self._tc.client_tenant.oc(f"label ns --overwrite {namespace} pod-security.kubernetes.io/enforce=privileged \
                                         pod-security.kubernetes.io/enforce-version=v1.24 \
@@ -45,7 +46,7 @@ class TrafficFlowTests():
             raise Exception(f"configure_namespace(): Failed to label namespace {namespace}")
         logger.info(f"Configured namespace {namespace}")
 
-    def cleanup_previous_testspace(self, namespace: str):
+    def _cleanup_previous_testspace(self, namespace: str):
         logger.info(f"Cleaning pods with label tft-tests in namespace {namespace}")
         r = self._tc.client_tenant.oc(f"delete pods -n {namespace} -l tft-tests")
         if r.returncode != 0:
@@ -62,19 +63,21 @@ class TrafficFlowTests():
         cmd = f"podman stop {iperf.EXTERNAL_IPERF3_SERVER}"
         self.lh.run(cmd)
 
-    def enable_measure_cpu_plugin(self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool):
+    def _enable_measure_cpu_plugin(self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool):
         s = MeasureCPU(self._tc, node_server_name, tenant)
         c = MeasureCPU(self._tc, node_client_name, tenant)
         monitors.append(s)
         monitors.append(c)
 
-    def enable_measure_power_plugin(self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool):
+    def _enable_measure_power_plugin(self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool):
         s = MeasurePower(self._tc, node_server_name, tenant)
         c = MeasurePower(self._tc, node_client_name, tenant)
         monitors.append(s)
         monitors.append(c)
 
-    def run_tests(self, servers, clients, monitors, duration: int):
+    def _run_tests(self, servers, clients, monitors, duration: int) -> TftAggregateOutput:
+        tft_aggregate_output = TftAggregateOutput()
+        
         for tasks in servers + clients + monitors:
             tasks.setup()
 
@@ -85,71 +88,59 @@ class TrafficFlowTests():
             tasks.stop()
 
         for tasks in servers + clients + monitors:
-            tasks.output()
+            tasks.output(tft_aggregate_output)
 
-    def create_log_paths_from_tests(self, tests: dict):     
+        return tft_aggregate_output
+
+    def _create_log_paths_from_tests(self, tests: dict):     
         if "logs" in tests:
             self.log_path = Path(tests['logs'])
-        self.log_path = self.log_path
-        logger.info(f"Logs will be written to {self.log_path}")
-        if self.log_path.is_dir():
-            shutil.rmtree(self.log_path)
-        
-        # Create directory for each connection / instance to store run results
-        for connections in tests['connections']:
-            for index in range(connections['instances']):
-                path=Path(f"{self.log_path}/{connections['name']}-{index}")
-                logger.info(f"Creating dir {path}")
-                path.mkdir(parents=True)
-        
+        self.log_path.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        self.log_file = self.log_path / f"{timestamp}.json"
+        logger.info(f"Logs will be written to {self.log_file}")
 
-    def evaluate_flow_tests(self, eval_config: str, log_dir: Path) -> PassFailStatus:
-        evaluator = Evaluator(eval_config)
+    def _dump_result_to_log(self):
+        # Dump test outputs into log file
+        log = self.log_file
+        json_out = {TFT_TESTS: []}
+        for out in self.tft_output:
+            json_out[TFT_TESTS].append(
+                asdict(out)
+            )
+        with open(log, "w") as output_file:
+            json.dump(json_out, output_file)
 
-        logger.info(f"Evaluating results of tests {log_dir}")
-        results_path = self.log_path / "RESULTS"
-        results_path.mkdir(exist_ok=True)
+    def evaluate_run_success(self) -> bool:
+        # For the result of every test run, check the status of each run log to ensure all test passed
+        evaluator = Evaluator(self.eval_config)
 
-        # Hand evaluator files to evaluate
-        for file in log_dir.iterdir():
-            if file.exists():
-                logger.debug(f"Evaluating log {file}")
-                evaluator.eval_log(file)
+        logger.info(f"Evaluating results of tests {self.log_file}")
+        results_file = str(self.log_file.stem) + "-RESULTS"
+        results_path = self.log_path / results_file
+
+
+        evaluator.eval_log(self.log_file)
 
         # Generate Resulting Json
-        file = results_path / "summary.json"
-        logger.info(f"Dumping results to {file}")
+        logger.info(f"Dumping results to {results_path}")
         data = evaluator.dump_to_json()
-        with open(file, "w") as file:
+        with open(results_path, "w") as file:
             file.write(data)
 
         # Return PassFailStatus
-        return evaluator.evaluate_pass_fail_status()
+        pfstatus = evaluator.evaluate_pass_fail_status()
 
-    def evaluate_run_success(self) -> bool:
-        all_passing = True
-        # For the result of every test run, check the status of each run log to ensure all test passed
-        results = []
-        for run_log_path in self.paths_to_run_logs:
-            results.append(self.evaluate_flow_tests(self.eval_config, run_log_path))
+        logger.info(f"RESULT: Success = {pfstatus.result}. Passed {pfstatus.num_passed}/{pfstatus.num_passed + pfstatus.num_failed}")
 
+        return pfstatus.result
 
-        for pfstatus in results:
-            logger.info(f"RESULT: Success = {pfstatus.result}. Passed {pfstatus.num_passed}/{pfstatus.num_passed + pfstatus.num_failed}")
-            if not pfstatus.result:
-                all_passing = False
-
-        return all_passing
-    
     def _run(self, connections: dict, test_type: TestType, test_id: int, index: int, duration: int, reverse: bool = False):
         servers = []
         clients = []
         monitors = []
         node_server_name = connections['server'][0]['name']
         node_client_name = connections['client'][0]['name']
-        log_path=Path(os.path.join(self.log_path, f"{connections['name']}-{index}"))
-        if log_path not in self.paths_to_run_logs:
-            self.paths_to_run_logs.append(log_path)
 
         if test_type == TestType.IPERF_TCP or test_type == TestType.IPERF_UDP:
             self.test_settings = TestSettings(
@@ -161,25 +152,26 @@ class TrafficFlowTests():
                 client_pod_type=self._tc.validate_pod_type(connections['client'][0]),
                 index=index,
                 test_type=test_type,
-                log_path=log_path,
                 reverse=reverse
             )
-            s, c = self.create_iperf_server_client(self.test_settings)
+            s, c = self._create_iperf_server_client(self.test_settings)
             servers.append(s)
             clients.append(c)
         else:
             logger.error("http connections not currently supported")
+            raise Exception("http connections not currently supported")
         if connections['plugins']:
             for plugins in connections['plugins']:
                 if plugins['name'] == "measure_cpu":
-                    self.enable_measure_cpu_plugin(monitors, node_server_name, node_client_name, True)
+                    self._enable_measure_cpu_plugin(monitors, node_server_name, node_client_name, True)
                 if plugins['name'] == "measure_power":
-                    self.enable_measure_power_plugin(monitors, node_server_name, node_client_name, True)
+                    self._enable_measure_power_plugin(monitors, node_server_name, node_client_name, True)
 
-        self.run_tests(servers, clients, monitors, duration)
+        output = self._run_tests(servers, clients, monitors, duration)
+        self.tft_output.append(output)
 
 
-    def run_test_case(self, tests: dict, test_id: int):
+    def _run_test_case(self, tests: dict, test_id: int):
         duration = tests['duration']
         #TODO Allow for multiple connections / instances to run simultaneously
         for connections in tests['connections']:
@@ -191,17 +183,17 @@ class TrafficFlowTests():
                 self._run(connections=connections, test_type=test_type, test_id=test_id, index=index, duration=duration)
                 if test_type == TestType.IPERF_TCP:
                     self._run(connections=connections, test_type=test_type, test_id=test_id, index=index, duration=duration, reverse=True)
-                self.cleanup_previous_testspace(tests['namespace'])
+                self._cleanup_previous_testspace(tests['namespace'])
 
-    def run(self, tests: dict, eval_config: str):
-        self.paths_to_run_logs = []
+    def run(self, tests: dict, eval_config: str) -> Path:
         self.eval_config = eval_config
-        self.configure_namespace(tests['namespace'])
-        self.cleanup_previous_testspace(tests['namespace'])
-        self.create_log_paths_from_tests(tests)
+        self._configure_namespace(tests['namespace'])
+        self._cleanup_previous_testspace(tests['namespace'])
+        self._create_log_paths_from_tests(tests)
         logger.info(f"Running test {tests['name']} for {tests['duration']} seconds")
         test_cases = self._tc.parse_test_cases(tests['test_cases'])
         for test_id in test_cases:
-            self.run_test_case(
+            self._run_test_case(
                 tests=tests,
                 test_id=test_id)
+        self._dump_result_to_log()


### PR DESCRIPTION
Aggregate logs to single file

Rather than outputing each individual flow result to a separate file,
compile all tests to a single log. Refactor evaluator to accept a single
file.

Add basic outline to allow plugins to output results. Add a temporary
placeholder for measureCpu and measurePower to store results as json.

TODO: Update plugins to sync with test case intervals.
TODO: Update evaluator to evaluate each plugin