### PR TITLE
[th/test-settings-cleanup] testSettings: make TestSettings a frozen dataclass

### DIFF
--- a/tftbase.py
+++ b/tftbase.py
@@ -322,6 +322,12 @@ def test_case_type_is_same_node(test_case_type: TestCaseType) -> bool:
     return _test_case_typ_infos[test_case_type].is_same_node
 
 
+def test_case_type_get_node_location(test_case_type: TestCaseType) -> NodeLocation:
+    if test_case_type_is_same_node(test_case_type):
+        return NodeLocation.SAME_NODE
+    return NodeLocation.DIFF_NODE
+
+
 def test_case_type_to_server_pod_type(
     test_case_type: TestCaseType,
     pod_type: PodType,

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -155,7 +155,7 @@ class TrafficFlowTests:
         c_client = connection.client[0]
 
         ts = TestSettings(
-            cfg_descr,
+            cfg_descr=cfg_descr,
             conf_server=c_server,
             conf_client=c_client,
             instance_index=instance_index,


### PR DESCRIPTION
TestSettings is already immutable, in the sense that no code currently modifies a TestSettings instance after creation.

Make it a frozen dataclass, which helps enforcing the immutablility via typing hints and runtime checks.

Also, make the computed attributes to be property getters.  The benefit is, that it is quite obvious that these getters don't modify the object. More importantly, with the frozen data classes it would be cumbersome to set these values as attributes.