### PR TITLE
[th/task-context] pass the TestSettings to the Task

### DIFF
--- a/iperf.py
+++ b/iperf.py
@@ -9,7 +9,6 @@ import tftbase
 from host import Result
 from logger import logger
 from syncManager import SyncManager
-from testConfig import TestConfig
 from testSettings import TestSettings
 from tftbase import ConnectionMode
 from tftbase import IperfOutput
@@ -25,8 +24,8 @@ IPERF_REV_OPT = "-R"
 
 
 class IperfServer(perf.PerfServer):
-    def __init__(self, tc: TestConfig, ts: TestSettings):
-        super().__init__(tc, ts)
+    def __init__(self, ts: TestSettings):
+        super().__init__(ts)
 
         self.exec_persistent = ts.conf_server.persistent
 
@@ -72,8 +71,8 @@ class IperfServer(perf.PerfServer):
 
 
 class IperfClient(perf.PerfClient):
-    def __init__(self, tc: TestConfig, ts: TestSettings, server: IperfServer):
-        super().__init__(tc, ts, server)
+    def __init__(self, ts: TestSettings, server: IperfServer):
+        super().__init__(ts, server)
 
     def run(self, duration: int) -> None:
         def client(self: IperfClient, cmd: str) -> Result:

--- a/main.py
+++ b/main.py
@@ -57,15 +57,16 @@ def main() -> None:
     args = parse_args()
 
     tft = TrafficFlowTests(
-        TestConfig(config_path=args.config),
-        args.evaluator_config,
+        TestConfig(
+            config_path=args.config,
+            evaluator_config=args.evaluator_config,
+        )
     )
 
     for cfg_descr in ConfigDescriptor(tft.tc).describe_all_tft():
         tft.test_run(cfg_descr)
-        if args.evaluator_config:
-            if not tft.evaluate_run_success():
-                print(f"Failure detected in {cfg_descr.get_tft().name} results")
+        if not tft.evaluate_run_success():
+            print(f"Failure detected in {cfg_descr.get_tft().name} results")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from logger import configure_logger
 from testConfig import TestConfig
+from testConfig import ConfigDescriptor
 from trafficFlowTests import TrafficFlowTests
 
 
@@ -60,11 +61,11 @@ def main() -> None:
         args.evaluator_config,
     )
 
-    for test in tft.tc.config.tft:
-        tft.test_run(test)
+    for cfg_descr in ConfigDescriptor(tft.tc).describe_all_tft():
+        tft.test_run(cfg_descr)
         if args.evaluator_config:
             if not tft.evaluate_run_success():
-                print(f"Failure detected in {test.name} results")
+                print(f"Failure detected in {cfg_descr.get_tft().name} results")
 
 
 if __name__ == "__main__":

--- a/netperf.py
+++ b/netperf.py
@@ -4,7 +4,6 @@ import tftbase
 from host import Result
 from logger import logger
 from syncManager import SyncManager
-from testConfig import TestConfig
 from testSettings import TestSettings
 from tftbase import ConnectionMode
 from tftbase import IperfOutput
@@ -17,8 +16,8 @@ NETPERF_CLIENT_EXE = "netperf"
 
 
 class NetPerfServer(perf.PerfServer):
-    def __init__(self, tc: TestConfig, ts: TestSettings):
-        super().__init__(tc, ts)
+    def __init__(self, ts: TestSettings):
+        super().__init__(ts)
 
         self.exec_persistent = ts.conf_server.persistent
 
@@ -64,8 +63,8 @@ class NetPerfServer(perf.PerfServer):
 
 
 class NetPerfClient(perf.PerfClient):
-    def __init__(self, tc: TestConfig, ts: TestSettings, server: NetPerfServer):
-        super().__init__(tc, ts, server)
+    def __init__(self, ts: TestSettings, server: NetPerfServer):
+        super().__init__(ts, server)
 
     def run(self, duration: int) -> None:
         def client(self: NetPerfClient, cmd: str) -> Result:

--- a/perf.py
+++ b/perf.py
@@ -6,7 +6,6 @@ import tftbase
 from logger import logger
 from syncManager import SyncManager
 from task import Task
