### PR TITLE
[th/host-no-ipa] host: drop host.Host.{ipa,ipr,all_ports}()

### DIFF
--- a/host.py
+++ b/host.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import shlex
@@ -82,18 +81,6 @@ class BinResult(BaseResult[bytes]):
 
 
 class Host(ABC):
-    def ipa(self) -> list[dict[str, Any]]:
-        r = json.loads(self.run("ip -json a").out)
-        return typing.cast(list[dict[str, Any]], r)
-
-    def ipr(self) -> list[dict[str, Any]]:
-        r = json.loads(self.run("ip -json r").out)
-        return typing.cast(list[dict[str, Any]], r)
-
-    def all_ports(self) -> list[dict[str, Any]]:
-        r = json.loads(self.run("ip -json link").out)
-        return typing.cast(list[dict[str, Any]], r)
-
     @abstractmethod
     def pretty_str(self) -> str:
         pass


### PR DESCRIPTION
They are currently unused, but they are also not great.

- it should not be a method of Host. Sure, it uses Host.run() to invoke a command, but that doesn't mean that all methods that invoke a command should be methods of the Host. Instead, let Host be about invoking a command, and if you want to add helper functions on top of that, then let them take a Host argument.

- the methods just pass untrusted output to json.loads(). We should have boundaries of trust, and calling to iproute2 should not be trusted to always give valid JSON. We should handle failure or non-JSON output. Granted, the "handling" is failing with some undefined exception. But most callers wouldn't care about this, and they shouldn't be bothered with having to add a try/except around each call.

- likewise, passing untrusted data to json.loads() just gives some dictionary with untrusted content. We would want that the output is validated and parsed and a well-known, typed object gets returned.