### PR TITLE
[th/more-typing] use a stricter `mypy` check and fix typing errors for that

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,6 +21,8 @@ jobs:
         python -m pip install black mypy pytest
         python -m pip install -r requirements.txt
         python -m pip install flake8
+        python -m pip install types-PyYAML
+        python -m pip install jc
     - name: Check code formatting with Black
       run: |
        black --version
@@ -32,7 +34,7 @@ jobs:
     - name: Type check with Mypy
       run: |
        mypy --version
-       mypy --install-types --non-interactive --disallow-untyped-defs --ignore-missing-imports .
+       mypy --strict --config-file mypy.ini .
     - name: Run tests with Pytest
       run: | 
        pytest --version

--- a/common.py
+++ b/common.py
@@ -1,7 +1,7 @@
 import jinja2
 from dataclasses import dataclass, fields, field, is_dataclass
 from enum import Enum
-from typing import Optional, Any, Union, Type, TypeVar, cast
+from typing import Optional, Any, Type, TypeVar, cast
 from typing import Mapping
 
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
@@ -22,7 +22,7 @@ class Result:
 E = TypeVar("E", bound=Enum)
 
 
-def enum_convert(enum_type: Type[E], value: Union[E, str, int]) -> E:
+def enum_convert(enum_type: Type[E], value: E | str | int) -> E:
     if isinstance(value, enum_type):
         return value
     elif isinstance(value, str):
@@ -132,7 +132,7 @@ class TestMetadata:
 @dataclass
 class BaseOutput:
     command: str
-    result: dict[str, Union[str, int]]
+    result: dict[str, str | int]
 
     def __init__(self, command: str, result: Mapping[str, str | int]):
         if not isinstance(result, dict):
@@ -148,7 +148,7 @@ class IperfOutput(BaseOutput):
     def __init__(
         self,
         command: str,
-        result: Mapping[str, Union[str, int]],
+        result: Mapping[str, str | int],
         tft_metadata: TestMetadata | dict[str, Any],
     ):
         if isinstance(tft_metadata, dict):
@@ -206,8 +206,8 @@ def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> 
 
 
 def serialize_enum(
-    data: Union[Enum, dict[Any, Any], list[Any], Any]
-) -> Union[str, dict[Any, Any], list[Any], Any]:
+    data: Enum | dict[Any, Any] | list[Any] | Any
+) -> str | dict[Any, Any] | list[Any] | Any:
     if isinstance(data, Enum):
         return data.name
     elif isinstance(data, dict):

--- a/common.py
+++ b/common.py
@@ -2,6 +2,7 @@ import jinja2
 from dataclasses import dataclass, fields, field, is_dataclass
 from enum import Enum
 from typing import Optional, Any, Dict, List, Union, Type, TypeVar, cast
+from typing import Mapping
 
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
 TFT_TESTS = "tft-tests"
@@ -121,7 +122,7 @@ class TestMetadata:
 @dataclass
 class BaseOutput:
     command: str
-    result: dict
+    result: Mapping[str, Union[str, int]]
 
 
 @dataclass
@@ -137,7 +138,7 @@ class IperfOutput(BaseOutput):
 
 @dataclass
 class PluginOutput(BaseOutput):
-    plugin_metadata: dict
+    plugin_metadata: dict[str, str]
     name: str
 
 

--- a/common.py
+++ b/common.py
@@ -1,7 +1,7 @@
 import jinja2
 from dataclasses import dataclass, fields, field, is_dataclass
 from enum import Enum
