### PR TITLE
[th/strict-dataclasses] stricter check attributes for dataclasses and make them frozen (immutable)

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,4 +1,7 @@
+import dataclasses
 import jinja2
+import typing
+import collections
 
 from dataclasses import fields
 from dataclasses import is_dataclass
@@ -248,3 +251,101 @@ def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
         elif field_name in data:
             field_values[field_name] = data[field_name]
     return cast(T, cls(**field_values))
+
+
+def check_type(value: typing.Any, type_hint: type[typing.Any]) -> bool:
+
+    # Some naive type checking. This is used for ensuring that data classes
+    # contain the expected types (see @strict_dataclass).
+    #
+    # That is most interesting, when we initialize the data class with
+    # data from an untrusted source (like elements from a JSON parser).
+
+    actual_type = typing.get_origin(type_hint)
+    if actual_type is None:
+        if isinstance(type_hint, str):
+            raise NotImplementedError(
+                f'Type hint "{type_hint}" as string is not implemented by check_type()'
+            )
+
+        if type_hint is typing.Any:
+            return True
+        return isinstance(value, type_hint)
+
+    if actual_type is typing.Union:
+        args = typing.get_args(type_hint)
+        return any(check_type(value, a) for a in args)
+
+    if actual_type is list:
+        args = typing.get_args(type_hint)
+        (arg,) = args
+        return isinstance(value, list) and all(check_type(v, arg) for v in value)
+
+    if actual_type is dict or actual_type is collections.abc.Mapping:
+        args = typing.get_args(type_hint)
+        (arg_key, arg_val) = args
+        return isinstance(value, dict) and all(
+            check_type(k, arg_key) and check_type(v, arg_val) for k, v in value.items()
+        )
+
+    if actual_type is tuple:
+        # https://docs.python.org/3/library/typing.html#annotating-tuples
+        if not isinstance(value, tuple):
+            return False
+        args = typing.get_args(type_hint)
+        if len(args) == 1 and args[0] == ():
+            # This is an empty tuple tuple[()].
+            return len(value) == 0
+        if len(args) == 2 and args[1] is ...:
+            # This is a tuple[T, ...].
+            return all(check_type(v, args[0]) for v in value)
+        return len(value) == len(args) and all(
+            check_type(v, args[idx]) for idx, v in enumerate(value)
+        )
+
+    raise NotImplementedError(
+        f'Type hint "{type_hint}" with origin type "{actual_type}" is not implemented by check_type()'
+    )
+
+
+if typing.TYPE_CHECKING:
+    # https://github.com/python/typeshed/tree/main/stdlib/_typeshed#api-stability
+    # https://github.com/python/typeshed/blob/6220c20d9360b12e2287511587825217eec3e5b5/stdlib/_typeshed/__init__.pyi#L349
+    from _typeshed import DataclassInstance
+
+
+def dataclass_check(
+    instance: "DataclassInstance",
+    *,
+    with_post_check: bool = True,
+) -> None:
+
+    for field in dataclasses.fields(instance):
+        value = getattr(instance, field.name)
+        if not check_type(value, field.type):
+            raise TypeError(
+                f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
+            )
+
+    if with_post_check:
+        # Normally, data classes support __post_init__(), which is called by __init__()
+        # already. Add a way for a @strict_dataclass to add additional validation *after*
+        # the original check.
+        _post_check = getattr(type(instance), "_post_check", None)
+        if _post_check is not None:
+            _post_check(instance)
+
+
+TCallable = typing.TypeVar("TCallable", bound=typing.Callable[..., typing.Any])
+
+
+def strict_dataclass(cls: TCallable) -> TCallable:
+
+    init = getattr(cls, "__init__")
+
+    def wrapped_init(self: Any, *args: Any, **argv: Any) -> None:
+        init(self, *args, **argv)
+        dataclass_check(self)
+
+    setattr(cls, "__init__", wrapped_init)
+    return cls

--- a/evaluator.py
+++ b/evaluator.py
@@ -15,6 +15,7 @@ import tftbase
 
 from common import dataclass_from_dict
 from common import serialize_enum
