### PR TITLE
[th/dataclass-from-dict-extend] common: add dataclass_to_dict() and extend dataclass_from_dict()

### DIFF
--- a/common.py
+++ b/common.py
@@ -286,6 +286,8 @@ def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
                 return dataclass_from_dict(ck_type, value)
             if actual_type is None and issubclass(ck_type, Enum):
                 return enum_convert(ck_type, value)
+            if ck_type is float and isinstance(value, int):
+                return float(value)
             return value
 
         actual_type = typing.get_origin(field.type)

--- a/common.py
+++ b/common.py
@@ -15,6 +15,11 @@ from typing import Type
 from typing import TypeVar
 from typing import cast
 
+if typing.TYPE_CHECKING:
+    # https://github.com/python/typeshed/tree/main/stdlib/_typeshed#api-stability
+    # https://github.com/python/typeshed/blob/6220c20d9360b12e2287511587825217eec3e5b5/stdlib/_typeshed/__init__.pyi#L349
+    from _typeshed import DataclassInstance
+
 
 # This is used as default value for some arguments, to recognize that the
 # caller didn't specify the argument. This is useful, when we want to
@@ -239,6 +244,11 @@ def serialize_enum(
 T = TypeVar("T")
 
 
+def dataclass_to_dict(obj: "DataclassInstance") -> dict[str, Any]:
+    d = dataclasses.asdict(obj)
+    return typing.cast(dict[str, Any], serialize_enum(d))
+
+
 # Takes a dataclass and the dict you want to convert from
 # If your dataclass has a dataclass member, it handles that recursively
 def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
@@ -271,21 +281,49 @@ def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
         if not field.init:
             continue
 
+        def convert_simple(ck_type: Any, value: Any) -> Any:
+            if is_dataclass(ck_type) and isinstance(value, dict):
+                return dataclass_from_dict(ck_type, value)
+            if actual_type is None and issubclass(ck_type, Enum):
+                return enum_convert(ck_type, value)
+            return value
+
         actual_type = typing.get_origin(field.type)
 
         value = data.pop(field.name)
 
-        if is_dataclass(field.type) and isinstance(value, dict):
-            value = dataclass_from_dict(field.type, value)
-        elif actual_type is None and issubclass(field.type, Enum):
-            value = enum_convert(field.type, value)
+        converted = False
 
-        if not check_type(value, field.type):
+        if actual_type is typing.Union:
+            # This is an Optional[]. We already have a value, we check for the requested
+            # type. check_type() already implements this, but we need to also check
+            # it here, for the dataclass/enum handling below.
+            args = typing.get_args(field.type)
+            ck_type = None
+            if len(args) == 2:
+                NoneType = type(None)
+                if args[0] is NoneType:
+                    ck_type = args[1]
+                elif args[1] is NoneType:
+                    ck_type = args[0]
+            if ck_type is not None:
+                value_converted = convert_simple(ck_type, value)
+                converted = True
+        elif actual_type is list:
+            args = typing.get_args(field.type)
+            if isinstance(value, list) and len(args) == 1:
+                value_converted = [convert_simple(args[0], v) for v in value]
+                converted = True
+
+        if not converted:
+            value_converted = convert_simple(field.type, value)
+
+        if not check_type(value_converted, field.type):
             raise TypeError(
                 f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
             )
 
-        create_kwargs[field.name] = value
+        create_kwargs[field.name] = value_converted
 
     if data:
         raise ValueError(
@@ -348,12 +386,6 @@ def check_type(value: typing.Any, type_hint: type[typing.Any]) -> bool:
     raise NotImplementedError(
         f'Type hint "{type_hint}" with origin type "{actual_type}" is not implemented by check_type()'
     )
-
-
-if typing.TYPE_CHECKING:
-    # https://github.com/python/typeshed/tree/main/stdlib/_typeshed#api-stability
-    # https://github.com/python/typeshed/blob/6220c20d9360b12e2287511587825217eec3e5b5/stdlib/_typeshed/__init__.pyi#L349
-    from _typeshed import DataclassInstance
 
 
 def dataclass_check(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -340,6 +340,15 @@ def test_strict_dataclass() -> None:
     with pytest.raises(NotImplementedError):
         C9("foo")
 
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    C10(1.0)
+    with pytest.raises(TypeError):
+        C10(1)
+
 
 def test_host_result_bin() -> None:
     res = host.local.run("echo -n out; echo -n err >&2", text=False)
@@ -414,3 +423,28 @@ def test_dataclass_tofrom_dict() -> None:
         == '{"enum_val": "IPERF_UDP", "c1_opt": {"foo": 2, "str": "2"}, "c1_opt_2": null, "c1_list": [{"foo": 3, "str": "3"}, {"foo": 4, "str": "4"}]}'
     )
     assert c2 == common.dataclass_from_dict(C2, d2)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    assert common.dataclass_to_dict(C10(1.0)) == {"x": 1.0}
+
+    c10 = C10(1.0)
+    assert type(c10.x) is float
+    common.dataclass_check(c10)
+    c10.x = 1
+    assert type(c10.x) is int
+    with pytest.raises(TypeError):
+        common.dataclass_check(c10)
+    assert common.dataclass_to_dict(c10) == {"x": 1}
+
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == C10(1.0)
+    assert common.dataclass_from_dict(C10, {"x": 1}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1}) == C10(1.0)
+    assert type(common.dataclass_from_dict(C10, {"x": 1}).x) is float
+    assert type(common.dataclass_from_dict(C10, {"x": 1.0}).x) is float
+    assert type(c10.x) is int
+    assert type(C10(1.0).x) is float


### PR DESCRIPTION
"dataclass_from_dict()" cannot read any kinds of data classes (and fields). It should however be able to read the classes we care about.

Extend it, so that Optional[dataclass] and list[dataclass] also works.

Also, add dataclass_to_dict(), which is the opposite operation.