### PR TITLE
[th/podman-run-cleanup] perf: cleanup podman-run commands

### DIFF
--- a/iperf.py
+++ b/iperf.py
@@ -42,13 +42,14 @@ class IperfServer(perf.PerfServer):
         }
 
     def setup(self) -> None:
+        cmd = f"{IPERF_EXE} -s -p {self.port} --one-off --json"
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
-            cmd = f"podman run -it --rm -p {self.port} --entrypoint {IPERF_EXE} --name={self.pod_name} {tftbase.TFT_TOOLS_IMG} -s --one-off"
+            cmd = f"podman run -it --init --replace --rm -p {self.port} --name={self.pod_name} {tftbase.TFT_TOOLS_IMG} {cmd}"
             cleanup_cmd = f"podman rm --force {self.pod_name}"
         else:
             # Create the server pods
             super().setup()
-            cmd = f"exec {self.pod_name} -- {IPERF_EXE} -s -p {self.port} --one-off --json"
+            cmd = f"exec {self.pod_name} -- {cmd}"
             cleanup_cmd = f"exec -t {self.pod_name} -- killall {IPERF_EXE}"
 
         logger.info(f"Running {cmd}")

--- a/netperf.py
+++ b/netperf.py
@@ -34,13 +34,14 @@ class NetPerfServer(perf.PerfServer):
         }
 
     def setup(self) -> None:
+        cmd = f"{NETPERF_SERVER_EXE} -p {self.port} -N"
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
-            cmd = f"podman run -it --rm -p {self.port} --entrypoint {NETPERF_SERVER_EXE} --name={self.pod_name} {tftbase.TFT_TOOLS_IMG} -p {self.port} -N"
+            cmd = f"podman run -it --init --replace --rm -p {self.port} --name={self.pod_name} {tftbase.TFT_TOOLS_IMG} {cmd}"
             cleanup_cmd = f"podman rm --force {self.pod_name}"
         else:
             # Create the server pods
             super().setup()
-            cmd = f"exec {self.pod_name} -- {NETPERF_SERVER_EXE} -p {self.port} -N"
+            cmd = f"exec {self.pod_name} -- {cmd}"
             cleanup_cmd = f"exec -t {self.pod_name} -- killall {NETPERF_SERVER_EXE}"
 
         logger.info(f"Running {cmd}")


### PR DESCRIPTION
Adjust the two podman-run commands of iperf/netperf:

- don't overwrite "--entrypoint". That is commonly not necessary. Also note that we build our image "{tftbase.TFT_TOOLS_IMG} with the container file from "images/Containerfile". This doesn't specify ENTRYPOINT, so our image's entrypoint defaults to "/bin/sh -c", which is fine. The benefit is also that we don't need to split up the command and can re-use the same string for podman-run and kubectl-exec commands.

- pass "--init" to podman-run. It's kinda nice to have a mostly functioning init process inside our container. For example, processes with PID 1 won't receive SIGTERM if the don't handle it.

- pass "--replace". Usually, we shouldn't have the container with the requested name around. Still, it does not seem to hurt to be sure that we can start this container and replace the old one.

- extract the shared command line and use it for both podman-run and kubectl-exec.

- also, pass "--json" to podman-run when running the iperf command. That makes it do the same thing as when run via kubectl-exec.