### PR TITLE
[th/plugin-fixes] fix some result handling of the plugin

### DIFF
--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -75,9 +75,8 @@ class TaskMeasureCPU(PluginTask):
 
     def output(self, out: TftAggregateOutput) -> None:
         # Return machine-readable output to top level
-        assert isinstance(
-            self._output, PluginOutput
-        ), f"Expected variable to be of type PluginOutput, got {type(self._output)} instead."
+        if not isinstance(self._output, PluginOutput):
+            return
         out.plugins.append(self._output)
 
         # Print summary to console logs

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -84,7 +84,7 @@ class TaskMeasurePower(PluginTask):
                 iteration += 1
                 time.sleep(0.2)
 
-            r = Result(f"{total_pwr/iteration}", "", 0)
+            r = Result(json.dumps({"measure_power": f"{total_pwr/iteration}"}), "", 0)
             return r
 
         # 1 report at intervals defined by the duration in seconds.
@@ -101,7 +101,7 @@ class TaskMeasurePower(PluginTask):
         out.plugins.append(self._output)
 
         # Print summary to console logs
-        logger.info(f"measurePower results: {self._output.result}")
+        logger.info(f"measurePower results: {self._output.result['measure_power']}")
 
     def generate_output(self, data: str) -> PluginOutput:
         parsed_data = json.loads(data)

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -95,9 +95,8 @@ class TaskMeasurePower(PluginTask):
 
     def output(self, out: TftAggregateOutput) -> None:
         # Return machine-readable output to top level
-        assert isinstance(
-            self._output, PluginOutput
-        ), f"Expected variable to be of type PluginOutput, got {type(self._output)} instead."
+        if not isinstance(self._output, PluginOutput):
+            return
         out.plugins.append(self._output)
 
         # Print summary to console logs

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -200,9 +200,9 @@ class TaskValidateOffload(PluginTask):
         self.exec_thread.start()
 
     def output(self, out: TftAggregateOutput) -> None:
-        assert isinstance(
-            self._output, PluginOutput
-        ), f"Expected variable to be of type PluginOutput, got {type(self._output)} instead."
+        if not isinstance(self._output, PluginOutput):
+            return
+
         out.plugins.append(self._output)
 
         if self.perf_pod_type == PodType.HOSTBACKED:


### PR DESCRIPTION
the result handling of the tasks is IMO not good. There are no strong types, and it's quite ill defined what is returned. This should be improved later (by returning typed instances instead of strings or dictionaries or undefined content).

for now, two patches to workaround crashes.