### PR TITLE
[th/github-action-no-push] github: don't push test image for pull requests

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build-and-push:
+  build:
 
     runs-on: ubuntu-latest
 
@@ -16,16 +16,10 @@ jobs:
     - name: Set up Docker Buildx
       run: |
         docker buildx create --use
-    - name: Authenticate
-      uses: docker/login-action@v1
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-    - name: Build and Push Multiarch image
+    - name: Build Multiarch image
       run: |
         docker buildx build \
           --file ./images/Containerfile \
           --platform linux/arm64,linux/amd64\
           --tag quay.io/wizhao/tft-tools:pr_test \
-          --push .
+          .


### PR DESCRIPTION
Pull requests don't have access to the quay secrets, this thus fails for certain users (or if the pull request originates from another repository, that is not quite clear to me).

Don't push the result, just build it.

---

Note how various the open pull requests have this task failed.