+from common import strict_dataclass
 from logger import logger
 from tftbase import IperfOutput
 from tftbase import PluginOutput
@@ -23,13 +24,15 @@ from tftbase import TestCaseType
 from tftbase import TestType
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class Bitrate:
     tx: float
     rx: float
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class PassFailStatus:
     """Pass/Fail ratio and result from evaluating a full tft Flow Test result
 
@@ -45,7 +48,8 @@ class PassFailStatus:
     num_plugin_failed: int
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class TestResult:
     """Result of a single test case run
 

--- a/host.py
+++ b/host.py
@@ -13,7 +13,7 @@ from typing import Any
 from logger import logger
 
 
-@dataclass
+@dataclass(frozen=True)
 class Result:
     out: str
     err: str

--- a/testConfig.py
+++ b/testConfig.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 import common
 import host
 
+from common import strict_dataclass
 from k8sClient import K8sClient
 from logger import logger
 from pluginbase import Plugin
@@ -79,12 +80,14 @@ def _check_and_pop_name_required(vdict: dict[str, Any], yamlpath: str) -> str:
     return typing.cast(str, _check_and_pop_name(vdict, yamlpath, required=True))
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class _ConfBase(abc.ABC):
     yamlpath: str
     yamlidx: int
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class _ConfBaseNamed(_ConfBase, abc.ABC):
     name: str
@@ -93,6 +96,7 @@ class _ConfBaseNamed(_ConfBase, abc.ABC):
 T2 = TypeVar("T2", bound="ConfServer | ConfClient")
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class _ConfBaseClientServer(_ConfBaseNamed, abc.ABC):
     sriov: bool
@@ -151,6 +155,7 @@ class _ConfBaseClientServer(_ConfBaseNamed, abc.ABC):
         return typing.cast("T2", result)
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfPlugin(_ConfBaseNamed):
     plugin: Plugin
@@ -181,6 +186,7 @@ class ConfPlugin(_ConfBaseNamed):
         )
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfServer(_ConfBaseClientServer):
     persistent: bool
@@ -190,6 +196,7 @@ class ConfServer(_ConfBaseClientServer):
         return _ConfBaseClientServer._parse(ConfServer, yamlidx, yamlpath, arg)
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfClient(_ConfBaseClientServer):
     @staticmethod
@@ -197,6 +204,7 @@ class ConfClient(_ConfBaseClientServer):
         return _ConfBaseClientServer._parse(ConfClient, yamlidx, yamlpath, arg)
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfConnection(_ConfBaseNamed):
     test_type: TestType
@@ -288,6 +296,7 @@ class ConfConnection(_ConfBaseNamed):
         )
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfTest(_ConfBaseNamed):
     namespace: str
@@ -375,6 +384,7 @@ class ConfTest(_ConfBaseNamed):
         )
 
 
+@strict_dataclass
 @dataclass(frozen=True)
 class ConfConfig(_ConfBase):
     tft: tuple[ConfTest, ...]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -193,20 +193,6 @@ def test_test_metadata() -> None:
     assert metadata.server == server
     assert metadata.client == client
 
-    # Test with dictionary input
-    metadata_dict = TestMetadata(
-        reverse=True,
-        test_case_id=TestCaseType.POD_TO_POD_DIFF_NODE,
-        test_type=TestType.IPERF_UDP,
-        server=server.__dict__,
-        client=client.__dict__,
-    )
-    assert metadata_dict.reverse is True
-    assert metadata_dict.test_case_id == TestCaseType.POD_TO_POD_DIFF_NODE
-    assert metadata_dict.test_type == TestType.IPERF_UDP
-    assert isinstance(metadata_dict.server, PodInfo)
-    assert isinstance(metadata_dict.client, PodInfo)
-
 
 def test_iperf_output() -> None:
     server = PodInfo(
@@ -217,15 +203,31 @@ def test_iperf_output() -> None:
     )
     metadata = TestMetadata(
         reverse=False,
-        test_case_id="POD_TO_POD_SAME_NODE",
-        test_type="IPERF_TCP",
-        server=server.__dict__,
-        client=client.__dict__,
+        test_case_id=TestCaseType.POD_TO_POD_SAME_NODE,
+        test_type=TestType.IPERF_TCP,
+        server=server,
+        client=client,
     )
     IperfOutput(command="command", result={}, tft_metadata=metadata)
 
