### PR TITLE
Fixed containerfile to add working crictl. Updated TFT tools image to…

### DIFF
--- a/common.py
+++ b/common.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import List
 
 FT_BASE_IMG = "quay.io/wizhao/ft-base-image:0.9"
-TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:0.3"
+TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:09-27-2023"
 TFT_TESTS = "tft-tests"
 
 class TestType(Enum):

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -1,7 +1,9 @@
 FROM quay.io/centos/centos:stream9
 
-RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/CentOS_8/devel:kubic:libcontainers:stable.repo \
-curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:${VERSION}.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:${VERSION}/CentOS_8/devel:kubic:libcontainers:stable:cri-o:${VERSION}.repo
+RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:1.26.1.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:1.26.1/CentOS_9_Stream/devel:kubic:libcontainers:stable:cri-o:1.26.1.repo
+
+RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/devel:kubic:libcontainers:stable.repo
+
 
 RUN INSTALL_PKGS="vim wget jq python3 git cri-tools net-tools iptables iproute pciutils ethtool httpd iperf3 tcpdump sysstat ipmitool util-linux" && yum install -y ${INSTALL_PKGS}
 


### PR DESCRIPTION
… a working image
Current docker file did not have a working crictl command. This commit makes it so that the dockerfile now has an updated crictl. In addition, this also an updated image with the updated crictl.