### PR TITLE
[th/black-reformat] style: adjust code so that different black versions format it the same

### DIFF
--- a/perf.py
+++ b/perf.py
@@ -35,23 +35,20 @@ class PerfServer(Task):
             self.out_file_yaml = (
                 f"./manifests/yamls/sriov-pod-{self.node_name}-server.yaml"
             )
-            self.template_args["pod_name"] = (
-                f"sriov-pod-{self.node_name}-server-{self.port}"
-            )
+            s = f"sriov-pod-{self.node_name}-server-{self.port}"
+            self.template_args["pod_name"] = s
         elif self.pod_type == PodType.NORMAL:
             self.in_file_template = "./manifests/pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/pod-{self.node_name}-server.yaml"
-            self.template_args["pod_name"] = (
-                f"normal-pod-{self.node_name}-server-{self.port}"
-            )
+            s = f"normal-pod-{self.node_name}-server-{self.port}"
+            self.template_args["pod_name"] = s
         elif self.pod_type == PodType.HOSTBACKED:
             self.in_file_template = "./manifests/host-pod.yaml.j2"
             self.out_file_yaml = (
                 f"./manifests/yamls/host-pod-{self.node_name}-server.yaml"
             )
-            self.template_args["pod_name"] = (
-                f"host-pod-{self.node_name}-server-{self.port}"
-            )
+            s = f"host-pod-{self.node_name}-server-{self.port}"
+            self.template_args["pod_name"] = s
 
         self.template_args["port"] = f"{self.port}"
 
@@ -115,23 +112,20 @@ class PerfClient(Task):
             self.out_file_yaml = (
                 f"./manifests/yamls/sriov-pod-{self.node_name}-client.yaml"
             )
-            self.template_args["pod_name"] = (
-                f"sriov-pod-{self.node_name}-client-{self.port}"
-            )
+            s = f"sriov-pod-{self.node_name}-client-{self.port}"
+            self.template_args["pod_name"] = s
         elif self.pod_type == PodType.NORMAL:
             self.in_file_template = "./manifests/pod.yaml.j2"
             self.out_file_yaml = f"./manifests/yamls/pod-{self.node_name}-client.yaml"
-            self.template_args["pod_name"] = (
-                f"normal-pod-{self.node_name}-client-{self.port}"
-            )
+            s = f"normal-pod-{self.node_name}-client-{self.port}"
+            self.template_args["pod_name"] = s
         elif self.pod_type == PodType.HOSTBACKED:
             self.in_file_template = "./manifests/host-pod.yaml.j2"
             self.out_file_yaml = (
                 f"./manifests/yamls/host-pod-{self.node_name}-client.yaml"
             )
-            self.template_args["pod_name"] = (
-                f"host-pod-{self.node_name}-client-{self.port}"
-            )
+            s = f"host-pod-{self.node_name}-client-{self.port}"
+            self.template_args["pod_name"] = s
 
         self.pod_name = self.template_args["pod_name"]
 

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -41,7 +41,6 @@ plugin = PluginMeasureCpu()
 
 
 class TaskMeasureCPU(PluginTask):
-
     @property
     def plugin(self) -> pluginbase.Plugin:
         return plugin

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -40,7 +40,6 @@ plugin = PluginMeasurePower()
 
 
 class TaskMeasurePower(PluginTask):
-
     @property
     def plugin(self) -> pluginbase.Plugin:
         return plugin

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -87,7 +87,6 @@ plugin = PluginValidateOffload()
 
 
 class TaskValidateOffload(PluginTask):
-
     @property
     def plugin(self) -> pluginbase.Plugin:
         return plugin


### PR DESCRIPTION
The formatting that python black produces depends on the version of the tool. The authoritative version is the one from the github action, that is, "24.4.2" which we currently install via pip.

On current Fedora 40, we have 22.12.0.

It's cumbersome if different versions fight over the formatting. Even if the correct solution is to use the same version as used in github, we can avoid this problem by rewriting the code a bit, so that it formats the same with versions 22.12.0 and 24.4.2.