### PR TITLE
[th/traffic-flow-tests-no-state] remove state from TrafficFlowTests object and instead pass data as function arguments/return values

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,8 +64,6 @@ def main() -> None:
 
     for cfg_descr in ConfigDescriptor(tc).describe_all_tft():
         tft.test_run(cfg_descr)
-        if not tft.evaluate_run_success(cfg_descr):
-            print(f"Failure detected in {cfg_descr.get_tft().name} results")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -56,16 +56,15 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    tft = TrafficFlowTests(
-        TestConfig(
-            config_path=args.config,
-            evaluator_config=args.evaluator_config,
-        )
+    tc = TestConfig(
+        config_path=args.config,
+        evaluator_config=args.evaluator_config,
     )
+    tft = TrafficFlowTests()
 
-    for cfg_descr in ConfigDescriptor(tft.tc).describe_all_tft():
+    for cfg_descr in ConfigDescriptor(tc).describe_all_tft():
         tft.test_run(cfg_descr)
-        if not tft.evaluate_run_success():
+        if not tft.evaluate_run_success(cfg_descr):
             print(f"Failure detected in {cfg_descr.get_tft().name} results")
 
 


### PR DESCRIPTION
Often, it is most convenient if we can attach some data to an object.

It can also make code harder to read, because this state is accessible from various places, and it's not clear in which order it gets modified. It can be better (if possible), to pass data around as function parameter. Then at any point, you know that the input-data comes from the caller, and you can look where the caller gets it from.

Drop all state from `TrafficFlowTests` object.