-    with pytest.raises(ValueError):
-        IperfOutput(command="command", result={}, tft_metadata="string")  # type: ignore
+    common.dataclass_from_dict(
+        IperfOutput,
+        {
+            "command": "command",
+            "result": {},
+            "tft_metadata": metadata,
+        },
+    )
+
+    with pytest.raises(TypeError):
+        common.dataclass_from_dict(
+            IperfOutput,
+            {
+                "command": "command",
+                "result": {},
+                "tft_metadata": "string",
+            },
+        )
 
 
 def test_serialize_enum() -> None:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,7 @@
-import sys
+import dataclasses
 import os
 import pytest
+import sys
 import typing
 
 from enum import Enum
@@ -336,3 +337,114 @@ def test_test_case_type_to_client_pod_type() -> None:
             assert _alternative(
                 test_case_type, pod_type
             ) == tftbase.test_case_type_to_client_pod_type(test_case_type, pod_type)
+
+
+def test_strict_dataclass() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        a: str
+        b: int
+        c: typing.Optional[str] = None
+
+    C2("a", 5)
+    C2("a", 5, None)
+    C2("a", 5, "")
+    with pytest.raises(TypeError):
+        C2("a", "5")  # type: ignore
+    with pytest.raises(TypeError):
+        C2(3, 5)  # type: ignore
+    with pytest.raises(TypeError):
+        C2("a", 5, [])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C3:
+        a: typing.List[str]
+
+    C3([])
+    C3([""])
+    with pytest.raises(TypeError):
+        C3(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C3([1])  # type: ignore
+    with pytest.raises(TypeError):
+        C3(None)  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C4:
+        a: typing.Optional[typing.List[str]]
+
+    C4(None)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C5:
+        a: typing.Optional[typing.List[typing.Dict[str, str]]] = None
+
+    C5(None)
+    C5([])
+    with pytest.raises(TypeError):
+        C5([1])  # type: ignore
+    C5([{}])
+    C5([{"a": "b"}])
+    C5([{"a": "b"}, {}])
+    C5([{"a": "b"}, {"c": "", "d": "x"}])
+    with pytest.raises(TypeError):
+        C5([{"a": None}])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C6:
+        a: typing.Optional[typing.Tuple[str, str]] = None
+
+    C6()
+    C6(None)
+    C6(("a", "b"))
+    with pytest.raises(TypeError):
+        C6(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a",))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", "b", "c"))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", 1))  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C7:
+        addr_info: typing.List[PodInfo]
+
+        def _post_check(self) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        C7(None)  # type: ignore
+    C7([])
+    C7([PodInfo("name", PodType.NORMAL, True, 5)])
+    with pytest.raises(TypeError):
+        C7([PodInfo("name", PodType.NORMAL, True, 5), None])  # type:ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C8:
+        a: str
+
+        def _post_check(self) -> None:
+            if self.a == "invalid":
+                raise ValueError("_post_check() failed")
+
+    with pytest.raises(TypeError):
+        C8(None)  # type: ignore
+    C8("hi")
+    with pytest.raises(ValueError):
+        C8("invalid")
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C9:
+        a: "str"
+
+    with pytest.raises(NotImplementedError):
+        C9("foo")

--- a/tftbase.py
+++ b/tftbase.py
@@ -4,11 +4,7 @@ import typing
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
-from typing import Mapping
 from typing import Optional
-
-from common import dataclass_from_dict
-from common import enum_convert
 
 
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
@@ -108,53 +104,16 @@ class TestMetadata:
     server: PodInfo
     client: PodInfo
 
-    def __init__(
-        self,
-        reverse: bool,
-        test_case_id: TestCaseType | str | int,
-        test_type: TestType | str | int,
-        server: PodInfo | dict[str, Any],
-        client: PodInfo | dict[str, Any],
-    ):
-        if isinstance(server, dict):
-            server = dataclass_from_dict(PodInfo, server)
-        if isinstance(client, dict):
-            client = dataclass_from_dict(PodInfo, client)
-        self.reverse = reverse
-        self.test_case_id = enum_convert(TestCaseType, test_case_id)
-        self.test_type = enum_convert(TestType, test_type)
-        self.server = server
-        self.client = client
-
 
 @dataclass
 class BaseOutput:
     command: str
     result: dict[str, Any]
 
