### PR TITLE
[th/gitignore] gitignore: ignore ctags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# ctags file
+/tags
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
ctags is useful for python. Ignore it's "tags" artifact.