-from testConfig import TestConfig
 from testSettings import TestSettings
 from tftbase import ConnectionMode
 from tftbase import PodType
@@ -16,8 +15,8 @@ EXTERNAL_PERF_SERVER = "external-perf-server"
 
 
 class PerfServer(Task):
-    def __init__(self, tc: TestConfig, ts: TestSettings):
-        super().__init__(tc, ts.server_index, ts.node_server_name, ts.server_is_tenant)
+    def __init__(self, ts: TestSettings):
+        super().__init__(ts, ts.server_index, ts.node_server_name, ts.server_is_tenant)
 
         connection_mode = ts.connection_mode
         pod_type = ts.server_pod_type
@@ -47,7 +46,6 @@ class PerfServer(Task):
         self.port = port
         self.pod_type = pod_type
         self.connection_mode = ts.connection_mode
-        self.ts = ts
         self.in_file_template = in_file_template
         self.out_file_yaml = out_file_yaml
         self.pod_name = pod_name
@@ -104,8 +102,8 @@ class PerfServer(Task):
 
 
 class PerfClient(Task):
-    def __init__(self, tc: TestConfig, ts: TestSettings, server: PerfServer):
-        super().__init__(tc, ts.client_index, ts.conf_client.name, ts.client_is_tenant)
+    def __init__(self, ts: TestSettings, server: PerfServer):
+        super().__init__(ts, ts.client_index, ts.conf_client.name, ts.client_is_tenant)
 
         pod_type = ts.client_pod_type
         node_name = self.node_name
@@ -132,7 +130,6 @@ class PerfClient(Task):
         self.connection_mode = ts.connection_mode
         self.test_type = ts.connection.test_type
         self.test_case_id = ts.test_case_id
-        self.ts = ts
         self.reverse = ts.reverse
         self.cmd = ""
         self.in_file_template = in_file_template

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -10,7 +10,7 @@ from host import Result
 from logger import logger
 from syncManager import SyncManager
 from task import PluginTask
-from testConfig import TestConfig
+from testSettings import TestSettings
 from tftbase import PluginOutput
 from tftbase import TFT_TOOLS_IMG
 from tftbase import TftAggregateOutput
@@ -23,7 +23,7 @@ class PluginMeasureCpu(pluginbase.Plugin):
     def _enable(
         self,
         *,
-        tc: TestConfig,
+        ts: TestSettings,
         node_server_name: str,
         node_client_name: str,
         perf_server: perf.PerfServer,
@@ -31,8 +31,8 @@ class PluginMeasureCpu(pluginbase.Plugin):
         tenant: bool,
     ) -> list[PluginTask]:
         return [
-            TaskMeasureCPU(tc, node_server_name, tenant),
-            TaskMeasureCPU(tc, node_client_name, tenant),
+            TaskMeasureCPU(ts, node_server_name, tenant),
+            TaskMeasureCPU(ts, node_client_name, tenant),
         ]
 
 
@@ -44,8 +44,8 @@ class TaskMeasureCPU(PluginTask):
     def plugin(self) -> pluginbase.Plugin:
         return plugin
 
