### PR TITLE
Synchronize threads

### DIFF
--- a/measureCpu.py
+++ b/measureCpu.py
@@ -5,6 +5,7 @@ from thread import ReturnValueThread
 from task import Task
 import jc
 from typing import List, Dict, Any, cast
+from syncManager import SyncManager
 
 
 class MeasureCPU(Task):
@@ -27,6 +28,7 @@ class MeasureCPU(Task):
 
     def run(self, duration: int) -> None:
         def stat(self, cmd: str) -> Result:
+            SyncManager.wait_on_barrier()
             return self.run_oc(cmd)
 
         # 1 report at intervals defined by the duration in seconds.

--- a/syncManager.py
+++ b/syncManager.py
@@ -1,0 +1,65 @@
+import threading
+from threading import Barrier, Event
+
+
+class SyncManager:
+    _instance = None
+    _lock = threading.RLock()
+
+    def __new__(cls, barrier_size):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(SyncManager, cls).__new__(cls)
+                cls._initialize(barrier_size)
+        return cls._instance
+
+    @staticmethod
+    def _initialize(barrier_size):
+        SyncManager._instance.start_barrier = Barrier(barrier_size)
+        SyncManager._instance.client_finished = Event()
+        SyncManager._instance.server_alive = Event()
+
+    @classmethod
+    def reset(cls, barrier_size):
+        with cls._lock:
+            if barrier_size >= 0:
+                if cls._instance is None:
+                    cls.__new__(cls, barrier_size)
+                else:
+                    cls._initialize(barrier_size)
+
+    @classmethod
+    def client_finished(cls):
+        if cls._instance:
+            return cls._instance.client_finished
+
+    @classmethod
+    def set_client_finished(cls):
+        if cls._instance:
+            cls._instance.client_finished.set()
+
+    @classmethod
+    def set_server_alive(cls):
+        if cls._instance:
+            cls._instance.server_alive.set()
+
+    @classmethod
+    def wait_on_barrier(cls):
+        if cls._instance and cls._instance.start_barrier:
+            cls._instance.start_barrier.wait()
+
+    @classmethod
+    def wait_on_client_finish(cls):
+        if cls._instance and cls._instance.client_finished:
+            cls._instance.client_finished.wait()
+
+    @classmethod
+    def wait_on_server_alive(cls):
+        if cls._instance and cls._instance.server_alive:
+            cls._instance.server_alive.wait()
+
+    @classmethod
+    def client_not_finished(cls):
+        if cls._instance and cls._instance.client_finished:
+            return not cls._instance.client_finished.is_set()
+        return True

--- a/syncManager.py
+++ b/syncManager.py
@@ -2,6 +2,8 @@ import threading
 from threading import Barrier, Event
 
 
+# Singleton class, synchronizes threads using barriers and events
+# https://docs.python.org/3/library/threading.html
 class SyncManager:
     _instance = None
     _lock = threading.RLock()
@@ -21,17 +23,12 @@ class SyncManager:
 
     @classmethod
     def reset(cls, barrier_size):
+        assert barrier_size >= 0, "barrier_size must be non-negative"
         with cls._lock:
-            if barrier_size >= 0:
-                if cls._instance is None:
-                    cls.__new__(cls, barrier_size)
-                else:
-                    cls._initialize(barrier_size)
-
-    @classmethod
-    def client_finished(cls):
-        if cls._instance:
-            return cls._instance.client_finished
+            if cls._instance is None:
+                cls.__new__(cls, barrier_size)
+            else:
+                cls._initialize(barrier_size)
 
     @classmethod
     def set_client_finished(cls):
@@ -43,6 +40,8 @@ class SyncManager:
         if cls._instance:
             cls._instance.server_alive.set()
 
+    # .wait() on a barrier decrements it
+    # once the barrier hits 0, all waiting threads are simultaneously unblocked
     @classmethod
     def wait_on_barrier(cls):
         if cls._instance and cls._instance.start_barrier:

--- a/task.py
+++ b/task.py
@@ -106,7 +106,9 @@ class Task(ABC):
 
     @abstractmethod
     def run(self, duration: int) -> None:
-        raise NotImplementedError("Must implement run()")
+        raise NotImplementedError(
+            "Must implement run(). Use SyncManager.wait_barrier()"
+        )
 
     def stop(self) -> None:
         class_name = self.__class__.__name__

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -18,6 +18,7 @@ from evaluator import Evaluator
 from typing import List
 import datetime
 from dataclasses import asdict
+from syncManager import SyncManager
 
 
 class TrafficFlowTests:
@@ -109,8 +110,12 @@ class TrafficFlowTests:
         for tasks in servers + clients + monitors:
             tasks.setup()
 
+        SyncManager.wait_on_server_alive()
+
         for tasks in servers + clients + monitors:
             tasks.run(duration)
+
+        SyncManager.wait_on_client_finish()
 
         for tasks in servers + clients + monitors:
             tasks.stop()
@@ -213,6 +218,7 @@ class TrafficFlowTests:
                         monitors, iperf_server, iperf_client, True
                     )
 
+        SyncManager.reset(len(clients) + len(monitors))
         output = self._run_tests(servers, clients, monitors, duration)
         self.tft_output.append(output)
 


### PR DESCRIPTION
- Only commit on this branch is [Synchronize threads with SyncManager singleton](https://github.com/wizhaoredhat/ocp-traffic-flow-tests/commit/113d449d855c6c279a4c7ac81de397df23d34d60)
- Rebased on my other changes to Thread & Task to reduce conflicts with them

Resolve #20 

Use barriers to have all of the `ReturnValueThreads` start simultaneously.

Use events for the client to signal when its done, instead of relying on a duration.


