### PR TITLE
Remove unused `-t`

### DIFF
--- a/iperf.py
+++ b/iperf.py
@@ -70,7 +70,7 @@ class IperfServer(Task):
         else:
             # Create the server pods
             super().setup()
-            cmd = f"exec -t {self.pod_name} -- {IPERF_EXE} -s -p {self.port} --one-off --json"
+            cmd = f"exec {self.pod_name} -- {IPERF_EXE} -s -p {self.port} --one-off --json"
 
         logger.info(f"Running {cmd}")
 
@@ -140,7 +140,7 @@ class IperfClient(Task):
             return self.run_oc(cmd)
 
         server_ip = self.get_target_ip()
-        self.cmd = f"exec -t {self.pod_name} -- {IPERF_EXE} -c {server_ip} -p {self.port} --json -t {duration}"
+        self.cmd = f"exec {self.pod_name} -- {IPERF_EXE} -c {server_ip} -p {self.port} --json -t {duration}"
         if self.test_type == TestType.IPERF_UDP:
             self.cmd = f" {self.cmd} {IPERF_UDP_OPT}"
         if self.reverse:

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -30,7 +30,7 @@ class MeasureCPU(Task):
             return self.run_oc(cmd)
 
         # 1 report at intervals defined by the duration in seconds.
-        self.cmd = f"exec -t {self.pod_name} -- mpstat -P ALL {duration} 1"
+        self.cmd = f"exec {self.pod_name} -- mpstat -P ALL {duration} 1"
         self.exec_thread = ReturnValueThread(target=stat, args=(self, self.cmd))
         self.exec_thread.start()
         logger.info(f"Running {self.cmd}")

--- a/measurePower.py
+++ b/measurePower.py
@@ -56,7 +56,7 @@ class MeasurePower(Task):
             return r
 
         # 1 report at intervals defined by the duration in seconds.
-        self.cmd = f"exec -t {self.pod_name} -- ipmitool dcmi power reading"
+        self.cmd = f"exec {self.pod_name} -- ipmitool dcmi power reading"
         self.exec_thread = ReturnValueThread(
             target=stat, args=(self, self.cmd, duration)
         )


### PR DESCRIPTION
When viewing the logs of the pod, they contain things like "can't open /dev/tty2: No such file or directory"

- Remove the unneeded `-t` in `oc exec`
- I was able to run the tests with this change