-    def __init__(self, tc: TestConfig, node_name: str, tenant: bool):
-        super().__init__(tc, 0, node_name, tenant)
+    def __init__(self, ts: TestSettings, node_name: str, tenant: bool):
+        super().__init__(ts, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = (

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -9,7 +9,7 @@ from host import Result
 from logger import logger
 from syncManager import SyncManager
 from task import PluginTask
-from testConfig import TestConfig
+from testSettings import TestSettings
 from tftbase import PluginOutput
 from tftbase import TFT_TOOLS_IMG
 from tftbase import TftAggregateOutput
@@ -22,7 +22,7 @@ class PluginMeasurePower(pluginbase.Plugin):
     def _enable(
         self,
         *,
-        tc: TestConfig,
+        ts: TestSettings,
         node_server_name: str,
         node_client_name: str,
         perf_server: perf.PerfServer,
@@ -30,8 +30,8 @@ class PluginMeasurePower(pluginbase.Plugin):
         tenant: bool,
     ) -> list[PluginTask]:
         return [
-            TaskMeasurePower(tc, node_server_name, tenant),
-            TaskMeasurePower(tc, node_client_name, tenant),
+            TaskMeasurePower(ts, node_server_name, tenant),
+            TaskMeasurePower(ts, node_client_name, tenant),
         ]
 
 
@@ -43,8 +43,8 @@ class TaskMeasurePower(PluginTask):
     def plugin(self) -> pluginbase.Plugin:
         return plugin
 
-    def __init__(self, tc: TestConfig, node_name: str, tenant: bool):
-        super().__init__(tc, 0, node_name, tenant)
+    def __init__(self, ts: TestSettings, node_name: str, tenant: bool):
+        super().__init__(ts, 0, node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = (

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -9,7 +9,7 @@ from host import Result
 from logger import logger
 from syncManager import SyncManager
 from task import PluginTask
-from testConfig import TestConfig
+from testSettings import TestSettings
 from tftbase import PluginOutput
 from tftbase import PluginResult
 from tftbase import PodType
@@ -36,7 +36,7 @@ class PluginValidateOffload(pluginbase.Plugin):
     def _enable(
         self,
         *,
-        tc: TestConfig,
+        ts: TestSettings,
         node_server_name: str,
         node_client_name: str,
         perf_server: perf.PerfServer,
@@ -45,8 +45,8 @@ class PluginValidateOffload(pluginbase.Plugin):
     ) -> list[PluginTask]:
         # TODO allow this to run on each individual server + client pairs.
         return [
-            TaskValidateOffload(tc, perf_server, tenant),
-            TaskValidateOffload(tc, perf_client, tenant),
+            TaskValidateOffload(ts, perf_server, tenant),
+            TaskValidateOffload(ts, perf_client, tenant),
         ]
 
     def eval_log(
@@ -92,11 +92,11 @@ class TaskValidateOffload(PluginTask):
 
     def __init__(
         self,
-        tft: TestConfig,
+        ts: TestSettings,
         perf_instance: perf.PerfServer | perf.PerfClient,
         tenant: bool,
     ):
-        super().__init__(tft, 0, perf_instance.node_name, tenant)
+        super().__init__(ts, 0, perf_instance.node_name, tenant)
 
         self.in_file_template = "./manifests/tools-pod.yaml.j2"
         self.out_file_yaml = (

--- a/pluginbase.py
+++ b/pluginbase.py
@@ -20,7 +20,7 @@ class Plugin(ABC):
     def enable(
         self,
         *,
-        tc: "TestConfig",
+        ts: "TestSettings",
         node_server_name: str,
         node_client_name: str,
         perf_server: "PerfServer",
@@ -28,7 +28,7 @@ class Plugin(ABC):
         tenant: bool,
     ) -> list["PluginTask"]:
         tasks = self._enable(
-            tc=tc,
+            ts=ts,
             node_server_name=node_server_name,
             node_client_name=node_client_name,
             perf_server=perf_server,
@@ -42,7 +42,7 @@ class Plugin(ABC):
     def _enable(
         self,
         *,
-        tc: "TestConfig",
+        ts: "TestSettings",
         node_server_name: str,
         node_client_name: str,
         perf_server: "PerfServer",
@@ -104,7 +104,7 @@ def get_by_name(plugin_name: str) -> Plugin:
 
 
 if typing.TYPE_CHECKING:
-    # "pluginbase" cannot import modules like perf, task or testConfig, because
+    # "pluginbase" cannot import modules like perf, task or testSettings, because
     # those modules import "pluginbase" in turn. However, to forward declare
     # type annotations, we do need those module here. Import them with
     # TYPE_CHECKING, but otherwise avoid the cyclic dependency between
@@ -112,4 +112,4 @@ if typing.TYPE_CHECKING:
     from perf import PerfClient
     from perf import PerfServer
     from task import PluginTask
-    from testConfig import TestConfig
+    from testSettings import TestSettings

--- a/task.py
+++ b/task.py
@@ -37,7 +37,7 @@ class Task(ABC):
 
     def get_template_args(self) -> dict[str, str]:
         return {
-            "name_space": "default",
+            "name_space": self.ts.cfg_descr.get_tft().namespace,
             "test_image": tftbase.TFT_TOOLS_IMG,
             "command": "/sbin/init",
             "args": "",

--- a/task.py
+++ b/task.py
@@ -11,7 +11,7 @@ import host
 import tftbase
 
 from logger import logger
-from testConfig import TestConfig
+from testSettings import TestSettings
 from tftbase import ClusterMode
 from thread import ReturnValueThread
 from pluginbase import Plugin
@@ -19,7 +19,7 @@ from pluginbase import Plugin
 
 class Task(ABC):
     def __init__(
-        self, tc: TestConfig, index: int, node_name: str, tenant: bool
+        self, ts: TestSettings, index: int, node_name: str, tenant: bool
     ) -> None:
         self.in_file_template = ""
         self.out_file_yaml = ""
@@ -29,9 +29,10 @@ class Task(ABC):
         self.index = index
         self.node_name = node_name
         self.tenant = tenant
-        self.tc = tc
+        self.ts = ts
+        self.tc = ts.cfg_descr.tc
 
-        if not self.tenant and tc.mode == ClusterMode.SINGLE:
+        if not self.tenant and self.tc.mode == ClusterMode.SINGLE:
             raise ValueError("Cannot have non-tenant Task when cluster mode is single")
 
     def get_template_args(self) -> dict[str, str]:

--- a/testConfig.py
+++ b/testConfig.py
@@ -3,7 +3,9 @@ import json
 import pathlib
 import typing
 import yaml
+import dataclasses
 
+from collections.abc import Generator
 from dataclasses import dataclass
 from typing import Any
 from typing import Optional
@@ -583,3 +585,71 @@ class TestConfig:
     @property
     def client_infra(self) -> K8sClient:
         return self.client(tenant=False)
+
+
+@strict_dataclass
+@dataclass(frozen=True)
+class ConfigDescriptor:
+    tc: TestConfig
+    tft_idx: int = dataclasses.field(default=-1, kw_only=True)
+    test_cases_idx: int = dataclasses.field(default=-1, kw_only=True)
+    connections_idx: int = dataclasses.field(default=-1, kw_only=True)
+
+    def _post_check(self) -> None:
+        if self.tft_idx < -1 or self.tft_idx >= len(self.tc.config.tft):
+            raise ValueError("tft_idx out of range")
+
+        if self.test_cases_idx < -1:
+            raise ValueError("test_cases_idx out of range")
+        if self.test_cases_idx >= 0:
+            if self.tft_idx < 0:
+                raise ValueError("test_cases_idx requires tft_idx")
+            if self.test_cases_idx >= len(self.tc.config.tft[self.tft_idx].test_cases):
+                raise ValueError("test_cases_idx out or range")
+
+        if self.connections_idx < -1:
+            raise ValueError("connections_idx out of range")
+        if self.connections_idx >= 0:
+            if self.tft_idx < 0:
+                raise ValueError("connections_idx requires tft_idx")
+            if self.connections_idx >= len(
+                self.tc.config.tft[self.tft_idx].connections
+            ):
+                raise ValueError("connections_idx out or range")
+
+    def get_tft(self) -> ConfTest:
+        if self.tft_idx < 0:
+            raise RuntimeError("No tft_idx set")
+        return self.tc.config.tft[self.tft_idx]
+
+    def get_test_case(self) -> TestCaseType:
+        if self.test_cases_idx < 0:
+            raise RuntimeError("No test_cases_idx set")
+        return self.get_tft().test_cases[self.test_cases_idx]
+
+    def get_connection(self) -> ConfConnection:
+        if self.connections_idx < 0:
+            raise RuntimeError("No connections_idx set")
+        return self.get_tft().connections[self.connections_idx]
+
+    def describe_all_tft(self) -> Generator["ConfigDescriptor", None, None]:
+        for tft_idx in range(len(self.tc.config.tft)):
+            yield ConfigDescriptor(tc=self.tc, tft_idx=tft_idx)
+
+    def describe_all_test_cases(self) -> Generator["ConfigDescriptor", None, None]:
+        for test_cases_idx in range(len(self.get_tft().test_cases)):
+            yield ConfigDescriptor(
+                tc=self.tc,
+                tft_idx=self.tft_idx,
+                connections_idx=self.connections_idx,
+                test_cases_idx=test_cases_idx,
+            )
+
+    def describe_all_connections(self) -> Generator["ConfigDescriptor", None, None]:
+        for connections_idx in range(len(self.get_tft().connections)):
+            yield ConfigDescriptor(
+                tc=self.tc,
+                tft_idx=self.tft_idx,
+                test_cases_idx=self.test_cases_idx,
+                connections_idx=connections_idx,
+            )

--- a/testConfig.py
+++ b/testConfig.py
@@ -486,6 +486,7 @@ class TestConfig:
     kc_infra: Optional[str]
     _client_tenant: Optional[K8sClient]
     _client_infra: Optional[K8sClient]
+    evaluator_config: Optional[str]
 
     @staticmethod
     def _detect_mode_args() -> tuple[ClusterMode, str, Optional[str]]:
@@ -521,6 +522,7 @@ class TestConfig:
         full_config: Optional[dict[str, Any]] = None,
         config_path: Optional[str] = None,
         mode_args: Optional[tuple[ClusterMode, str, Optional[str]]] = None,
+        evaluator_config: Optional[str] = None,
     ) -> None:
 
         if config_path is not None:
@@ -552,6 +554,8 @@ class TestConfig:
         self._client_infra = None
 
         self.mode, self.kc_tenant, self.kc_infra = mode_args
+
+        self.evaluator_config = evaluator_config
 
         s = json.dumps(full_config["tft"])
         logger.info(f"config: {s}")

--- a/testSettings.py
+++ b/testSettings.py
@@ -3,7 +3,6 @@ import tftbase
 
 from tftbase import NodeLocation
 from tftbase import PodInfo
-from tftbase import TestCaseType
 from tftbase import TestMetadata
 
 
@@ -12,13 +11,16 @@ class TestSettings:
 
     def __init__(
         self,
-        connection: testConfig.ConfConnection,
-        test_case_id: TestCaseType,
+        cfg_descr: testConfig.ConfigDescriptor,
         conf_server: testConfig.ConfServer,
         conf_client: testConfig.ConfClient,
         instance_index: int,
         reverse: bool = False,
     ):
+        connection = cfg_descr.get_connection()
+        test_case_id = cfg_descr.get_test_case()
+
+        self.cfg_descr = cfg_descr
         self.connection = connection
         self.test_case_id = test_case_id
         self.conf_server = conf_server

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -166,6 +166,13 @@ tft:
 
     _check_testConfig(tc)
 
+    cfg_descr1 = testConfig.ConfigDescriptor(tc)
+    t: list[TestCaseType] = []
+    for cfg_descr2 in cfg_descr1.describe_all_tft():
+        for cfg_descr3 in cfg_descr2.describe_all_test_cases():
+            t.append(cfg_descr3.get_test_case())
+    assert tc.config.tft[0].test_cases == tuple(t)
+
     # A minimal yaml.
     full_config = yaml.safe_load(
         """

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -29,7 +29,7 @@ from tftbase import TftAggregateOutput
 class TrafficFlowTests:
     def __init__(self, tc: TestConfig, eval_config: str):
         self.tc = tc
-        self.test_settings: TestSettings
+        self.ts: TestSettings
         self.lh = LocalHost()
         self.log_path: Path = Path("ft-logs")
         self.log_file: Path
@@ -37,25 +37,25 @@ class TrafficFlowTests:
         self.eval_config = eval_config
 
     def _create_iperf_server_client(
-        self, test_settings: TestSettings
+        self, ts: TestSettings
     ) -> tuple[perf.PerfServer, perf.PerfClient]:
         logger.info(
-            f"Initializing iperf server/client for test:\n {test_settings.get_test_info()}"
+            f"Initializing iperf server/client for test:\n {ts.get_test_info()}"
         )
 
-        s = IperfServer(tc=self.tc, ts=self.test_settings)
-        c = IperfClient(tc=self.tc, ts=self.test_settings, server=s)
+        s = IperfServer(tc=self.tc, ts=self.ts)
+        c = IperfClient(tc=self.tc, ts=self.ts, server=s)
         return (s, c)
 
     def _create_netperf_server_client(
-        self, test_settings: TestSettings
+        self, ts: TestSettings
     ) -> tuple[perf.PerfServer, perf.PerfClient]:
         logger.info(
-            f"Initializing Netperf server/client for test:\n {test_settings.get_test_info()}"
+            f"Initializing Netperf server/client for test:\n {ts.get_test_info()}"
         )
 
-        s = NetPerfServer(tc=self.tc, ts=self.test_settings)
-        c = NetPerfClient(tc=self.tc, ts=self.test_settings, server=s)
+        s = NetPerfServer(tc=self.tc, ts=self.ts)
+        c = NetPerfClient(tc=self.tc, ts=self.ts, server=s)
         return (s, c)
 
     def _configure_namespace(self, namespace: str) -> None:
@@ -152,7 +152,7 @@ class TrafficFlowTests:
         c_server = connection.server[0]
         c_client = connection.client[0]
 
-        self.test_settings = TestSettings(
+        self.ts = TestSettings(
             cfg_descr,
             conf_server=c_server,
             conf_client=c_client,
@@ -163,14 +163,14 @@ class TrafficFlowTests:
             connection.test_type == TestType.IPERF_TCP
             or connection.test_type == TestType.IPERF_UDP
         ):
-            s, c = self._create_iperf_server_client(self.test_settings)
+            s, c = self._create_iperf_server_client(self.ts)
             servers.append(s)
             clients.append(c)
         elif (
             connection.test_type == TestType.NETPERF_TCP_STREAM
             or connection.test_type == TestType.NETPERF_TCP_RR
         ):
-            s, c = self._create_netperf_server_client(self.test_settings)
+            s, c = self._create_netperf_server_client(self.ts)
             servers.append(s)
             clients.append(c)
         else:

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -27,13 +27,12 @@ from tftbase import TftAggregateOutput
 
 
 class TrafficFlowTests:
-    def __init__(self, tc: TestConfig, eval_config: str):
+    def __init__(self, tc: TestConfig):
         self.tc = tc
         self.lh = LocalHost()
         self.log_path: Path = Path("ft-logs")
         self.log_file: Path
         self.tft_output: list[TftAggregateOutput] = []
-        self.eval_config = eval_config
 
     def _create_iperf_server_client(
         self, ts: TestSettings
@@ -109,8 +108,13 @@ class TrafficFlowTests:
             json.dump(serialize_enum(json_out), output_file)
 
     def evaluate_run_success(self) -> bool:
-        # For the result of every test run, check the status of each run log to ensure all test passed
-        evaluator = Evaluator(self.eval_config)
+        # For the result of every test run, check the status of each run log to
+        # ensure all test passed
+
+        if not self.tc.evaluator_config:
+            return True
+
+        evaluator = Evaluator(self.tc.evaluator_config)
 
         logger.info(f"Evaluating results of tests {self.log_file}")
         results_file = str(self.log_file.stem) + "-RESULTS"


### PR DESCRIPTION
- instead of giving only the `TestConfig` to the `Task`, give it the `TestSettings`. This one contains the `TestConfig`, but more additional context about the current part of the test. As `TestSettings` is immutable, this is not a concern.

- add `ConfigDescriptor`, which is an immutable object that refers the (immutable) `TestConfig` and indexes about which part of the test we currently care about. For example, as we iterate over the `test_config.config.tft` list, the `ConfigDescriptor` tells is which the current index to the tft list is (and we can get correct `ConfTest` instance from it).

- with this, the task can know the currently configured namespace. The namespace is configurable in the config YAML, and now accessible at `cfg_descr.get_tft().namespace`. Previously, this setting was ignored.

- track the `evaluator_config` also in the `TestConfig` object. This is part of the run configuration, also add it there.