### PR TITLE
Add an undo_target function to return value thread

### DIFF
--- a/task.py
+++ b/task.py
@@ -108,10 +108,10 @@ class Task(ABC):
     def run(self, duration: int) -> None:
         raise NotImplementedError("Must implement run()")
 
-    def stop(self) -> None:
+    def stop(self, timeout: float) -> None:
         class_name = self.__class__.__name__
         logger.info(f"Stopping execution on {class_name}")
-        self.exec_thread.join()
+        self.exec_thread.join(timeout=timeout * 1.5)
         if self.exec_thread.result is not None:
             r = self.exec_thread.result
             if r.returncode != 0:

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -113,7 +113,7 @@ class TrafficFlowTests:
             tasks.run(duration)
 
         for tasks in servers + clients + monitors:
-            tasks.stop()
+            tasks.stop(duration)
 
         for tasks in servers + clients + monitors:
             tasks.output(tft_aggregate_output)


### PR DESCRIPTION
.join() has no way to actually kill the containers it creates. So let `ReturnValueThread` take a `cleanup_action` to undo the `target` action.

- gives threads the possibility to clean themselves up, in case "join" doesn't return
- pass a timeout to `stop`. After this timeout, join will attempt to kill the thread. If it is not able to, the thread is orphaned
- have IperfServer use the new `cleanup_action` parameter

Depends on #17 to add `Result` in common.py, and the new `stop` implementation