### PR TITLE
Pin PyYAML to 6.0.1, remove cython issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4.1
+PyYAML==6.0.1
 jinja2
 kubernetes
 jc


### PR DESCRIPTION
Bump PyYAML to 6.0.1 to resolve [issue with cython dependency](https://github.com/yaml/pyyaml/issues/723)

Currently, installing the requirements using a python3.11 venv gives
```
    File "<string>", line 201, in get_source_files
        File "/tmp/pip-build-env-x1b36mp_/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
```

[PyYAML changelog](https://github.com/yaml/pyyaml/blob/main/CHANGES)