### PR TITLE
Refactor task.py abstract `stop`

### DIFF
--- a/common.py
+++ b/common.py
@@ -8,6 +8,13 @@ TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
 TFT_TESTS = "tft-tests"
 
 
+@dataclass
+class Result:
+    out: str
+    err: str
+    returncode: int
+
+
 class TestType(Enum):
     IPERF_TCP = 1
     IPERF_UDP = 2

--- a/common.py
+++ b/common.py
@@ -79,17 +79,19 @@ class TestMetadata:
 
 
 @dataclass
-class IperfOutput:
-    tft_metadata: TestMetadata
+class BaseOutput:
     command: str
     result: dict
 
 
 @dataclass
-class PluginOutput:
+class IperfOutput(BaseOutput):
+    tft_metadata: TestMetadata
+
+
+@dataclass
+class PluginOutput(BaseOutput):
     plugin_metadata: dict
-    command: str
-    result: dict
     name: str
 
 

--- a/common.py
+++ b/common.py
@@ -103,14 +103,6 @@ class PluginOutput(BaseOutput):
 
 
 @dataclass
-class RxTxData:
-    rx_start: int
-    tx_start: int
-    rx_end: int
-    tx_end: int
-
-
-@dataclass
 class TftAggregateOutput:
     """Aggregated output of a single tft run. A single run of a trafficFlowTests._run_tests() will
     pass a reference to an instance of TftAggregateOutput to each task to which the task will append

--- a/host.py
+++ b/host.py
@@ -1,14 +1,10 @@
 import subprocess
-from collections import namedtuple
 import os
 import json
 import shlex
 import sys
 from logger import logger
-
-
-Result = namedtuple("Result", "out err returncode")
-
+from common import Result
 
 class Host:
     def ipa(self) -> dict:

--- a/iperf.py
+++ b/iperf.py
@@ -159,6 +159,9 @@ class IperfClient(Task):
 
     def output(self, out: common.TftAggregateOutput):
         # Return machine-readable output to top level
+        assert isinstance(
+            self._output, IperfOutput
+        ), f"Expected variable to be of type IperfOutput, got {type(self._output)} instead."
         out.flow_test = self._output
 
         # Print summary to console logs

--- a/iperf.py
+++ b/iperf.py
@@ -4,7 +4,7 @@ from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
 from task import Task
-from host import Result
+from common import Result
 from testSettings import TestSettings
 import json
 
@@ -74,7 +74,7 @@ class IperfServer(Task):
 
         logger.info(f"Running {cmd}")
 
-        def server(self, cmd: str):
+        def server(self, cmd: str) -> Result:
             if self.connection_mode == ConnectionMode.EXTERNAL_IP:
                 return self.lh.run(cmd)
             elif self.exec_persistent:
@@ -135,8 +135,8 @@ class IperfClient(Task):
         common.j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
         logger.info(f"Generated Client Pod Yaml {self.out_file_yaml}")
 
-    def run(self, duration: int):
-        def client(self, cmd: str):
+    def run(self, duration: int) -> None:
+        def client(self, cmd: str) -> Result:
             return self.run_oc(cmd)
 
         server_ip = self.get_target_ip()

--- a/iperf.py
+++ b/iperf.py
@@ -84,20 +84,14 @@ class IperfServer(Task):
         self.exec_thread = ReturnValueThread(target=server, args=(self, cmd))
         self.exec_thread.start()
 
-    def run(self, duration: int):
+    def run(self, duration: int) -> None:
         pass
 
-    def stop(self):
-        logger.info(f"Stopping execution on {self.pod_name}")
-        r = self.exec_thread.join()
-        if r.returncode != 0:
-            logger.error(
-                f"Error occured while stopping Iperf server: errcode: {r.returncode} err {r.err}"
-            )
-        logger.debug(f"IperfServer.stop(): {r.out}")
-
-    def output(self, out: common.TftAggregateOutput):
+    def output(self, out: common.TftAggregateOutput) -> None:
         pass
+
+    def generate_output(self, data: str) -> common.BaseOutput:
+        return common.BaseOutput("", {})
 
 
 class IperfClient(Task):
@@ -154,20 +148,12 @@ class IperfClient(Task):
         self.exec_thread = ReturnValueThread(target=client, args=(self, self.cmd))
         self.exec_thread.start()
 
-    def stop(self):
-        logger.info(f"Stopping execution on {self.pod_name}")
-        r = self.exec_thread.join()
-        if r.returncode != 0:
-            logger.error(r)
-        logger.debug(f"IperfClient.stop(): {r.out}")
-        data = json.loads(r.out)
-        self._output = self.generate_output(data)
-
-    def generate_output(self, data: dict) -> IperfOutput:
+    def generate_output(self, data: str) -> IperfOutput:
+        parsed_data = json.loads(data)
         json_dump = IperfOutput(
             tft_metadata=self.ts.get_test_metadata(),
             command=self.cmd,
-            result=data,
+            result=parsed_data,
         )
         return json_dump
 

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,6 +1,7 @@
 import kubernetes
 import yaml
 import host
+from common import Result
 from typing import List
 
 
@@ -23,6 +24,6 @@ class K8sClient:
             for e in self._client.list_node(label_selector=label_selector).items
         ]
 
-    def oc(self, cmd: str) -> host.Result:
+    def oc(self, cmd: str) -> Result:
         lh = host.LocalHost()
         return lh.run(f"oc --kubeconfig {self._kc} {cmd} ")

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -1,4 +1,4 @@
-from common import TFT_TOOLS_IMG, PluginOutput, j2_render, TftAggregateOutput
+from common import TFT_TOOLS_IMG, PluginOutput, j2_render, TftAggregateOutput, Result
 from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
@@ -25,8 +25,8 @@ class MeasureCPU(Task):
         j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
         logger.info(f"Generated Server Pod Yaml {self.out_file_yaml}")
 
-    def run(self, duration: int):
-        def stat(self, cmd: str):
+    def run(self, duration: int) -> None:
+        def stat(self, cmd: str) -> Result:
             return self.run_oc(cmd)
 
         # 1 report at intervals defined by the duration in seconds.

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -37,6 +37,9 @@ class MeasureCPU(Task):
 
     def output(self, out: TftAggregateOutput):
         # Return machine-readable output to top level
+        assert isinstance(
+            self._output, PluginOutput
+        ), f"Expected variable to be of type PluginOutput, got {type(self._output)} instead."
         out.plugins.append(self._output)
 
         # Print summary to console logs

--- a/measurePower.py
+++ b/measurePower.py
@@ -3,7 +3,7 @@ from logger import logger
 from testConfig import TestConfig
 from thread import ReturnValueThread
 from task import Task
-from host import Result
+from common import Result
 import re
 import time
 import json
@@ -27,7 +27,7 @@ class MeasurePower(Task):
         j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
         logger.info(f"Generated Server Pod Yaml {self.out_file_yaml}")
 
-    def run(self, duration: int):
+    def run(self, duration: int) -> None:
         def extract(r: Result) -> int:
             for e in r.out.split("\n"):
                 if "Instantaneous power reading" in e:
@@ -37,7 +37,7 @@ class MeasurePower(Task):
             logger.error(f"Could not find Instantaneous power reading: {e}.")
             return 0
 
-        def stat(self, cmd: str, duration: int):
+        def stat(self, cmd: str, duration: int) -> Result:
             end_time = time.time() + float(duration)
             total_pwr = 0
             iteration = 0

--- a/measurePower.py
+++ b/measurePower.py
@@ -65,6 +65,9 @@ class MeasurePower(Task):
 
     def output(self, out: TftAggregateOutput) -> None:
         # Return machine-readable output to top level
+        assert isinstance(
+            self._output, PluginOutput
+        ), f"Expected variable to be of type PluginOutput, got {type(self._output)} instead."
         out.plugins.append(self._output)
 
         # Print summary to console logs

--- a/measurePower.py
+++ b/measurePower.py
@@ -6,6 +6,7 @@ from task import Task
 from host import Result
 import re
 import time
+import json
 
 
 class MeasurePower(Task):
@@ -62,21 +63,15 @@ class MeasurePower(Task):
         self.exec_thread.start()
         logger.info(f"Running {self.cmd}")
 
-    def stop(self):
-        logger.info(f"Stopping measurePower execution on {self.pod_name}")
-        r = self.exec_thread.join()
-        if r.returncode != 0:
-            logger.error(r)
-        self._output = self.generate_output(data=r.out)
-
-    def output(self, out: TftAggregateOutput):
+    def output(self, out: TftAggregateOutput) -> None:
         # Return machine-readable output to top level
         out.plugins.append(self._output)
 
         # Print summary to console logs
         logger.info(f"measurePower results: {self._output.result}")
 
-    def generate_output(self, data) -> PluginOutput:
+    def generate_output(self, data: str) -> PluginOutput:
+        parsed_data = json.loads(data)
         return PluginOutput(
             plugin_metadata={
                 "name": "MeasurePower",
@@ -84,6 +79,6 @@ class MeasurePower(Task):
                 "pod_name": self.pod_name,
             },
             command=self.cmd,
-            result=data,
+            result=parsed_data,
             name="measure_power",
         )

--- a/task.py
+++ b/task.py
@@ -36,7 +36,7 @@ class Task(ABC):
         self.template_args["node_name"] = self.node_name
         self.tc = tc
 
-    def run_oc(self, cmd: str) -> host.Result:
+    def run_oc(self, cmd: str) -> common.Result:
         if self.tenant:
             r = self.tc.client_tenant.oc(cmd)
         else:
@@ -105,7 +105,7 @@ class Task(ABC):
             sys.exit(-1)
 
     @abstractmethod
-    def run(self, duration: int):
+    def run(self, duration: int) -> None:
         raise NotImplementedError("Must implement run()")
 
     def stop(self) -> None:
@@ -135,5 +135,5 @@ class Task(ABC):
         raise NotImplementedError("Must implement output()")
 
     @abstractmethod
-    def generate_output(self, data: dict) -> common.BaseOutput:
+    def generate_output(self, data: str) -> common.BaseOutput:
         raise NotImplementedError("Must implement generate_output()")

--- a/thread.py
+++ b/thread.py
@@ -19,7 +19,7 @@ class ReturnValueThread(Thread):
         try:
             self.result = self._target(*self._args, **self._kwargs)
         except Exception as e:
-            logger.error(e)
+            logger.error(f"Thread with target {self._target} experienced exception {e}")
 
     def join(self, *args: Any, **kwargs: Any) -> Result:
         super().join(*args, **kwargs)

--- a/thread.py
+++ b/thread.py
@@ -1,24 +1,26 @@
 from threading import Thread
 from logger import logger
+from common import Result
+from typing import Callable, Any, Optional
 
 
 class ReturnValueThread(Thread):
-    def __init__(self, *args, **kwargs):
-        self._target = None
+    def __init__(self, *args: Any, **kwargs: Any):
+        self._target: Callable[..., Result] = None
         self._args = args
         self._kwargs = kwargs
         super().__init__(*args, **kwargs)
-        self.result = None
+        self.result: Optional[Result] = None
 
-    def run(self):
+    def run(self) -> None:
         if self._target is None:
+            logger.error("Called ReturnValueThread with target=None")
             return
         try:
             self.result = self._target(*self._args, **self._kwargs)
         except Exception as e:
             logger.error(e)
-            pass
 
-    def join(self, *args, **kwargs):
+    def join(self, *args: Any, **kwargs: Any) -> Result:
         super().join(*args, **kwargs)
         return self.result

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -217,7 +217,7 @@ class TrafficFlowTests:
         self.tft_output.append(output)
 
     def _run_test_case(self, tests: dict, test_id: int):
-        duration = tests["duration"]
+        duration = int(tests["duration"])
         # TODO Allow for multiple connections / instances to run simultaneously
         for connections in tests["connections"]:
             logger.info(f"Starting {connections['name']}")

--- a/validateOffload.py
+++ b/validateOffload.py
@@ -5,6 +5,7 @@ from common import (
     TftAggregateOutput,
     PodType,
     RxTxData,
+    BaseOutput,
 )
 from dataclasses import asdict
 from logger import logger
@@ -112,7 +113,7 @@ class ValidateOffload(Task):
             data = {}
         else:
             data = asdict(r)
-        self._output_ethtool = self.generate_output_ethtool(data, self.ethtool_cmd)
+        self._output_ethtool = self.generate_output(data, self.ethtool_cmd)
 
     def output(self, out: TftAggregateOutput):
         out.plugins.append(self._output_ethtool)
@@ -134,7 +135,7 @@ class ValidateOffload(Task):
                 % (rx_packet_start, tx_packet_start, rx_packet_end, tx_packet_end)
             )
 
-    def generate_output_ethtool(self, data, cmd: str) -> PluginOutput:
+    def generate_output(self, data, cmd: str) -> PluginOutput:
         return PluginOutput(
             plugin_metadata={
                 "name": "GetEthtoolStats",

--- a/validateOffload.py
+++ b/validateOffload.py
@@ -96,6 +96,8 @@ class ValidateOffload(Task):
             self.ethtool_cmd = (
                 f'exec -n default {self.pod_name} -- /bin/sh -c "ethtool -S {vf_rep}"'
             )
+            if vf_rep == "ovn-k8s-mp0":
+                return Result(out="Hostbacked pod", err="", returncode=0)
             if vf_rep == "external":
                 return Result(out="External Iperf Server", err="", returncode=0)
 

--- a/validateOffload.py
+++ b/validateOffload.py
@@ -4,12 +4,10 @@ from common import (
     j2_render,
     TftAggregateOutput,
     PodType,
-    RxTxData,
-    BaseOutput,
+    Result,
 )
-from dataclasses import asdict
 from logger import logger
-from time import sleep
+import time
 from testConfig import TestConfig
 from iperf import IperfServer, IperfClient
 from thread import ReturnValueThread
@@ -37,7 +35,7 @@ class ValidateOffload(Task):
 
         self.pod_name = self.template_args["pod_name"]
         self._iperf_instance = iperf_instance
-        self.iperf_pod_name = iperf_instance.template_args["pod_name"]
+        self.iperf_pod_name = iperf_instance.pod_name
         self.iperf_pod_type = iperf_instance.pod_type
 
         j2_render(self.in_file_template, self.out_file_yaml, self.template_args)
@@ -63,7 +61,7 @@ class ValidateOffload(Task):
         )
         return data["containers"][0]["podSandboxId"][:15]
 
-    def run_ethtool_cmd(self, vf_rep: str) -> (int, int):
+    def run_ethtool_cmd(self, vf_rep: str) -> Result:
         self.ethtool_cmd = (
             f'exec -n default {self.pod_name} -- /bin/sh -c "ethtool -S {vf_rep}"'
         )
@@ -72,12 +70,11 @@ class ValidateOffload(Task):
             if r.returncode != 0:
                 if "already exists" not in r.err:
                     logger.info(r)
-                    sys.exit(-1)
+                    raise RuntimeError(
+                        f"ValidateOffload error: {r.err} returncode: {r.returncode}"
+                    )
 
-        ethtool_output = r.out
-        rxpacket = self.parse_out_packet(ethtool_output, "rx_packet")
-        txpacket = self.parse_out_packet(ethtool_output, "tx_packet")
-        return (rxpacket, txpacket)
+        return r
 
     def parse_out_packet(self, output: str, prefix: str) -> Optional[int]:
         for line in output.splitlines():
@@ -87,62 +84,62 @@ class ValidateOffload(Task):
 
         return None
 
-    def run_st(self) -> RxTxData:
+    def run_st(self) -> Result:
         vf_rep = self.extract_vf_rep()
-        (rxpacket_start, txpacket_start) = self.run_ethtool_cmd(vf_rep)
-        sleep(self._duration)
-        (rxpacket_end, txpacket_end) = self.run_ethtool_cmd(vf_rep)
+        r1 = self.run_ethtool_cmd(vf_rep)
+        time.sleep(self._duration)
+        r2 = self.run_ethtool_cmd(vf_rep)
 
-        return RxTxData(
-            rx_start=rxpacket_start,
-            tx_start=txpacket_start,
-            rx_end=rxpacket_end,
-            tx_end=txpacket_end,
+        combined_out = f"{r1.out}--DELIMIT--{r2.out}"
+        combined_err = f"R1: {r1.err} R2: {r2.err}"
+        combined_returncode = max(r1.returncode, r2.returncode)
+
+        return Result(
+            out=combined_out, err=combined_err, returncode=combined_returncode
         )
 
-    def run(self, duration: int):
+    def run(self, duration: int) -> None:
         self.exec_thread = ReturnValueThread(target=self.run_st)
         self._duration = int(duration)
         self.exec_thread.start()
 
-    def stop(self):
-        logger.info(f"Stopping Get Vf Rep execution on {self.pod_name}")
-        r = self.exec_thread.join()
-
-        if self.iperf_pod_type == PodType.HOSTBACKED:
-            data = {}
-        else:
-            data = asdict(r)
-        self._output_ethtool = self.generate_output(data, self.ethtool_cmd)
-
     def output(self, out: TftAggregateOutput):
-        out.plugins.append(self._output_ethtool)
+        out.plugins.append(self._output)
 
         if self.iperf_pod_type == PodType.HOSTBACKED:
             if isinstance(self._iperf_instance, IperfClient):
                 logger.info(f"The client VF representor ovn-k8s-mp0_0 does not exist")
             else:
                 logger.info(f"The server VF representor ovn-k8s-mp0_0 does not exist")
-        else:
-            # Print summary to console logs
-            rx_packet_start = self._output_ethtool.result["rx_start"]
-            tx_packet_start = self._output_ethtool.result["tx_start"]
-            rx_packet_end = self._output_ethtool.result["rx_end"]
-            tx_packet_end = self._output_ethtool.result["tx_end"]
 
-            logger.info(
-                "rx_packet_start: %d\n tx_packet_start: %d\n rx_packet_end: %d\n tx_packet_end: %d\n"
-                % (rx_packet_start, tx_packet_start, rx_packet_end, tx_packet_end)
-            )
+    def generate_output(self, data: str) -> PluginOutput:
+        split_data = data.split("--DELIMIT--")
+        parsed_data = {}
 
-    def generate_output(self, data, cmd: str) -> PluginOutput:
+        if len(split_data) >= 1:
+            parsed_data["rx_start"] = self.parse_out_packet(split_data[0], "rx_packet")
+            parsed_data["tx_start"] = self.parse_out_packet(split_data[0], "tx_packet")
+
+        if len(split_data) >= 2:
+            parsed_data["rx_end"] = self.parse_out_packet(split_data[1], "rx_packet")
+            parsed_data["tx_end"] = self.parse_out_packet(split_data[1], "tx_packet")
+
+        if len(split_data) >= 3:
+            parsed_data["additional_info"] = "--DELIMIT--".join(split_data[2:])
+
+        logger.info(
+            f"rx_packet_start: {parsed_data.get('rx_start', 'N/A')}\n"
+            f"tx_packet_start: {parsed_data.get('tx_start', 'N/A')}\n"
+            f"rx_packet_end: {parsed_data.get('rx_end', 'N/A')}\n"
+            f"tx_packet_end: {parsed_data.get('tx_end', 'N/A')}\n"
+        )
         return PluginOutput(
+            command=self.ethtool_cmd,
             plugin_metadata={
                 "name": "GetEthtoolStats",
                 "node_name": self.node_name,
                 "pod_name": self.pod_name,
             },
-            command=cmd,
-            result=data,
+            result=parsed_data,
             name="get_ethtool_stats",
         )


### PR DESCRIPTION
`stop` is used almost the same way by all of Task's derived classes. The derived classes similarly all use a `generate_output` function.

1. Make `task.py`'s stop not abstract, provide an implementation to join the threads, set `self._output` to `self.generate_output`
2. Create a `common.BaseOutput` class to abstract common functionality of `IperfOutput` and `PluginOutput`
3. Make a `self.generate_output` abstract function, to return a `common.BaseOutput`

- All derived classes now use Task's `stop` implementation
- ValidateOffload was fixed to correctly count packets. The previous implementation always returned the default value of "None"


This is one of the most potentially breaking changes, and I have several commits to change `stop` and `generate_output`, so I squashed them into this PR
I'll test that its non-breaking before I mark it as ready for review.
