### PR TITLE
[th/podman-rm-fix] trafficFlowTest: fix podman-rm command line

### DIFF
--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -88,7 +88,7 @@ class TrafficFlowTests:
         logger.info(
             f"Cleaning external containers {perf.EXTERNAL_PERF_SERVER} (if present)"
         )
-        cmd = f"podman stop --time 10 {perf.EXTERNAL_PERF_SERVER}; podman rm --time 10 {perf.EXTERNAL_PERF_SERVER}"
+        cmd = f"podman rm --force --time 10 {perf.EXTERNAL_PERF_SERVER}"
         self.lh.run(cmd)
 
     def _run_test_tasks(


### PR DESCRIPTION
`podman rm --time n` fails unless we also specify "--force". If we do that, we don't need to call a separate "stop" first.

Also, currently Host.run() interprets the cmd string not as shell script, so specifying two commands separated by semicolon is not going to work. That probably should change, because interpreting the cmd as shell script is a useful feature. Anyway, for now, this doesn't work.