-    def __init__(self, command: str, result: Mapping[str, str | int]):
-        if not isinstance(result, dict):
-            result = dict(result)
-        self.command = command
-        self.result = result
-
 
 @dataclass
 class IperfOutput(BaseOutput):
     tft_metadata: TestMetadata
-
-    def __init__(
-        self,
-        command: str,
-        result: Mapping[str, str | int],
-        tft_metadata: TestMetadata | dict[str, Any],
-    ):
-        if isinstance(tft_metadata, dict):
-            tft_metadata = dataclass_from_dict(TestMetadata, tft_metadata)
-        elif not isinstance(tft_metadata, TestMetadata):
-            raise ValueError("tft_metadata must be a TestMetadata instance or a dict")
-        super().__init__(command, result)
-        self.tft_metadata = tft_metadata
 
 
 @dataclass
@@ -177,21 +136,6 @@ class TftAggregateOutput:
 
     flow_test: Optional[IperfOutput] = None
     plugins: list[PluginOutput] = dataclasses.field(default_factory=list)
-
-    def __post_init__(self) -> None:
-        if isinstance(self.flow_test, dict):
-            self.flow_test = dataclass_from_dict(IperfOutput, self.flow_test)
-        elif self.flow_test is not None and not isinstance(self.flow_test, IperfOutput):
-            raise ValueError("flow_test must be an IperfOutput instance or a dict")
-
-        self.plugins = [
-            (
-                dataclass_from_dict(PluginOutput, plugin)
-                if isinstance(plugin, dict)
-                else plugin
-            )
-            for plugin in self.plugins
-        ]
 
 
 class TestCaseTypInfo(typing.NamedTuple):

--- a/tftbase.py
+++ b/tftbase.py
@@ -6,6 +6,8 @@ from enum import Enum
 from typing import Any
 from typing import Optional
 
+from common import strict_dataclass
+
 
 TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
 TFT_TESTS = "tft-tests"
@@ -71,7 +73,8 @@ class NodeLocation(Enum):
     DIFF_NODE = 2
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class PodInfo:
     name: str
     pod_type: PodType
@@ -79,7 +82,8 @@ class PodInfo:
     index: int
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class PluginResult:
     """Result of a single plugin from a given run
 
@@ -96,7 +100,8 @@ class PluginResult:
     success: bool
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class TestMetadata:
     reverse: bool
     test_case_id: TestCaseType
@@ -105,23 +110,27 @@ class TestMetadata:
     client: PodInfo
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class BaseOutput:
     command: str
     result: dict[str, Any]
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class IperfOutput(BaseOutput):
     tft_metadata: TestMetadata
 
 
-@dataclass
+@strict_dataclass
+@dataclass(frozen=True)
 class PluginOutput(BaseOutput):
     plugin_metadata: dict[str, str]
     name: str
 
 
+@strict_dataclass
 @dataclass
 class TftAggregateOutput:
     """Aggregated output of a single tft run. A single run of a trafficFlowTests._run_tests() will

--- a/tftbase.py
+++ b/tftbase.py
@@ -130,7 +130,7 @@ class TestMetadata:
 @dataclass
 class BaseOutput:
     command: str
-    result: dict[str, str | int]
+    result: dict[str, Any]
 
     def __init__(self, command: str, result: Mapping[str, str | int]):
         if not isinstance(result, dict):


### PR DESCRIPTION
- add `@strict_dataclass` decorator, which can be used to automatically check that a dataclass was initialized with values of the expected type.
- expand `dataclass_from_dict()` to perform the same type checking.
- at the same time, `dataclass_from_dict()` can also handle certain conversions, like string to enum (which is useful, when we load the dict from YAML). This allows us to drop certain `__init__()` methods that worked around this problem.
- mark various dataclasses as frozen. Immutable types a great!!