-from typing import Optional, Any, Dict, List, Union, Type, TypeVar, cast
+from typing import Optional, Any, Union, Type, TypeVar, cast
 from typing import Mapping
 
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
@@ -178,7 +178,7 @@ class TftAggregateOutput:
         resulting output to."""
 
     flow_test: Optional[IperfOutput] = None
-    plugins: List[PluginOutput] = field(default_factory=list)
+    plugins: list[PluginOutput] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if isinstance(self.flow_test, dict):
@@ -196,7 +196,7 @@ class TftAggregateOutput:
         ]
 
 
-def j2_render(in_file_name: str, out_file_name: str, kwargs: Dict[str, Any]) -> None:
+def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> None:
     with open(in_file_name) as inFile:
         contents = inFile.read()
     template = jinja2.Template(contents)
@@ -206,8 +206,8 @@ def j2_render(in_file_name: str, out_file_name: str, kwargs: Dict[str, Any]) -> 
 
 
 def serialize_enum(
-    data: Union[Enum, Dict[Any, Any], List[Any], Any]
-) -> Union[str, Dict[Any, Any], List[Any], Any]:
+    data: Union[Enum, dict[Any, Any], list[Any], Any]
+) -> Union[str, dict[Any, Any], list[Any], Any]:
     if isinstance(data, Enum):
         return data.name
     elif isinstance(data, dict):
@@ -223,7 +223,7 @@ T = TypeVar("T")
 
 # Takes a dataclass and the dict you want to convert from
 # If your dataclass has a dataclass member, it handles that recursively
-def dataclass_from_dict(cls: Type[T], data: Dict[str, Any]) -> T:
+def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
     assert is_dataclass(
         cls
     ), "dataclass_from_dict() should only be used with dataclasses."

--- a/evaluator.py
+++ b/evaluator.py
@@ -16,6 +16,9 @@ from logger import logger
 from pathlib import Path
 from typing import List
 from common import serialize_enum, dataclass_from_dict
+from typing import Any
+from typing import Mapping
+import typing
 
 
 @dataclass
@@ -186,14 +189,18 @@ class Evaluator:
     ) -> int:
         traffic_direction = "reverse" if is_reverse else "normal"
         try:
-            return self.config[test_type.name][test_case_id.value][traffic_direction]
+            return typing.cast(
+                int, self.config[test_type.name][test_case_id.value][traffic_direction]
+            )
         except KeyError as e:
             logger.error(
                 f"KeyError: {e}. Config does not contain valid config for test case {test_type.name} id {test_case_id} reverse: {is_reverse}"
             )
             raise Exception("get_threshold(): Failed to parse evaluator config")
 
-    def calculate_gbps(self, result: dict, test_type: TestType) -> Bitrate:
+    def calculate_gbps(
+        self, result: Mapping[str, str | int], test_type: TestType
+    ) -> Bitrate:
         if test_type == TestType.IPERF_TCP:
             return self.calculate_gbps_iperf_tcp(result)
         elif test_type == TestType.IPERF_UDP:
@@ -225,7 +232,7 @@ class Evaluator:
             }
         )
 
-    def calculate_gbps_iperf_tcp(self, result: dict) -> Bitrate:
+    def calculate_gbps_iperf_tcp(self, result: Mapping[str, Any]) -> Bitrate:
         # If an error occurred, bitrate = 0
         if "error" in result:
             logger.error(f"An error occurred during iperf test: {result['error']}")
@@ -247,7 +254,7 @@ class Evaluator:
 
         return Bitrate(float(f"{bitrate_sent:.5g}"), float(f"{bitrate_received:.5g}"))
 
-    def calculate_gbps_iperf_udp(self, result: dict) -> Bitrate:
+    def calculate_gbps_iperf_udp(self, result: Mapping[str, Any]) -> Bitrate:
         # If an error occurred, bitrate = 0
         if "error" in result:
             logger.error(f"An error occurred during iperf test: {result['error']}")
@@ -259,10 +266,9 @@ class Evaluator:
         bitrate_sent = sum_data["bits_per_second"] / 1e9
         return Bitrate(float(f"{bitrate_sent:.5g}"), float(f"{bitrate_sent:.5g}"))
 
-    def calculate_gbps_http(self, result: dict) -> Bitrate:
+    def calculate_gbps_http(self, result: Mapping[str, Any]) -> Bitrate:
         # TODO: Add http traffic testing
         raise NotImplementedError("calculate_gbps_http is not yet implemented")
-        return -1  # type: ignore
 
     def evaluate_pass_fail_status(self) -> PassFailStatus:
         tft_passing = 0

--- a/evaluator.py
+++ b/evaluator.py
@@ -14,7 +14,6 @@ from common import (
 )
 from logger import logger
 from pathlib import Path
-from typing import List
 from common import serialize_enum, dataclass_from_dict
 from typing import Any
 from typing import Mapping
@@ -98,8 +97,8 @@ class Evaluator:
                 for test_type, test_cases in c.items()
             }
 
-        self.test_results: List[TestResult] = []
-        self.plugin_results: List[PluginResult] = []
+        self.test_results: list[TestResult] = []
+        self.plugin_results: list[PluginResult] = []
 
     def _eval_flow_test(self, run: IperfOutput) -> None:
         md = run.tft_metadata

--- a/generate_new_eval_config.py
+++ b/generate_new_eval_config.py
@@ -4,6 +4,7 @@ import yaml
 import math
 import sys
 from common import TestCaseType
+from typing import Any
 
 
 # can implement custom rounding if you want
@@ -12,7 +13,9 @@ def custom_floor(value: float) -> int:
     return base - 2
 
 
-def process_test_cases(test_cases: dict, test_config_map: dict) -> None:
+def process_test_cases(
+    test_cases: list[dict[str, Any]], test_config_map: dict[tuple[str, int], Any]
+) -> None:
     for item in test_cases:
         test_id_desc = item["test_id"]
         test_type = item["test_type"]
@@ -46,7 +49,7 @@ with open(results_json_path, "r") as json_file:
     result_json = json.load(json_file)
 
 # Create a test configuration map for easy access to threshold data
-test_config_map = {}
+test_config_map: dict[tuple[str, int], Any] = {}
 for test_type, tests in eval_config.items():
     for test in tests:
         test_config_map[(test_type, test["id"])] = test

--- a/host.py
+++ b/host.py
@@ -6,20 +6,25 @@ import sys
 from logger import logger
 from common import Result
 from abc import ABC, abstractmethod
+from typing import Any
+import typing
 
 
 class Host(ABC):
-    def ipa(self) -> dict:
-        return json.loads(self.run("ip -json a").out)
+    def ipa(self) -> list[dict[str, Any]]:
+        r = json.loads(self.run("ip -json a").out)
+        return typing.cast(list[dict[str, Any]], r)
 
-    def ipr(self) -> dict:
-        return json.loads(self.run("ip -json r").out)
+    def ipr(self) -> list[dict[str, Any]]:
+        r = json.loads(self.run("ip -json r").out)
+        return typing.cast(list[dict[str, Any]], r)
 
-    def all_ports(self) -> dict:
-        return json.loads(self.run("ip -json link").out)
+    def all_ports(self) -> list[dict[str, Any]]:
+        r = json.loads(self.run("ip -json link").out)
+        return typing.cast(list[dict[str, Any]], r)
 
     @abstractmethod
-    def run(self, cmd: str, env: dict = os.environ.copy()) -> Result:
+    def run(self, cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
         pass
 
 
@@ -27,7 +32,7 @@ class LocalHost(Host):
     def __init__(self) -> None:
         pass
 
-    def run(self, cmd: str, env: dict = os.environ.copy()) -> Result:
+    def run(self, cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
         args = shlex.split(cmd)
         pipe = subprocess.PIPE
         with subprocess.Popen(args, stdout=pipe, stderr=pipe, env=env) as proc:

--- a/iperf.py
+++ b/iperf.py
@@ -8,6 +8,8 @@ from testSettings import TestSettings
 import json
 from syncManager import SyncManager
 import perf
+from typing import Any
+from typing import Mapping
 
 IPERF_EXE = "iperf3"
 IPERF_UDP_OPT = "-u -b 25G"
@@ -104,7 +106,7 @@ class IperfClient(perf.PerfClient):
         if self.test_type == TestType.IPERF_UDP:
             self.print_udp_results(self._output.result)
 
-    def print_tcp_results(self, data: dict) -> None:
+    def print_tcp_results(self, data: Mapping[str, Any]) -> None:
         sum_sent = data["end"]["sum_sent"]
         sum_received = data["end"]["sum_received"]
 
@@ -121,7 +123,7 @@ class IperfClient(perf.PerfClient):
             f"  MSS = {mss}"
         )
 
-    def print_udp_results(self, data: dict) -> None:
+    def print_udp_results(self, data: Mapping[str, Any]) -> None:
         sum_data = data["end"]["sum"]
 
         total_gigabytes = sum_data["bytes"] / (1024**3)
@@ -138,5 +140,5 @@ class IperfClient(perf.PerfClient):
             f"  Total Lost Percent: {total_lost_percent:.2f}%"
         )
 
-    def iperf_error_occurred(self, data: dict) -> bool:
+    def iperf_error_occurred(self, data: Mapping[str, Any]) -> bool:
         return "error" in data

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,4 +1,4 @@
-import kubernetes
+import kubernetes  # type: ignore
 import yaml
 import host
 from common import Result

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -2,7 +2,6 @@ import kubernetes  # type: ignore
 import yaml
 import host
 from common import Result
-from typing import List
 
 
 class K8sClient:
@@ -15,10 +14,10 @@ class K8sClient:
 
     def get_nodes(
         self,
-    ) -> List[str]:
+    ) -> list[str]:
         return [e.metadata.name for e in self._client.list_node().items]
 
-    def get_nodes_with_label(self, label_selector: str) -> List[str]:
+    def get_nodes_with_label(self, label_selector: str) -> list[str]:
         return [
             e.metadata.name
             for e in self._client.list_node(label_selector=label_selector).items

--- a/measureCpu.py
+++ b/measureCpu.py
@@ -11,7 +11,7 @@ from testConfig import TestConfig
 from thread import ReturnValueThread
 from task import Task
 import jc
-from typing import List, Dict, Any, cast
+from typing import Any, cast
 from syncManager import SyncManager
 
 
@@ -58,7 +58,7 @@ class MeasureCPU(Task):
     # TODO: We are currently only storing the "cpu: all" data from mpstat
     def generate_output(self, data: str) -> PluginOutput:
         # satisfy the linter. jc.parse returns a list of dicts in this case
-        parsed_data = cast(List[Dict[str, Any]], jc.parse("mpstat", data))
+        parsed_data = cast(list[dict[str, Any]], jc.parse("mpstat", data))
         return PluginOutput(
             plugin_metadata={
                 "name": "MeasureCPU",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-exclude = ^tests/
+
 [mypy-jc]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,4 @@
 [mypy]
 exclude = ^tests/
+[mypy-jc]
+ignore_missing_imports = True

--- a/task.py
+++ b/task.py
@@ -7,7 +7,6 @@ from testConfig import TestConfig
 from testConfig import ClusterMode
 from thread import ReturnValueThread
 import host
-from typing import Dict
 import typing
 
 
@@ -15,7 +14,7 @@ class Task(ABC):
     def __init__(
         self, tc: TestConfig, index: int, node_name: str, tenant: bool
     ) -> None:
-        self.template_args: Dict[str, str] = {}
+        self.template_args: dict[str, str] = {}
         self.in_file_template = ""
         self.out_file_yaml = ""
         self.pod_name = ""

--- a/task.py
+++ b/task.py
@@ -8,6 +8,7 @@ from testConfig import ClusterMode
 from thread import ReturnValueThread
 import host
 from typing import Dict
+import typing
 
 
 class Task(ABC):
@@ -51,7 +52,7 @@ class Task(ABC):
             sys.exit(-1)
 
         y = yaml.safe_load(r.out)
-        return y["status"]["podIP"]
+        return typing.cast(str, y["status"]["podIP"])
 
     def create_cluster_ip_service(self) -> str:
         in_file_template = "./manifests/svc-cluster-ip.yaml.j2"

--- a/testConfig.py
+++ b/testConfig.py
@@ -6,7 +6,9 @@ from k8sClient import K8sClient
 from yaml import safe_load
 import io
 from common import TestType, TestCaseType, enum_convert, PodType
+from typing import Any
 from typing import List, Dict
+import typing
 
 
 class ClusterMode(Enum):
@@ -22,7 +24,7 @@ class TestConfig:
     mode: ClusterMode = ClusterMode.SINGLE
     client_tenant: K8sClient
     client_infra: K8sClient
-    full_config: dict
+    full_config: dict[str, Any]
 
     def __init__(self, config_path: str):
         with open(config_path, "r") as f:
@@ -91,7 +93,7 @@ class TestConfig:
             return connection["default-network"]
         return "default/default"
 
-    def validate_test_type(self, connection: dict) -> TestType:
+    def validate_test_type(self, connection: dict[str, str]) -> TestType:
         if "type" not in connection:
             return TestType.IPERF_TCP
 
@@ -114,5 +116,5 @@ class TestConfig:
                 Supported connection types: iperf-tcp (default), iperf-udp, http"
             )
 
-    def GetConfig(self) -> List[dict]:
-        return self.full_config["tft"]
+    def GetConfig(self) -> List[dict[str, Any]]:
+        return typing.cast(list[dict[str, Any]], self.full_config["tft"])

--- a/testConfig.py
+++ b/testConfig.py
@@ -7,7 +7,6 @@ from yaml import safe_load
 import io
 from common import TestType, TestCaseType, enum_convert, PodType
 from typing import Any
-from typing import List, Dict
 import typing
 
 
@@ -56,8 +55,8 @@ class TestConfig:
 
         logger.info(self.GetConfig())
 
-    def parse_test_cases(self, input_str: str) -> List[TestCaseType]:
-        output: List[TestCaseType] = []
+    def parse_test_cases(self, input_str: str) -> list[TestCaseType]:
+        output: list[TestCaseType] = []
         parts = input_str.split(",")
 
         for part in parts:
@@ -82,13 +81,13 @@ class TestConfig:
 
         return output
 
-    def pod_type_from_config(self, connection_server: Dict[str, str]) -> PodType:
+    def pod_type_from_config(self, connection_server: dict[str, str]) -> PodType:
         if "sriov" in connection_server:
             if "true" in connection_server["sriov"].lower():
                 return PodType.SRIOV
         return PodType.NORMAL
 
-    def default_network_from_config(self, connection: Dict[str, str]) -> str:
+    def default_network_from_config(self, connection: dict[str, str]) -> str:
         if "default-network" in connection:
             return connection["default-network"]
         return "default/default"
@@ -116,5 +115,5 @@ class TestConfig:
                 Supported connection types: iperf-tcp (default), iperf-udp, http"
             )
 
-    def GetConfig(self) -> List[dict[str, Any]]:
+    def GetConfig(self) -> list[dict[str, Any]]:
         return typing.cast(list[dict[str, Any]], self.full_config["tft"])

--- a/testSettings.py
+++ b/testSettings.py
@@ -137,7 +137,10 @@ class TestSettings:
     def client_test_to_pod_type(
         self, test_id: TestCaseType, cfg_pod_type: PodType
     ) -> PodType:
-        if test_id in range(13, 25) or test_id.value == 26:
+        if (
+            test_id.value >= TestCaseType.HOST_TO_HOST_SAME_NODE.value
+            and test_id.value <= TestCaseType.HOST_TO_EXTERNAL.value
+        ):
             return PodType.HOSTBACKED
 
         if cfg_pod_type == PodType.SRIOV:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -57,8 +57,8 @@ def test_test_metadata() -> None:
     # Test with dictionary input
     metadata_dict = TestMetadata(
         reverse=True,
-        test_case_id="POD_TO_POD_DIFF_NODE",
-        test_type="IPERF_UDP",
+        test_case_id=TestCaseType.POD_TO_POD_DIFF_NODE,
+        test_type=TestType.IPERF_UDP,
         server=server.__dict__,
         client=client.__dict__,
     )
@@ -78,15 +78,15 @@ def test_iperf_output() -> None:
     )
     metadata = TestMetadata(
         reverse=False,
-        test_case_id=TestCaseType.POD_TO_POD_SAME_NODE,
-        test_type=TestType.IPERF_TCP,
-        server=server,
-        client=client,
+        test_case_id="POD_TO_POD_SAME_NODE",
+        test_type="IPERF_TCP",
+        server=server.__dict__,
+        client=client.__dict__,
     )
     IperfOutput(command="command", result={}, tft_metadata=metadata)
 
     with pytest.raises(ValueError):
-        IperfOutput(command="command", result={}, tft_metadata="string")
+        IperfOutput(command="command", result={}, tft_metadata="string")  # type: ignore
 
 
 def test_serialize_enum() -> None:

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -3,6 +3,7 @@ import pytest
 import subprocess
 from pathlib import Path
 import filecmp
+from typing import Any
 
 current_dir = os.path.dirname(__file__)
 parent_dir = os.path.dirname(current_dir)
@@ -13,7 +14,9 @@ evaluator_file = os.path.join(parent_dir, "evaluator.py")
 COMMON_COMMAND = ["python", evaluator_file, config_path]
 
 
-def run_subprocess(command, **kwargs):
+def run_subprocess(
+    command: list[str], **kwargs: Any
+) -> subprocess.CompletedProcess[str]:
     full_command = COMMON_COMMAND + command
     result = subprocess.run(full_command, text=True, **kwargs)
     print("STDOUT:", result.stdout)

--- a/thread.py
+++ b/thread.py
@@ -1,5 +1,6 @@
 from threading import Thread
 from logger import logger
+from typing import Any
 from typing import Callable, Optional
 from common import Result
 
@@ -8,11 +9,11 @@ class ReturnValueThread(Thread):
     def __init__(
         self,
         target: Optional[Callable[..., Result]],
-        args: tuple = (),
-        kwargs: dict = {},
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] = {},
         cleanup_action: Optional[Callable[..., Result]] = None,
-        cleanup_args: tuple = (),
-        cleanup_kwargs: dict = {},
+        cleanup_args: tuple[Any, ...] = (),
+        cleanup_kwargs: dict[str, Any] = {},
     ) -> None:
         super().__init__()
         self._target = target

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -27,6 +27,7 @@ import datetime
 from dataclasses import asdict
 from syncManager import SyncManager
 from typing import Tuple
+from typing import Any
 
 
 class TrafficFlowTests:
@@ -94,7 +95,11 @@ class TrafficFlowTests:
         self.lh.run(cmd)
 
     def _enable_measure_cpu_plugin(
-        self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool
+        self,
+        monitors: list[Task],
+        node_server_name: str,
+        node_client_name: str,
+        tenant: bool,
     ) -> None:
         s = MeasureCPU(self._tc, node_server_name, tenant)
         c = MeasureCPU(self._tc, node_client_name, tenant)
@@ -102,7 +107,11 @@ class TrafficFlowTests:
         monitors.append(c)
 
     def _enable_measure_power_plugin(
-        self, monitors: list, node_server_name: str, node_client_name: str, tenant: bool
+        self,
+        monitors: list[Task],
+        node_server_name: str,
+        node_client_name: str,
+        tenant: bool,
     ) -> None:
         s = MeasurePower(self._tc, node_server_name, tenant)
         c = MeasurePower(self._tc, node_client_name, tenant)
@@ -111,7 +120,7 @@ class TrafficFlowTests:
 
     def enable_validate_offload_plugin(
         self,
-        monitors: list,
+        monitors: list[Task],
         perf_server: perf.PerfServer,
         perf_client: perf.PerfClient,
         tenant: bool,
@@ -148,7 +157,7 @@ class TrafficFlowTests:
 
         return tft_aggregate_output
 
-    def _create_log_paths_from_tests(self, tests: dict) -> None:
+    def _create_log_paths_from_tests(self, tests: dict[str, str]) -> None:
         if "logs" in tests:
             self.log_path = Path(tests["logs"])
         self.log_path.mkdir(parents=True, exist_ok=True)
@@ -159,7 +168,7 @@ class TrafficFlowTests:
     def _dump_result_to_log(self) -> None:
         # Dump test outputs into log file
         log = self.log_file
-        json_out: dict = {TFT_TESTS: []}
+        json_out: dict[str, list[dict[str, Any]]] = {TFT_TESTS: []}
         for out in self.tft_output:
             json_out[TFT_TESTS].append(asdict(out))
         with open(log, "w") as output_file:
@@ -195,7 +204,7 @@ class TrafficFlowTests:
 
     def _run(
         self,
-        connections: dict,
+        connections: dict[str, Any],
         test_type: TestType,
         test_id: TestCaseType,
         index: int,
@@ -261,7 +270,7 @@ class TrafficFlowTests:
         output = self._run_tests(servers, clients, monitors, duration)
         self.tft_output.append(output)
 
-    def _run_test_case(self, tests: dict, test_id: TestCaseType) -> None:
+    def _run_test_case(self, tests: dict[str, Any], test_id: TestCaseType) -> None:
         duration = int(tests["duration"])
         # TODO Allow for multiple connections / instances to run simultaneously
         for connections in tests["connections"]:
@@ -290,7 +299,7 @@ class TrafficFlowTests:
                     )
                 self._cleanup_previous_testspace(tests["namespace"])
 
-    def run(self, tests: dict, eval_config: str) -> None:
+    def run(self, tests: dict[str, Any], eval_config: str) -> None:
         self.eval_config = eval_config
         self._configure_namespace(tests["namespace"])
         self._cleanup_previous_testspace(tests["namespace"])

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -22,11 +22,9 @@ from host import LocalHost
 import json
 from pathlib import Path
 from evaluator import Evaluator
-from typing import List
 import datetime
 from dataclasses import asdict
 from syncManager import SyncManager
-from typing import Tuple
 from typing import Any
 
 
@@ -37,11 +35,11 @@ class TrafficFlowTests:
         self.lh = LocalHost()
         self.log_path: Path = Path("ft-logs")
         self.log_file: Path
-        self.tft_output: List[TftAggregateOutput] = []
+        self.tft_output: list[TftAggregateOutput] = []
 
     def _create_iperf_server_client(
         self, test_settings: TestSettings
-    ) -> Tuple[perf.PerfServer, perf.PerfClient]:
+    ) -> tuple[perf.PerfServer, perf.PerfClient]:
         logger.info(
             f"Initializing iperf server/client for test:\n {test_settings.get_test_info()}"
         )
@@ -52,7 +50,7 @@ class TrafficFlowTests:
 
     def _create_netperf_server_client(
         self, test_settings: TestSettings
-    ) -> Tuple[perf.PerfServer, perf.PerfClient]:
+    ) -> tuple[perf.PerfServer, perf.PerfClient]:
         logger.info(
             f"Initializing Netperf server/client for test:\n {test_settings.get_test_info()}"
         )
@@ -132,9 +130,9 @@ class TrafficFlowTests:
 
     def _run_tests(
         self,
-        servers: List[perf.PerfServer],
-        clients: List[perf.PerfClient],
-        monitors: List[Task],
+        servers: list[perf.PerfServer],
+        clients: list[perf.PerfClient],
+        monitors: list[Task],
         duration: int,
     ) -> TftAggregateOutput:
         tft_aggregate_output = TftAggregateOutput()
@@ -211,9 +209,9 @@ class TrafficFlowTests:
         duration: int,
         reverse: bool = False,
     ) -> None:
-        servers: List[perf.PerfServer] = []
-        clients: List[perf.PerfClient] = []
-        monitors: List[Task] = []
+        servers: list[perf.PerfServer] = []
+        clients: list[perf.PerfClient] = []
+        monitors: list[Task] = []
         node_server_name = connections["server"][0]["name"]
         node_client_name = connections["client"][0]["name"]
 

--- a/validateOffload.py
+++ b/validateOffload.py
@@ -15,6 +15,7 @@ from task import Task
 from typing import Union
 import json
 from syncManager import SyncManager
+import typing
 
 
 class ValidateOffload(Task):
@@ -63,7 +64,7 @@ class ValidateOffload(Task):
         logger.info(
             f"The VF representor is: {data['containers'][0]['podSandboxId'][:15]}"
         )
-        return data["containers"][0]["podSandboxId"][:15]
+        return typing.cast(str, data["containers"][0]["podSandboxId"][:15])
 
     def run_ethtool_cmd(self, ethtool_cmd: str) -> Result:
         logger.info(f"Running {ethtool_cmd}")

--- a/validateOffload.py
+++ b/validateOffload.py
@@ -12,7 +12,6 @@ from testConfig import TestConfig
 import perf
 from thread import ReturnValueThread
 from task import Task
-from typing import Union
 import json
 from syncManager import SyncManager
 import typing
@@ -22,7 +21,7 @@ class ValidateOffload(Task):
     def __init__(
         self,
         tft: TestConfig,
-        perf_instance: Union[perf.PerfServer, perf.PerfClient],
+        perf_instance: perf.PerfServer | perf.PerfClient,
         tenant: bool,
     ):
         super().__init__(tft, 0, perf_instance.node_name, tenant)
@@ -149,7 +148,7 @@ class ValidateOffload(Task):
         # TODO: switch to debug
         logger.info(f"generate hwol output from data: {data}")
         split_data = data.split("--DELIMIT--")
-        parsed_data: dict[str, Union[str, int]] = {}
+        parsed_data: dict[str, str | int] = {}
 
         if len(split_data) >= 1:
             parsed_data["rx_start"] = self.parse_packets(split_data[0], "rx")


### PR DESCRIPTION
Currently, our github action runs `mypy --install-types --non-interactive --disallow-untyped-defs --ignore-missing-imports .`. 

We will adjust that to run `mypy --strict --config-file mypy.ini .` which is stricter. Fix the code for the typing errors due to that.

Also replace `typing.{List,Dict,Tuple,Union}`.
