### PR TITLE
[th/k8sclient-error-logging] k8sClient: add "die_on_error" and "may_fail" options to K8sClient.oc()

### DIFF
--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,4 +1,6 @@
 import kubernetes  # type: ignore
+import logging
+import shlex
 import yaml
 
 import host
@@ -23,5 +25,15 @@ class K8sClient:
             for e in self._client.list_node(label_selector=label_selector).items
         ]
 
-    def oc(self, cmd: str) -> host.Result:
-        return host.local.run(f"kubectl --kubeconfig {self._kc} {cmd} ")
+    def oc(
+        self,
+        cmd: str,
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+    ) -> host.Result:
+        return host.local.run(
+            ["kubectl", "--kubeconfig", self._kc, *shlex.split(cmd)],
+            die_on_error=die_on_error,
+            log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
+        )


### PR DESCRIPTION
Previously, we get failures like:
```
  2024-06-06 10:20:33 DEBUG: cmd[11;localhost]: result `kubectl --kubeconfig /root/kubeconfig.nicmodecluster wait --for=condition=ready pod/sriov-pod-worker-247-server-5201 --timeout=1m `: failed (1); err='Error from server (NotFound): pods "sriov-pod-worker-247-server-5201" not found\n'
  2024-06-06 10:20:33 INFO: Result(out='', err='Error from server (NotFound): pods "sriov-pod-worker-247-server-5201" not found\n', returncode=1)
```
At DEBUG level, at least we see the command that was called.  However, at INFO level, we only see the result. It's unclear that the command was. Also, we need two logging lines.

We can do better.

Note that Host.run() already does logging, and it does better than plain
```
   logger.info(r)
```
It won't be  perfect. A perfect logging line needs to be manually crafted. It does the best we can do without spending any effort.

Use the "die_on_error" option from Host.run(). On error, we will log an ERROR message with the full result output, right before quitting.

Also, we have some calls that we don't expect to fail (but we don't want to quit on error). If they unexpectedly fail, log an error via "may_fail=False", which translates to "log_level_fail=logging.ERROR". "may_fail=False" is already the default. So you need to opt-out from such error messages, if you expect that commands fail (or maybe add " || :" to the command).