### PR TITLE
[th/log-format] logger: log the thread id and align level

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -8,7 +8,7 @@ def configure_logger(lvl: int) -> None:
     global logger
     logger.setLevel(lvl)
 
-    fmt = "%(asctime)s %(levelname)s: %(message)s"
+    fmt = "%(asctime)s %(levelname)-7s [th:%(thread)s]: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(fmt, datefmt)
 


### PR DESCRIPTION
Since we have multiple threads, its useful to see which thread logs what.

Also, align the logging level. Otherwise, lines with different level misalign and are harder to read.