### PR TITLE
[th/tests-prettify-json] tests: prettify the JSON test inputs

### DIFF
--- a/tests/input1.json
+++ b/tests/input1.json
@@ -1,1 +1,15204 @@
-{"tft-tests": [{"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 56762, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:32 UTC", "timesecs": 1711484912}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "snd_cwnd": 477192, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "snd_cwnd": 477192, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "snd_cwnd": 477192, "rtt": 27, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "snd_cwnd": 502804, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "snd_cwnd": 528416, "rtt": 29, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "snd_cwnd": 528416, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "snd_cwnd": 528416, "rtt": 30, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "snd_cwnd": 591772, "rtt": 26, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "snd_cwnd": 621428, "rtt": 27, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "snd_cwnd": 621428, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "max_snd_cwnd": 621428, "max_rtt": 30, "min_rtt": 25, "mean_rtt": 26, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040752, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "sender": true}, "sum_received": {"start": 0, "end": 10.040752, "seconds": 10.040752, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}, "cpu_utilization_percent": {"host_total": 51.95896032207571, "host_user": 0.46109579260875955, "host_system": 51.4978546106554, "remote_total": 46.34560190202221, "remote_user": 1.2743335369337774, "remote_system": 45.07127657478376}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 54270, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:43 UTC", "timesecs": 1711484923}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}], "sum": {"start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}], "sum": {"start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}], "sum": {"start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}], "sum": {"start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}], "sum": {"start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}], "sum": {"start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}], "sum": {"start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}], "sum": {"start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "sender": false}, "sum_received": {"start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}, "cpu_utilization_percent": {"host_total": 59.961165048543684, "host_user": 1.7074681645153693, "host_system": 58.25370680355615, "remote_total": 54.92808068462117, "remote_user": 0.35009864909523675, "remote_system": 54.57798203552594}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 43488, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:03 UTC", "timesecs": 1711484943}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "snd_cwnd": 858676, "rtt": 477, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "snd_cwnd": 864068, "rtt": 582, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "snd_cwnd": 897768, "rtt": 469, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "snd_cwnd": 843848, "rtt": 459, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "snd_cwnd": 931468, "rtt": 278, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "snd_cwnd": 773752, "rtt": 389, "rttvar": 21, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "snd_cwnd": 706352, "rtt": 351, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "snd_cwnd": 957080, "rtt": 494, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "snd_cwnd": 668608, "rtt": 406, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "snd_cwnd": 835760, "rtt": 417, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "max_snd_cwnd": 957080, "max_rtt": 582, "min_rtt": 278, "mean_rtt": 432, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040323, "seconds": 10.000067, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "sender": true}, "sum_received": {"start": 0, "end": 10.040323, "seconds": 10.040323, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}, "cpu_utilization_percent": {"host_total": 13.428581942246796, "host_user": 0.18264039451277397, "host_system": 13.245951466295686, "remote_total": 23.0189867907264, "remote_user": 0.650631880001117, "remote_system": 22.368346697024506}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 52702, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:14 UTC", "timesecs": 1711484954}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}], "sum": {"start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}], "sum": {"start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}], "sum": {"start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}], "sum": {"start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}], "sum": {"start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}], "sum": {"start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "sender": false}, "sum_received": {"start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}, "cpu_utilization_percent": {"host_total": 27.136162389258295, "host_user": 1.0734065668100488, "host_system": 26.062755822448246, "remote_total": 12.134681085322041, "remote_user": 0.20150770671204546, "remote_system": 11.933173378609997}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 37248, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:34 UTC", "timesecs": 1711484974}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "snd_cwnd": 477192, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "max_snd_cwnd": 1412704, "max_rtt": 24, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040463, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040463, "seconds": 10.040463, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}, "cpu_utilization_percent": {"host_total": 51.42879332323217, "host_user": 0.48554830964161494, "host_system": 50.94323509492755, "remote_total": 45.16438235241609, "remote_user": 1.4607549345618025, "remote_system": 43.703627417854285}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 42348, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:45 UTC", "timesecs": 1711484985}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}], "sum": {"start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}], "sum": {"start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}], "sum": {"start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}], "sum": {"start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}], "sum": {"start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}, "cpu_utilization_percent": {"host_total": 58.9131700562321, "host_user": 1.8313076617106898, "host_system": 57.08186239452141, "remote_total": 54.91579537328721, "remote_user": 0.4710685503353111, "remote_system": 54.44472682295189}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 45258, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:05 UTC", "timesecs": 1711485005}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "snd_cwnd": 958428, "rtt": 667, "rttvar": 176, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "snd_cwnd": 913944, "rtt": 617, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "snd_cwnd": 698264, "rtt": 354, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "snd_cwnd": 789928, "rtt": 504, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "snd_cwnd": 698264, "rtt": 352, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "snd_cwnd": 947644, "rtt": 487, "rttvar": 19, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "snd_cwnd": 706352, "rtt": 362, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "snd_cwnd": 684784, "rtt": 352, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "snd_cwnd": 877548, "rtt": 463, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "snd_cwnd": 858676, "rtt": 461, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "max_snd_cwnd": 958428, "max_rtt": 667, "min_rtt": 352, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039933, "seconds": 10.000063, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "sender": true}, "sum_received": {"start": 0, "end": 10.039933, "seconds": 10.039933, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}, "cpu_utilization_percent": {"host_total": 12.965573157783645, "host_user": 0.2766736708792456, "host_system": 12.688899486904399, "remote_total": 23.378925135581515, "remote_user": 0.7967034489409502, "remote_system": 22.582213415818792}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 46944, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:16 UTC", "timesecs": 1711485016}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}], "sum": {"start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}], "sum": {"start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}], "sum": {"start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}], "sum": {"start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}], "sum": {"start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}], "sum": {"start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}], "sum": {"start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}], "sum": {"start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}, "cpu_utilization_percent": {"host_total": 26.49645360241422, "host_user": 1.0953846141637273, "host_system": 25.40107890796627, "remote_total": 12.308727742765743, "remote_user": 0.1856302180705536, "remote_system": 12.12309752469519}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 39718, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:35 UTC", "timesecs": 1711485035}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "snd_cwnd": 551332, "rtt": 31, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "snd_cwnd": 551332, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "snd_cwnd": 707700, "rtt": 27, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "snd_cwnd": 808800, "rtt": 30, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "snd_cwnd": 808800, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "max_snd_cwnd": 808800, "max_rtt": 31, "min_rtt": 26, "mean_rtt": 28, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}, "cpu_utilization_percent": {"host_total": 50.79991850744037, "host_user": 0.5093780915545499, "host_system": 50.29054041588581, "remote_total": 69.18971718930246, "remote_user": 1.6048329699753412, "remote_system": 67.58487595116893}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 45210, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:46 UTC", "timesecs": 1711485046}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}], "sum": {"start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}], "sum": {"start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}], "sum": {"start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}], "sum": {"start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}], "sum": {"start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}], "sum": {"start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}, "cpu_utilization_percent": {"host_total": 53.87293306289964, "host_user": 1.9549507299646565, "host_system": 51.91798233293498, "remote_total": 84.71007116240497, "remote_user": 0.4765840963192183, "remote_system": 84.23349673055752}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 42424, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:05 UTC", "timesecs": 1711485065}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 397, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 398, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "snd_cwnd": 760272, "rtt": 242, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "snd_cwnd": 1517848, "rtt": 400, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 393, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 373, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "snd_cwnd": 1442360, "rtt": 379, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "snd_cwnd": 1544808, "rtt": 397, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "snd_cwnd": 1569072, "rtt": 419, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "snd_cwnd": 1606816, "rtt": 410, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "max_snd_cwnd": 1763184, "max_rtt": 419, "min_rtt": 242, "mean_rtt": 380, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039772, "seconds": 10.000116, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "sender": true}, "sum_received": {"start": 0, "end": 10.039772, "seconds": 10.039772, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}, "cpu_utilization_percent": {"host_total": 19.865083177612643, "host_user": 0.41521108861582645, "host_system": 19.449872088996816, "remote_total": 59.10663386005702, "remote_user": 2.4033524078476156, "remote_system": 56.70327318135753}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 38322, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:16 UTC", "timesecs": 1711485076}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}], "sum": {"start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}], "sum": {"start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}], "sum": {"start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}], "sum": {"start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "sender": false}, "sum_received": {"start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}, "cpu_utilization_percent": {"host_total": 37.45748338542608, "host_user": 1.3319334804012157, "host_system": 36.125549905024855, "remote_total": 15.928314062618693, "remote_user": 0.36963858784471143, "remote_system": 15.558675474773981}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 47958, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:36 UTC", "timesecs": 1711485096}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "snd_cwnd": 579640, "rtt": 26, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "snd_cwnd": 579640, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "snd_cwnd": 899116, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 26, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 24, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "max_snd_cwnd": 1043352, "max_rtt": 26, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040386, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040386, "seconds": 10.040386, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}, "cpu_utilization_percent": {"host_total": 51.71680226694355, "host_user": 0.47637317598252343, "host_system": 51.24043901002937, "remote_total": 45.230156070887375, "remote_user": 1.3387075643093247, "remote_system": 43.891456788045936}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 60988, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:48 UTC", "timesecs": 1711485108}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}], "sum": {"start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}], "sum": {"start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}], "sum": {"start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}], "sum": {"start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}], "sum": {"start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}], "sum": {"start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72172176163449, "host_user": 1.7632532126911542, "host_system": 56.958468548943344, "remote_total": 54.5440108210963, "remote_user": 0.40678669250280086, "remote_system": 54.137214462757875}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 46580, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:07 UTC", "timesecs": 1711485127}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "snd_cwnd": 812844, "rtt": 417, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "snd_cwnd": 912596, "rtt": 445, "rttvar": 23, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "snd_cwnd": 669956, "rtt": 482, "rttvar": 128, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "snd_cwnd": 843848, "rtt": 461, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "snd_cwnd": 838456, "rtt": 544, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "snd_cwnd": 928772, "rtt": 486, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "snd_cwnd": 831716, "rtt": 416, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "snd_cwnd": 824976, "rtt": 580, "rttvar": 185, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "snd_cwnd": 634908, "rtt": 423, "rttvar": 97, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "snd_cwnd": 676696, "rtt": 360, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "max_snd_cwnd": 928772, "max_rtt": 580, "min_rtt": 360, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039945, "seconds": 10.000063, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "sender": true}, "sum_received": {"start": 0, "end": 10.039945, "seconds": 10.039945, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}, "cpu_utilization_percent": {"host_total": 13.61059396129923, "host_user": 0.19270043453809127, "host_system": 13.417903445457585, "remote_total": 23.486672814565882, "remote_user": 0.5555645903789477, "remote_system": 22.931108224186932}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 50678, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:19 UTC", "timesecs": 1711485139}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}], "sum": {"start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}], "sum": {"start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}], "sum": {"start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}], "sum": {"start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "sender": false}, "sum_received": {"start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}, "cpu_utilization_percent": {"host_total": 26.747516641197084, "host_user": 1.0158505257156165, "host_system": 25.731666115481467, "remote_total": 11.755923477356498, "remote_user": 0.13796182174123386, "remote_system": 11.617971314101807}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 41706, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:38 UTC", "timesecs": 1711485158}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "snd_cwnd": 525720, "rtt": 24, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 37, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "max_snd_cwnd": 1202416, "max_rtt": 37, "min_rtt": 21, "mean_rtt": 24, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040372, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040372, "seconds": 10.040372, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}, "cpu_utilization_percent": {"host_total": 51.579098862767125, "host_user": 0.4361726860977011, "host_system": 51.14293609532062, "remote_total": 44.789642459824776, "remote_user": 1.3832780535675204, "remote_system": 43.40635613187544}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 57026, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:50 UTC", "timesecs": 1711485170}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}], "sum": {"start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}], "sum": {"start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}], "sum": {"start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}], "sum": {"start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}], "sum": {"start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}], "sum": {"start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}], "sum": {"start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}], "sum": {"start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72825614611755, "host_user": 1.7371177997142697, "host_system": 56.991148265535564, "remote_total": 54.64429253795493, "remote_user": 0.4133314501365237, "remote_system": 54.23096108781841}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 43702, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:09 UTC", "timesecs": 1711485189}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "snd_cwnd": 816888, "rtt": 591, "rttvar": 85, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "snd_cwnd": 958428, "rtt": 636, "rttvar": 81, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "snd_cwnd": 688828, "rtt": 360, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "snd_cwnd": 804756, "rtt": 415, "rttvar": 1, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "snd_cwnd": 953036, "rtt": 494, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "snd_cwnd": 850588, "rtt": 461, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "snd_cwnd": 943600, "rtt": 507, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "snd_cwnd": 846544, "rtt": 461, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "snd_cwnd": 830368, "rtt": 478, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "snd_cwnd": 501456, "rtt": 244, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "max_snd_cwnd": 958428, "max_rtt": 636, "min_rtt": 244, "mean_rtt": 464, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039929, "seconds": 10.000215, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "sender": true}, "sum_received": {"start": 0, "end": 10.039929, "seconds": 10.039929, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}, "cpu_utilization_percent": {"host_total": 13.005006946322178, "host_user": 0.19271754050004394, "host_system": 12.812299324888505, "remote_total": 23.26438245505795, "remote_user": 0.8376646905752849, "remote_system": 22.426726025964516}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 57004, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:21 UTC", "timesecs": 1711485201}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}], "sum": {"start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}], "sum": {"start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}], "sum": {"start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}], "sum": {"start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}], "sum": {"start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}], "sum": {"start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "sender": false}, "sum_received": {"start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}, "cpu_utilization_percent": {"host_total": 26.064632328384384, "host_user": 1.162207899423042, "host_system": 24.902424428961346, "remote_total": 11.69062967191739, "remote_user": 0.12009331046577057, "remote_system": 11.570546012927187}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56708, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:39 UTC", "timesecs": 1711485219}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "snd_cwnd": 798016, "rtt": 32, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "snd_cwnd": 798016, "rtt": 30, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "max_snd_cwnd": 798016, "max_rtt": 35, "min_rtt": 30, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040107, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040107, "seconds": 10.040107, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}, "cpu_utilization_percent": {"host_total": 84.44527815243438, "host_user": 0.4874417118707169, "host_system": 83.95785625929561, "remote_total": 37.5809576369255, "remote_user": 1.2945095444412822, "remote_system": 36.286448092484214}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37086, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:51 UTC", "timesecs": 1711485231}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}], "sum": {"start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}], "sum": {"start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}], "sum": {"start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}], "sum": {"start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}], "sum": {"start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}], "sum": {"start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}, "cpu_utilization_percent": {"host_total": 91.26294493237891, "host_user": 1.8116036545309533, "host_system": 89.45135119667133, "remote_total": 44.14246868282316, "remote_user": 0.32552835005268926, "remote_system": 43.816940332770464}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55424, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:09 UTC", "timesecs": 1711485249}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "snd_cwnd": 641648, "rtt": 391, "rttvar": 37, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "snd_cwnd": 787232, "rtt": 223, "rttvar": 31, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "snd_cwnd": 655128, "rtt": 228, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "snd_cwnd": 849240, "rtt": 193, "rttvar": 25, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "snd_cwnd": 936860, "rtt": 606, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "snd_cwnd": 829020, "rtt": 197, "rttvar": 54, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "snd_cwnd": 917988, "rtt": 218, "rttvar": 40, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "snd_cwnd": 917988, "rtt": 200, "rttvar": 33, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "snd_cwnd": 934164, "rtt": 220, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "snd_cwnd": 776448, "rtt": 184, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "max_snd_cwnd": 936860, "max_rtt": 606, "min_rtt": 184, "mean_rtt": 266, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040277, "seconds": 10.00071, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "sender": true}, "sum_received": {"start": 0, "end": 10.040277, "seconds": 10.040277, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}, "cpu_utilization_percent": {"host_total": 95.82562437024121, "host_user": 0.2560031758234491, "host_system": 95.56962119441776, "remote_total": 24.102997438800752, "remote_user": 1.0351409018247604, "remote_system": 23.06785653697599}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39456, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:21 UTC", "timesecs": 1711485261}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}], "sum": {"start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}], "sum": {"start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}], "sum": {"start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}], "sum": {"start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}], "sum": {"start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "sender": false}, "sum_received": {"start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}, "cpu_utilization_percent": {"host_total": 44.47684113065824, "host_user": 1.8968527601361653, "host_system": 42.57999828989936, "remote_total": 12.529305328982618, "remote_user": 0.09332895016906215, "remote_system": 12.435986036196645}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56016, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:38 UTC", "timesecs": 1711485278}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "snd_cwnd": 663216, "rtt": 37, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "snd_cwnd": 663216, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "snd_cwnd": 663216, "rtt": 31, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "max_snd_cwnd": 663216, "max_rtt": 37, "min_rtt": 31, "mean_rtt": 33, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039647, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039647, "seconds": 10.039647, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}, "cpu_utilization_percent": {"host_total": 98.6366144037512, "host_user": 0.5079154773387307, "host_system": 98.12868897353042, "remote_total": 69.33475570009895, "remote_user": 1.8358332803622874, "remote_system": 67.4989133777374}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 41272, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:50 UTC", "timesecs": 1711485290}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}], "sum": {"start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}], "sum": {"start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}], "sum": {"start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}], "sum": {"start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}], "sum": {"start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}], "sum": {"start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}], "sum": {"start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}, "cpu_utilization_percent": {"host_total": 86.40432984604324, "host_user": 2.1048623181527053, "host_system": 84.29947744708186, "remote_total": 96.37010529501002, "remote_user": 0.5200516733573617, "remote_system": 95.85006329541284}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 35114, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:07 UTC", "timesecs": 1711485307}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "snd_cwnd": 2701392, "rtt": 911, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "snd_cwnd": 2724308, "rtt": 935, "rttvar": 42, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "snd_cwnd": 2744528, "rtt": 900, "rttvar": 30, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "snd_cwnd": 2345520, "rtt": 798, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "snd_cwnd": 2325300, "rtt": 778, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "snd_cwnd": 3097704, "rtt": 1023, "rttvar": 3, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "snd_cwnd": 3165104, "rtt": 1109, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "snd_cwnd": 2543676, "rtt": 841, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 1059, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 781, "rttvar": 78, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "max_snd_cwnd": 3165104, "max_rtt": 1109, "min_rtt": 778, "mean_rtt": 913, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000231, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}, "cpu_utilization_percent": {"host_total": 34.97762289166434, "host_user": 0.5691962216451614, "host_system": 34.40843658477508, "remote_total": 62.9251445256492, "remote_user": 2.6124474135751976, "remote_system": 60.31269711207401}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55052, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:19 UTC", "timesecs": 1711485319}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}], "sum": {"start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}], "sum": {"start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}], "sum": {"start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}], "sum": {"start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}], "sum": {"start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "sender": false}, "sum_received": {"start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}, "cpu_utilization_percent": {"host_total": 88.6667781634535, "host_user": 2.169277119907057, "host_system": 86.4975109631894, "remote_total": 22.440235970749637, "remote_user": 0.4127789042736779, "remote_system": 22.027466720316273}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 50458, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:37 UTC", "timesecs": 1711485337}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "snd_cwnd": 884288, "rtt": 40, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "snd_cwnd": 974604, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "snd_cwnd": 974604, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 33, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "max_snd_cwnd": 1074356, "max_rtt": 40, "min_rtt": 31, "mean_rtt": 34, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039944, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039944, "seconds": 10.039944, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}, "cpu_utilization_percent": {"host_total": 84.72291319227105, "host_user": 0.5304700943978504, "host_system": 84.19243318754582, "remote_total": 37.30641845607046, "remote_user": 1.3600734652179878, "remote_system": 35.946344990852474}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 53048, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:49 UTC", "timesecs": 1711485349}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}], "sum": {"start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}], "sum": {"start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}], "sum": {"start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}], "sum": {"start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}], "sum": {"start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}], "sum": {"start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}, "cpu_utilization_percent": {"host_total": 91.7129817857671, "host_user": 1.930649372470762, "host_system": 89.782322494473, "remote_total": 44.03409922696862, "remote_user": 0.28095210440615037, "remote_system": 43.75314712256247}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 47342, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:07 UTC", "timesecs": 1711485367}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "snd_cwnd": 841152, "rtt": 194, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "snd_cwnd": 831716, "rtt": 212, "rttvar": 24, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "snd_cwnd": 849240, "rtt": 240, "rttvar": 28, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "snd_cwnd": 683436, "rtt": 355, "rttvar": 32, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "snd_cwnd": 789928, "rtt": 201, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "snd_cwnd": 798016, "rtt": 187, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "snd_cwnd": 823628, "rtt": 270, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "snd_cwnd": 924728, "rtt": 210, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "snd_cwnd": 802060, "rtt": 187, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "snd_cwnd": 851936, "rtt": 272, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "max_snd_cwnd": 924728, "max_rtt": 355, "min_rtt": 187, "mean_rtt": 232, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040404, "seconds": 10.000796, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "sender": true}, "sum_received": {"start": 0, "end": 10.040404, "seconds": 10.040404, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}, "cpu_utilization_percent": {"host_total": 94.61572077164762, "host_user": 0.29949784294138804, "host_system": 94.31623284257061, "remote_total": 24.200736107154952, "remote_user": 0.7375246434410879, "remote_system": 23.463211463713865}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 48142, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:19 UTC", "timesecs": 1711485379}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}], "sum": {"start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}], "sum": {"start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}], "sum": {"start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}], "sum": {"start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}], "sum": {"start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}], "sum": {"start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "sender": false}, "sum_received": {"start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}, "cpu_utilization_percent": {"host_total": 44.48791626719862, "host_user": 1.6040884366461445, "host_system": 42.883837750090144, "remote_total": 12.877414932148609, "remote_user": 0.20340289771075803, "remote_system": 12.674021700497715}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39362, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:36 UTC", "timesecs": 1711485396}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "snd_cwnd": 412488, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "snd_cwnd": 412488, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "snd_cwnd": 599860, "rtt": 31, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "snd_cwnd": 769708, "rtt": 31, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "snd_cwnd": 769708, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "max_snd_cwnd": 769708, "max_rtt": 33, "min_rtt": 31, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040211, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040211, "seconds": 10.040211, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}, "cpu_utilization_percent": {"host_total": 98.19888011381254, "host_user": 0.5898692408770353, "host_system": 97.6090108729355, "remote_total": 71.89727658532618, "remote_user": 1.9320023444980647, "remote_system": 69.96528325535468}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37670, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:48 UTC", "timesecs": 1711485408}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}], "sum": {"start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}], "sum": {"start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}], "sum": {"start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}], "sum": {"start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}], "sum": {"start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}], "sum": {"start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}, "cpu_utilization_percent": {"host_total": 89.35457193175537, "host_user": 2.1531064410889655, "host_system": 87.20146549066642, "remote_total": 96.25175156651449, "remote_user": 0.5483803525296743, "remote_system": 95.70338087979988}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39876, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:05 UTC", "timesecs": 1711485425}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1011, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1030, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "snd_cwnd": 2109620, "rtt": 718, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "snd_cwnd": 2934596, "rtt": 882, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "snd_cwnd": 2067832, "rtt": 699, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "snd_cwnd": 2143320, "rtt": 731, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "snd_cwnd": 2985820, "rtt": 1004, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "snd_cwnd": 3150276, "rtt": 1131, "rttvar": 47, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "snd_cwnd": 2446620, "rtt": 816, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "snd_cwnd": 3163756, "rtt": 1040, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "max_snd_cwnd": 3301252, "max_rtt": 1131, "min_rtt": 699, "mean_rtt": 906, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040299, "seconds": 10.000062, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "sender": true}, "sum_received": {"start": 0, "end": 10.040299, "seconds": 10.040299, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}, "cpu_utilization_percent": {"host_total": 36.61979232353807, "host_user": 0.5177138138716962, "host_system": 36.10208842470637, "remote_total": 63.645622998347704, "remote_user": 2.779808989119691, "remote_system": 60.86582297594884}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 49506, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:17 UTC", "timesecs": 1711485437}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}], "sum": {"start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}], "sum": {"start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}], "sum": {"start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}], "sum": {"start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}], "sum": {"start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}], "sum": {"start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}], "sum": {"start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "sender": false}, "sum_received": {"start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}, "cpu_utilization_percent": {"host_total": 86.71637462053445, "host_user": 2.3097157068484533, "host_system": 84.40665891368599, "remote_total": 20.40828750936386, "remote_user": 0.3775983988088474, "remote_system": 20.030689110555013}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 38034, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:34 UTC", "timesecs": 1711485454}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2566, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2504, "rttvar": 111, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "snd_cwnd": 3298556, "rtt": 2578, "rttvar": 100, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2548, "rttvar": 49, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2544, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2626, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2637, "rttvar": 87, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2584, "rttvar": 65, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2646, "rttvar": 50, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2624, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "max_snd_cwnd": 3298556, "max_rtt": 2646, "min_rtt": 2504, "mean_rtt": 2585, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042436, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "sender": true}, "sum_received": {"start": 0, "end": 10.042436, "seconds": 10.042436, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}, "cpu_utilization_percent": {"host_total": 8.581878883067088, "host_user": 0.24757613109832505, "host_system": 8.334302751968762, "remote_total": 17.882794832888134, "remote_user": 0.6213889785332932, "remote_system": 17.261397456752558}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 59786, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:44 UTC", "timesecs": 1711485464}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}], "sum": {"start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}], "sum": {"start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}], "sum": {"start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}], "sum": {"start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}], "sum": {"start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}], "sum": {"start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}, "cpu_utilization_percent": {"host_total": 34.12079215423493, "host_user": 1.449299942928998, "host_system": 32.671502129797744, "remote_total": 9.21759648553234, "remote_user": 0.13056616222089867, "remote_system": 9.087020816528113}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 42748, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:01 UTC", "timesecs": 1711485481}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2528, "rttvar": 68, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2635, "rttvar": 38, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2580, "rttvar": 45, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2614, "rttvar": 61, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2540, "rttvar": 36, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2532, "rttvar": 66, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2621, "rttvar": 26, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2647, "rttvar": 79, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2616, "rttvar": 57, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2608, "rttvar": 75, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "max_snd_cwnd": 3302888, "max_rtt": 2647, "min_rtt": 2528, "mean_rtt": 2592, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042832, "seconds": 10.000062, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.042832, "seconds": 10.042832, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}, "cpu_utilization_percent": {"host_total": 9.991931328513951, "host_user": 0.30260245650629003, "host_system": 9.689348708938175, "remote_total": 19.41962833866342, "remote_user": 0.6099473016485951, "remote_system": 18.809681037014826}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 58986, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:11 UTC", "timesecs": 1711485491}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}], "sum": {"start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}], "sum": {"start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}], "sum": {"start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}], "sum": {"start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}], "sum": {"start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "sender": false}, "sum_received": {"start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}, "cpu_utilization_percent": {"host_total": 48.724054060084946, "host_user": 3.9110899538590087, "host_system": 44.81297402368786, "remote_total": 7.595950273368541, "remote_user": 0.15972436790366432, "remote_system": 7.436225905464877}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}]}
+{
+  "tft-tests": [
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 56762,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:32 UTC",
+              "timesecs": 1711484912
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000191,
+                  "seconds": 1.0001909732818604,
+                  "bytes": 4895539200,
+                  "bits_per_second": 39156835690.5809,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000191,
+                "seconds": 1.0001909732818604,
+                "bytes": 4895539200,
+                "bits_per_second": 39156835690.5809,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000191,
+                  "end": 2.000081,
+                  "seconds": 0.9998900294303894,
+                  "bytes": 4911267840,
+                  "bits_per_second": 39294463954.583626,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000191,
+                "end": 2.000081,
+                "seconds": 0.9998900294303894,
+                "bytes": 4911267840,
+                "bits_per_second": 39294463954.583626,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000081,
+                  "end": 3.000218,
+                  "seconds": 1.0001369714736938,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38781514278.83715,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 27,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000081,
+                "end": 3.000218,
+                "seconds": 1.0001369714736938,
+                "bytes": 4848353280,
+                "bits_per_second": 38781514278.83715,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000218,
+                  "end": 4.000267,
+                  "seconds": 1.0000489950180054,
+                  "bytes": 4840488960,
+                  "bits_per_second": 38722014494.20265,
+                  "retransmits": 0,
+                  "snd_cwnd": 502804,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000218,
+                "end": 4.000267,
+                "seconds": 1.0000489950180054,
+                "bytes": 4840488960,
+                "bits_per_second": 38722014494.20265,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000247,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4881121280,
+                  "bits_per_second": 39049752295.66235,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 29,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000247,
+                "seconds": 0.9999799728393555,
+                "bytes": 4881121280,
+                "bits_per_second": 39049752295.66235,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000247,
+                  "end": 6.00002,
+                  "seconds": 0.9997730255126953,
+                  "bytes": 4856217600,
+                  "bits_per_second": 38858560701.89271,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000247,
+                "end": 6.00002,
+                "seconds": 0.9997730255126953,
+                "bytes": 4856217600,
+                "bits_per_second": 38858560701.89271,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000117,
+                  "seconds": 1.0000970363616943,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38825001843.07837,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 30,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000117,
+                "seconds": 1.0000970363616943,
+                "bytes": 4853596160,
+                "bits_per_second": 38825001843.07837,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000117,
+                  "end": 8.000116,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4864081920,
+                  "bits_per_second": 38912694789.414955,
+                  "retransmits": 0,
+                  "snd_cwnd": 591772,
+                  "rtt": 26,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000117,
+                "end": 8.000116,
+                "seconds": 0.9999989867210388,
+                "bytes": 4864081920,
+                "bits_per_second": 38912694789.414955,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000116,
+                  "end": 9.000019,
+                  "seconds": 0.9999030232429504,
+                  "bytes": 4836556800,
+                  "bits_per_second": 38696207032.668144,
+                  "retransmits": 99,
+                  "snd_cwnd": 621428,
+                  "rtt": 27,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000116,
+                "end": 9.000019,
+                "seconds": 0.9999030232429504,
+                "bytes": 4836556800,
+                "bits_per_second": 38696207032.668144,
+                "retransmits": 99,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000019,
+                  "end": 10.000269,
+                  "seconds": 1.000249981880188,
+                  "bytes": 4773642240,
+                  "bits_per_second": 38179593713.378716,
+                  "retransmits": 0,
+                  "snd_cwnd": 621428,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000019,
+                "end": 10.000269,
+                "seconds": 1.000249981880188,
+                "bytes": 4773642240,
+                "bits_per_second": 38179593713.378716,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000269,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38847647222.28973,
+                  "retransmits": 99,
+                  "max_snd_cwnd": 621428,
+                  "max_rtt": 30,
+                  "min_rtt": 25,
+                  "mean_rtt": 26,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040752,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38691018585.06216,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000269,
+              "seconds": 10.000269,
+              "bytes": 48560865280,
+              "bits_per_second": 38847647222.28973,
+              "retransmits": 99,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040752,
+              "seconds": 10.040752,
+              "bytes": 48560865280,
+              "bits_per_second": 38691018585.06216,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.95896032207571,
+              "host_user": 0.46109579260875955,
+              "host_system": 51.4978546106554,
+              "remote_total": 46.34560190202221,
+              "remote_user": 1.2743335369337774,
+              "remote_system": 45.07127657478376
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 54270,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:43 UTC",
+              "timesecs": 1711484923
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000023,
+                  "seconds": 1.0000230073928833,
+                  "bytes": 5267935560,
+                  "bits_per_second": 42142514890.60282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000023,
+                "seconds": 1.0000230073928833,
+                "bytes": 5267935560,
+                "bits_per_second": 42142514890.60282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000023,
+                  "end": 2.000011,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5283380932,
+                  "bits_per_second": 42267553843.84901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000023,
+                "end": 2.000011,
+                "seconds": 0.9999880194664001,
+                "bytes": 5283380932,
+                "bits_per_second": 42267553843.84901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000011,
+                  "end": 3.000025,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5144593776,
+                  "bits_per_second": 41156176182.772766,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000011,
+                "end": 3.000025,
+                "seconds": 1.0000139474868774,
+                "bytes": 5144593776,
+                "bits_per_second": 41156176182.772766,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000025,
+                  "end": 4.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5313921024,
+                  "bits_per_second": 42511454343.92459,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000025,
+                "end": 4.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5313921024,
+                "bits_per_second": 42511454343.92459,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.000026,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 5324144640,
+                  "bits_per_second": 42593030182.8783,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.000026,
+                "seconds": 1.0000029802322388,
+                "bytes": 5324144640,
+                "bits_per_second": 42593030182.8783,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000026,
+                  "end": 6.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 5340397568,
+                  "bits_per_second": 42724036185.13606,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000026,
+                "end": 6.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 5340397568,
+                "bits_per_second": 42724036185.13606,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000006,
+                  "end": 7.000013,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 5317722112,
+                  "bits_per_second": 42541477686.97944,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000006,
+                "end": 7.000013,
+                "seconds": 1.0000070333480835,
+                "bytes": 5317722112,
+                "bits_per_second": 42541477686.97944,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000013,
+                  "end": 8.000023,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 5339086848,
+                  "bits_per_second": 42712267081.28284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000013,
+                "end": 8.000023,
+                "seconds": 1.0000100135803223,
+                "bytes": 5339086848,
+                "bits_per_second": 42712267081.28284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000023,
+                  "end": 9.000043,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5329256448,
+                  "bits_per_second": 42633197762.099625,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000023,
+                "end": 9.000043,
+                "seconds": 1.0000200271606445,
+                "bytes": 5329256448,
+                "bits_per_second": 42633197762.099625,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000043,
+                  "end": 10.000027,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5294784512,
+                  "bits_per_second": 42358952739.80874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000043,
+                "end": 10.000027,
+                "seconds": 0.9999840259552002,
+                "bytes": 5294784512,
+                "bits_per_second": 42358952739.80874,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040745,
+                  "seconds": 10.040745,
+                  "bytes": 52956665212,
+                  "bits_per_second": 42193415099.77596,
+                  "retransmits": 220,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000027,
+                  "seconds": 10.000027,
+                  "bytes": 52955223420,
+                  "bits_per_second": 42364064353.02625,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040745,
+              "seconds": 10.040745,
+              "bytes": 52956665212,
+              "bits_per_second": 42193415099.77596,
+              "retransmits": 220,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000027,
+              "seconds": 10.000027,
+              "bytes": 52955223420,
+              "bits_per_second": 42364064353.02625,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 59.961165048543684,
+              "host_user": 1.7074681645153693,
+              "host_system": 58.25370680355615,
+              "remote_total": 54.92808068462117,
+              "remote_user": 0.35009864909523675,
+              "remote_system": 54.57798203552594
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 43488,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:03 UTC",
+              "timesecs": 1711484943
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1552629896,
+                  "bits_per_second": 12420331432.172485,
+                  "retransmits": 1162,
+                  "snd_cwnd": 858676,
+                  "rtt": 477,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1552629896,
+                "bits_per_second": 12420331432.172485,
+                "retransmits": 1162,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000057,
+                  "seconds": 1,
+                  "bytes": 1785895104,
+                  "bits_per_second": 14287160832,
+                  "retransmits": 250,
+                  "snd_cwnd": 864068,
+                  "rtt": 582,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000057,
+                "seconds": 1,
+                "bytes": 1785895104,
+                "bits_per_second": 14287160832,
+                "retransmits": 250,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1781226624,
+                  "bits_per_second": 14249799402.332296,
+                  "retransmits": 41,
+                  "snd_cwnd": 897768,
+                  "rtt": 469,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1781226624,
+                "bits_per_second": 14249799402.332296,
+                "retransmits": 41,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000058,
+                  "end": 4.000033,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 1770754368,
+                  "bits_per_second": 14166388740.29625,
+                  "retransmits": 43,
+                  "snd_cwnd": 843848,
+                  "rtt": 459,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000058,
+                "end": 4.000033,
+                "seconds": 0.9999750256538391,
+                "bytes": 1770754368,
+                "bits_per_second": 14166388740.29625,
+                "retransmits": 43,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000033,
+                  "end": 5.00012,
+                  "seconds": 1.000087022781372,
+                  "bytes": 1756157248,
+                  "bits_per_second": 14048035484.879292,
+                  "retransmits": 508,
+                  "snd_cwnd": 931468,
+                  "rtt": 278,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000033,
+                "end": 5.00012,
+                "seconds": 1.000087022781372,
+                "bytes": 1756157248,
+                "bits_per_second": 14048035484.879292,
+                "retransmits": 508,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00012,
+                  "end": 6.000058,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 1776470548,
+                  "bits_per_second": 14212645409.268175,
+                  "retransmits": 774,
+                  "snd_cwnd": 773752,
+                  "rtt": 389,
+                  "rttvar": 21,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.00012,
+                "end": 6.000058,
+                "seconds": 0.9999380111694336,
+                "bytes": 1776470548,
+                "bits_per_second": 14212645409.268175,
+                "retransmits": 774,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000214,
+                  "seconds": 1.000156044960022,
+                  "bytes": 1780520960,
+                  "bits_per_second": 14241945296.215616,
+                  "retransmits": 107,
+                  "snd_cwnd": 706352,
+                  "rtt": 351,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000214,
+                "seconds": 1.000156044960022,
+                "bytes": 1780520960,
+                "bits_per_second": 14241945296.215616,
+                "retransmits": 107,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000214,
+                  "end": 8.000165,
+                  "seconds": 0.9999510049819946,
+                  "bytes": 1782724608,
+                  "bits_per_second": 14262495655.23143,
+                  "retransmits": 103,
+                  "snd_cwnd": 957080,
+                  "rtt": 494,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000214,
+                "end": 8.000165,
+                "seconds": 0.9999510049819946,
+                "bytes": 1782724608,
+                "bits_per_second": 14262495655.23143,
+                "retransmits": 103,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000165,
+                  "end": 9.000061,
+                  "seconds": 0.9998959898948669,
+                  "bytes": 1708298368,
+                  "bits_per_second": 13667808534.202581,
+                  "retransmits": 636,
+                  "snd_cwnd": 668608,
+                  "rtt": 406,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000165,
+                "end": 9.000061,
+                "seconds": 0.9998959898948669,
+                "bytes": 1708298368,
+                "bits_per_second": 13667808534.202581,
+                "retransmits": 636,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000061,
+                  "end": 10.000067,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1711744320,
+                  "bits_per_second": 13693872938.156792,
+                  "retransmits": 37,
+                  "snd_cwnd": 835760,
+                  "rtt": 417,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000061,
+                "end": 10.000067,
+                "seconds": 1.0000059604644775,
+                "bytes": 1711744320,
+                "bits_per_second": 13693872938.156792,
+                "retransmits": 37,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 17406422044,
+                  "bits_per_second": 13925044337.40294,
+                  "retransmits": 3661,
+                  "max_snd_cwnd": 957080,
+                  "max_rtt": 582,
+                  "min_rtt": 278,
+                  "mean_rtt": 432,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040323,
+                  "seconds": 10.000067,
+                  "bytes": 17404804444,
+                  "bits_per_second": 13867923925.554983,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 17406422044,
+              "bits_per_second": 13925044337.40294,
+              "retransmits": 3661,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040323,
+              "seconds": 10.040323,
+              "bytes": 17404804444,
+              "bits_per_second": 13867923925.554983,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.428581942246796,
+              "host_user": 0.18264039451277397,
+              "host_system": 13.245951466295686,
+              "remote_total": 23.0189867907264,
+              "remote_user": 0.650631880001117,
+              "remote_system": 22.368346697024506
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 52702,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:14 UTC",
+              "timesecs": 1711484954
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 1769360536,
+                  "bits_per_second": 14154529944.193699,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 1769360536,
+                "bits_per_second": 14154529944.193699,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000056,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 1654294820,
+                  "bits_per_second": 13233948381.508026,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000056,
+                "seconds": 1.0000309944152832,
+                "bytes": 1654294820,
+                "bits_per_second": 13233948381.508026,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000002,
+                  "seconds": 0.9999459981918335,
+                  "bytes": 1693522048,
+                  "bits_per_second": 13548908049.533356,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000002,
+                "seconds": 0.9999459981918335,
+                "bytes": 1693522048,
+                "bits_per_second": 13548908049.533356,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000002,
+                  "end": 4.000058,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1778357520,
+                  "bits_per_second": 14226063096.928802,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000002,
+                "end": 4.000058,
+                "seconds": 1.0000560283660889,
+                "bytes": 1778357520,
+                "bits_per_second": 14226063096.928802,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000058,
+                  "seconds": 1,
+                  "bytes": 1699132892,
+                  "bits_per_second": 13593063136,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000058,
+                "seconds": 1,
+                "bytes": 1699132892,
+                "bits_per_second": 13593063136,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1776734848,
+                  "bits_per_second": 14214631996.442686,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1776734848,
+                "bits_per_second": 14214631996.442686,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000005,
+                  "end": 7.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1770689664,
+                  "bits_per_second": 14165319741.388792,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000005,
+                "end": 7.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 1770689664,
+                "bits_per_second": 14165319741.388792,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.00003,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1596714580,
+                  "bits_per_second": 12773576548.933342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.00003,
+                "seconds": 1.0000109672546387,
+                "bytes": 1596714580,
+                "bits_per_second": 12773576548.933342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000056,
+                  "seconds": 1.000025987625122,
+                  "bytes": 1650146112,
+                  "bits_per_second": 13200825837.886824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000056,
+                "seconds": 1.000025987625122,
+                "bytes": 1650146112,
+                "bits_per_second": 13200825837.886824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000056,
+                  "end": 10.00005,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1544969596,
+                  "bits_per_second": 12359831175.038013,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000056,
+                "end": 10.00005,
+                "seconds": 0.9999939799308777,
+                "bytes": 1544969596,
+                "bits_per_second": 12359831175.038013,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039981,
+                  "seconds": 10.039981,
+                  "bytes": 16936819512,
+                  "bits_per_second": 13495499254.032454,
+                  "retransmits": 2334,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00005,
+                  "seconds": 10.00005,
+                  "bytes": 16933922616,
+                  "bits_per_second": 13547070357.448214,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039981,
+              "seconds": 10.039981,
+              "bytes": 16936819512,
+              "bits_per_second": 13495499254.032454,
+              "retransmits": 2334,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00005,
+              "seconds": 10.00005,
+              "bytes": 16933922616,
+              "bits_per_second": 13547070357.448214,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 27.136162389258295,
+              "host_user": 1.0734065668100488,
+              "host_system": 26.062755822448246,
+              "remote_total": 12.134681085322041,
+              "remote_user": 0.20150770671204546,
+              "remote_system": 11.933173378609997
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 37248,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:34 UTC",
+              "timesecs": 1711484974
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000223,
+                  "seconds": 1.0002230405807495,
+                  "bytes": 4827381760,
+                  "bits_per_second": 38610442384.50756,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000223,
+                "seconds": 1.0002230405807495,
+                "bytes": 4827381760,
+                "bits_per_second": 38610442384.50756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000223,
+                  "end": 2.000162,
+                  "seconds": 0.9999390244483948,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38799677831.7579,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000223,
+                "end": 2.000162,
+                "seconds": 0.9999390244483948,
+                "bytes": 4849664000,
+                "bits_per_second": 38799677831.7579,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000162,
+                  "end": 3.000191,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 4826247500,
+                  "bits_per_second": 38608861584.00477,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000162,
+                "end": 3.000191,
+                "seconds": 1.0000289678573608,
+                "bytes": 4826247500,
+                "bits_per_second": 38608861584.00477,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000191,
+                  "end": 4.00012,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4861460480,
+                  "bits_per_second": 38894444922.881874,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000191,
+                "end": 4.00012,
+                "seconds": 0.9999290108680725,
+                "bytes": 4861460480,
+                "bits_per_second": 38894444922.881874,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00012,
+                  "end": 5.000266,
+                  "seconds": 1.0001460313796997,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38487604562.00447,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.00012,
+                "end": 5.000266,
+                "seconds": 1.0001460313796997,
+                "bytes": 4811653120,
+                "bits_per_second": 38487604562.00447,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000266,
+                  "end": 6.000154,
+                  "seconds": 0.999888002872467,
+                  "bytes": 4818206720,
+                  "bits_per_second": 38549971246.046036,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000266,
+                "end": 6.000154,
+                "seconds": 0.999888002872467,
+                "bytes": 4818206720,
+                "bits_per_second": 38549971246.046036,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000154,
+                  "end": 7.000089,
+                  "seconds": 0.99993497133255,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38831294427.33196,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000154,
+                "end": 7.000089,
+                "seconds": 0.99993497133255,
+                "bytes": 4853596160,
+                "bits_per_second": 38831294427.33196,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000089,
+                  "end": 8.000143,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4870635520,
+                  "bits_per_second": 38962980088.62366,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000089,
+                "end": 8.000143,
+                "seconds": 1.0000540018081665,
+                "bytes": 4870635520,
+                "bits_per_second": 38962980088.62366,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000143,
+                  "end": 9.000159,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38796692259.89976,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000143,
+                "end": 9.000159,
+                "seconds": 1.0000159740447998,
+                "bytes": 4849664000,
+                "bits_per_second": 38796692259.89976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000159,
+                  "end": 10.000248,
+                  "seconds": 1.0000890493392944,
+                  "bytes": 4823449600,
+                  "bits_per_second": 38584160905.964096,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000159,
+                "end": 10.000248,
+                "seconds": 1.0000890493392944,
+                "bytes": 4823449600,
+                "bits_per_second": 38584160905.964096,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000248,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38712607015.34602,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1412704,
+                  "max_rtt": 24,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040463,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38557551666.69106,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000248,
+              "seconds": 10.000248,
+              "bytes": 48391958860,
+              "bits_per_second": 38712607015.34602,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040463,
+              "seconds": 10.040463,
+              "bytes": 48391958860,
+              "bits_per_second": 38557551666.69106,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.42879332323217,
+              "host_user": 0.48554830964161494,
+              "host_system": 50.94323509492755,
+              "remote_total": 45.16438235241609,
+              "remote_user": 1.4607549345618025,
+              "remote_system": 43.703627417854285
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 42348,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:45 UTC",
+              "timesecs": 1711484985
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5317084948,
+                  "bits_per_second": 42536086312.49434,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 5317084948,
+                "bits_per_second": 42536086312.49434,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000016,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 5316804608,
+                  "bits_per_second": 42534350665.67468,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000016,
+                "seconds": 1.0000020265579224,
+                "bytes": 5316804608,
+                "bits_per_second": 42534350665.67468,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000013,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5298323456,
+                  "bits_per_second": 42386713970.25147,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000013,
+                "seconds": 0.9999970197677612,
+                "bytes": 5298323456,
+                "bits_per_second": 42386713970.25147,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000013,
+                  "end": 4.000027,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5347213312,
+                  "bits_per_second": 42777109862.82153,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000013,
+                "end": 4.000027,
+                "seconds": 1.0000139474868774,
+                "bytes": 5347213312,
+                "bits_per_second": 42777109862.82153,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000027,
+                  "end": 5.000006,
+                  "seconds": 0.9999790191650391,
+                  "bytes": 5329387520,
+                  "bits_per_second": 42635994698.76817,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000027,
+                "end": 5.000006,
+                "seconds": 0.9999790191650391,
+                "bytes": 5329387520,
+                "bits_per_second": 42635994698.76817,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000006,
+                  "end": 6.000018,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 5332271104,
+                  "bits_per_second": 42657655227.93386,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000006,
+                "end": 6.000018,
+                "seconds": 1.0000120401382446,
+                "bytes": 5332271104,
+                "bits_per_second": 42657655227.93386,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000031,
+                  "seconds": 1.000012993812561,
+                  "bytes": 5274468352,
+                  "bits_per_second": 42195198539.4992,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000031,
+                "seconds": 1.000012993812561,
+                "bytes": 5274468352,
+                "bits_per_second": 42195198539.4992,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000031,
+                  "end": 8.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5300420608,
+                  "bits_per_second": 42404297508.9502,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000031,
+                "end": 8.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 5300420608,
+                "bits_per_second": 42404297508.9502,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000009,
+                  "end": 9.000029,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5310644224,
+                  "bits_per_second": 42484302952.03991,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000009,
+                "end": 9.000029,
+                "seconds": 1.0000200271606445,
+                "bytes": 5310644224,
+                "bits_per_second": 42484302952.03991,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000028,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5294129152,
+                  "bits_per_second": 42353076131.48099,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000028,
+                "seconds": 0.9999989867210388,
+                "bytes": 5294129152,
+                "bits_per_second": 42353076131.48099,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040317,
+                  "seconds": 10.040317,
+                  "bytes": 53121271572,
+                  "bits_per_second": 42326370031.54382,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 53120747284,
+                  "bits_per_second": 42496478837.05926,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040317,
+              "seconds": 10.040317,
+              "bytes": 53121271572,
+              "bits_per_second": 42326370031.54382,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 53120747284,
+              "bits_per_second": 42496478837.05926,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.9131700562321,
+              "host_user": 1.8313076617106898,
+              "host_system": 57.08186239452141,
+              "remote_total": 54.91579537328721,
+              "remote_user": 0.4710685503353111,
+              "remote_system": 54.44472682295189
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 45258,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:05 UTC",
+              "timesecs": 1711485005
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1756790944,
+                  "bits_per_second": 14053511676.447533,
+                  "retransmits": 563,
+                  "snd_cwnd": 958428,
+                  "rtt": 667,
+                  "rttvar": 176,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1756790944,
+                "bits_per_second": 14053511676.447533,
+                "retransmits": 563,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1762679616,
+                  "bits_per_second": 14101451216.70384,
+                  "retransmits": 117,
+                  "snd_cwnd": 913944,
+                  "rtt": 617,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1762679616,
+                "bits_per_second": 14101451216.70384,
+                "retransmits": 117,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000057,
+                  "seconds": 1,
+                  "bytes": 1743596572,
+                  "bits_per_second": 13948772576,
+                  "retransmits": 76,
+                  "snd_cwnd": 698264,
+                  "rtt": 354,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000057,
+                "seconds": 1,
+                "bytes": 1743596572,
+                "bits_per_second": 13948772576,
+                "retransmits": 76,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1585909824,
+                  "bits_per_second": 12687278592,
+                  "retransmits": 93,
+                  "snd_cwnd": 789928,
+                  "rtt": 504,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1585909824,
+                "bits_per_second": 12687278592,
+                "retransmits": 93,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1719381848,
+                  "bits_per_second": 13755041666.170042,
+                  "retransmits": 79,
+                  "snd_cwnd": 698264,
+                  "rtt": 352,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1719381848,
+                "bits_per_second": 13755041666.170042,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.00008,
+                  "seconds": 1.000022053718567,
+                  "bytes": 1698620928,
+                  "bits_per_second": 13588667743.34589,
+                  "retransmits": 427,
+                  "snd_cwnd": 947644,
+                  "rtt": 487,
+                  "rttvar": 19,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.00008,
+                "seconds": 1.000022053718567,
+                "bytes": 1698620928,
+                "bits_per_second": 13588667743.34589,
+                "retransmits": 427,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00008,
+                  "end": 7.000196,
+                  "seconds": 1.000115990638733,
+                  "bytes": 1755761024,
+                  "bits_per_second": 14044459166.210653,
+                  "retransmits": 62,
+                  "snd_cwnd": 706352,
+                  "rtt": 362,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00008,
+                "end": 7.000196,
+                "seconds": 1.000115990638733,
+                "bytes": 1755761024,
+                "bits_per_second": 14044459166.210653,
+                "retransmits": 62,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000196,
+                  "end": 8.000057,
+                  "seconds": 0.9998610019683838,
+                  "bytes": 1783120320,
+                  "bits_per_second": 14266945637.36077,
+                  "retransmits": 88,
+                  "snd_cwnd": 684784,
+                  "rtt": 352,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000196,
+                "end": 8.000057,
+                "seconds": 0.9998610019683838,
+                "bytes": 1783120320,
+                "bits_per_second": 14266945637.36077,
+                "retransmits": 88,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000057,
+                  "end": 9.000034,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1733497792,
+                  "bits_per_second": 13868301409.459152,
+                  "retransmits": 177,
+                  "snd_cwnd": 877548,
+                  "rtt": 463,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000057,
+                "end": 9.000034,
+                "seconds": 0.9999769926071167,
+                "bytes": 1733497792,
+                "bits_per_second": 13868301409.459152,
+                "retransmits": 177,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000063,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 1775311360,
+                  "bits_per_second": 14202079476.187506,
+                  "retransmits": 53,
+                  "snd_cwnd": 858676,
+                  "rtt": 461,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000063,
+                "seconds": 1.0000289678573608,
+                "bytes": 1775311360,
+                "bits_per_second": 14202079476.187506,
+                "retransmits": 53,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17314670228,
+                  "bits_per_second": 13851648917.011822,
+                  "retransmits": 1735,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 667,
+                  "min_rtt": 352,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039933,
+                  "seconds": 10.000063,
+                  "bytes": 17312453588,
+                  "bits_per_second": 13794875792.896229,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17314670228,
+              "bits_per_second": 13851648917.011822,
+              "retransmits": 1735,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039933,
+              "seconds": 10.039933,
+              "bytes": 17312453588,
+              "bits_per_second": 13794875792.896229,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 12.965573157783645,
+              "host_user": 0.2766736708792456,
+              "host_system": 12.688899486904399,
+              "remote_total": 23.378925135581515,
+              "remote_user": 0.7967034489409502,
+              "remote_system": 22.582213415818792
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 46944,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:16 UTC",
+              "timesecs": 1711485016
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000056,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1588301472,
+                  "bits_per_second": 12705699896.394789,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000056,
+                "seconds": 1.0000560283660889,
+                "bytes": 1588301472,
+                "bits_per_second": 12705699896.394789,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000056,
+                  "end": 2.000025,
+                  "seconds": 0.9999690055847168,
+                  "bytes": 1717632384,
+                  "bits_per_second": 13741484981.292118,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000056,
+                "end": 2.000025,
+                "seconds": 0.9999690055847168,
+                "bytes": 1717632384,
+                "bits_per_second": 13741484981.292118,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000025,
+                  "end": 3.000046,
+                  "seconds": 1.000020980834961,
+                  "bytes": 1637153304,
+                  "bits_per_second": 13096951647.019003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000025,
+                "end": 3.000046,
+                "seconds": 1.000020980834961,
+                "bytes": 1637153304,
+                "bits_per_second": 13096951647.019003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000057,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1548560832,
+                  "bits_per_second": 12388350789.802336,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000057,
+                "seconds": 1.0000109672546387,
+                "bytes": 1548560832,
+                "bits_per_second": 12388350789.802336,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000057,
+                  "seconds": 1,
+                  "bytes": 1661339904,
+                  "bits_per_second": 13290719232,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000057,
+                "seconds": 1,
+                "bytes": 1661339904,
+                "bits_per_second": 13290719232,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000057,
+                  "seconds": 1,
+                  "bytes": 1734958228,
+                  "bits_per_second": 13879665824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000057,
+                "seconds": 1,
+                "bytes": 1734958228,
+                "bits_per_second": 13879665824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000024,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 1733693804,
+                  "bits_per_second": 13870008433.176832,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000024,
+                "seconds": 0.9999669790267944,
+                "bytes": 1733693804,
+                "bits_per_second": 13870008433.176832,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000056,
+                  "seconds": 1.0000319480895996,
+                  "bytes": 1624242608,
+                  "bits_per_second": 12993525745.675262,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000056,
+                "seconds": 1.0000319480895996,
+                "bytes": 1624242608,
+                "bits_per_second": 12993525745.675262,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000056,
+                  "end": 9.000015,
+                  "seconds": 0.9999589920043945,
+                  "bytes": 1732061376,
+                  "bits_per_second": 13857059258.225166,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000056,
+                "end": 9.000015,
+                "seconds": 0.9999589920043945,
+                "bytes": 1732061376,
+                "bits_per_second": 13857059258.225166,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000015,
+                  "end": 10.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1706050368,
+                  "bits_per_second": 13648225601.514744,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000015,
+                "end": 10.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1706050368,
+                "bits_per_second": 13648225601.514744,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03969,
+                  "seconds": 10.03969,
+                  "bytes": 16687168488,
+                  "bits_per_second": 13296959159.49596,
+                  "retransmits": 2081,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 16683994280,
+                  "bits_per_second": 13347158051.957455,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03969,
+              "seconds": 10.03969,
+              "bytes": 16687168488,
+              "bits_per_second": 13296959159.49596,
+              "retransmits": 2081,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 16683994280,
+              "bits_per_second": 13347158051.957455,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.49645360241422,
+              "host_user": 1.0953846141637273,
+              "host_system": 25.40107890796627,
+              "remote_total": 12.308727742765743,
+              "remote_user": 0.1856302180705536,
+              "remote_system": 12.12309752469519
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 39718,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:35 UTC",
+              "timesecs": 1711485035
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000101,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 4825423936,
+                  "bits_per_second": 38599494086.72777,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 31,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000101,
+                "seconds": 1.0001009702682495,
+                "bytes": 4825423936,
+                "bits_per_second": 38599494086.72777,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000101,
+                  "end": 2.000064,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38452705227.057976,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000101,
+                "end": 2.000064,
+                "seconds": 0.9999629855155945,
+                "bytes": 4806410240,
+                "bits_per_second": 38452705227.057976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000064,
+                  "end": 3.000036,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 4803788800,
+                  "bits_per_second": 38431387023.910736,
+                  "retransmits": 0,
+                  "snd_cwnd": 707700,
+                  "rtt": 27,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000064,
+                "end": 3.000036,
+                "seconds": 0.9999719858169556,
+                "bytes": 4803788800,
+                "bits_per_second": 38431387023.910736,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000036,
+                  "end": 4.000268,
+                  "seconds": 1.0002319812774658,
+                  "bytes": 4790681600,
+                  "bits_per_second": 38316564074.51789,
+                  "retransmits": 78,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000036,
+                "end": 4.000268,
+                "seconds": 1.0002319812774658,
+                "bytes": 4790681600,
+                "bits_per_second": 38316564074.51789,
+                "retransmits": 78,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000268,
+                  "end": 5.000265,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4696309760,
+                  "bits_per_second": 37570590049.083694,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 30,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000268,
+                "end": 5.000265,
+                "seconds": 0.9999970197677612,
+                "bytes": 4696309760,
+                "bits_per_second": 37570590049.083694,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000265,
+                  "end": 6.000018,
+                  "seconds": 0.9997529983520508,
+                  "bytes": 4778885120,
+                  "bits_per_second": 38240526433.04741,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000265,
+                "end": 6.000018,
+                "seconds": 0.9997529983520508,
+                "bytes": 4778885120,
+                "bits_per_second": 38240526433.04741,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000112,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38112152918.41128,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000112,
+                "seconds": 1.0000940561294556,
+                "bytes": 4764467200,
+                "bits_per_second": 38112152918.41128,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000112,
+                  "end": 8.000259,
+                  "seconds": 1.0001469850540161,
+                  "bytes": 4839178240,
+                  "bits_per_second": 38707736461.265396,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000112,
+                "end": 8.000259,
+                "seconds": 1.0001469850540161,
+                "bytes": 4839178240,
+                "bits_per_second": 38707736461.265396,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000259,
+                  "end": 9.000227,
+                  "seconds": 0.9999679923057556,
+                  "bytes": 4712038400,
+                  "bits_per_second": 37697513810.49582,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000259,
+                "end": 9.000227,
+                "seconds": 0.9999679923057556,
+                "bytes": 4712038400,
+                "bits_per_second": 37697513810.49582,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000227,
+                  "end": 10.000156,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4784128000,
+                  "bits_per_second": 38275741161.63895,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000227,
+                "end": 10.000156,
+                "seconds": 0.9999290108680725,
+                "bytes": 4784128000,
+                "bits_per_second": 38275741161.63895,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000156,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38240452485.74122,
+                  "retransmits": 78,
+                  "max_snd_cwnd": 808800,
+                  "max_rtt": 31,
+                  "min_rtt": 26,
+                  "mean_rtt": 28,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38087381686.64706,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000156,
+              "seconds": 10.000156,
+              "bytes": 47801311296,
+              "bits_per_second": 38240452485.74122,
+              "retransmits": 78,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 47801311296,
+              "bits_per_second": 38087381686.64706,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 50.79991850744037,
+              "host_user": 0.5093780915545499,
+              "host_system": 50.29054041588581,
+              "remote_total": 69.18971718930246,
+              "remote_user": 1.6048329699753412,
+              "remote_system": 67.58487595116893
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 45210,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:46 UTC",
+              "timesecs": 1711485046
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000004,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 4517548360,
+                  "bits_per_second": 36140240399.41901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000004,
+                "seconds": 1.0000040531158447,
+                "bytes": 4517548360,
+                "bits_per_second": 36140240399.41901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000004,
+                  "end": 2.000005,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4473749504,
+                  "bits_per_second": 35789961900.03255,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000004,
+                "end": 2.000005,
+                "seconds": 1.0000009536743164,
+                "bytes": 4473749504,
+                "bits_per_second": 35789961900.03255,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4472438784,
+                  "bits_per_second": 35779011244.710175,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 4472438784,
+                "bits_per_second": 35779011244.710175,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000014,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 4757520384,
+                  "bits_per_second": 38060353632.204094,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000014,
+                "seconds": 0.9999949932098389,
+                "bytes": 4757520384,
+                "bits_per_second": 38060353632.204094,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000014,
+                  "end": 5.000022,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4763942596,
+                  "bits_per_second": 38111236372.7014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000014,
+                "end": 5.000022,
+                "seconds": 1.0000079870224,
+                "bytes": 4763942596,
+                "bits_per_second": 38111236372.7014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000022,
+                  "end": 6.000016,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4744937788,
+                  "bits_per_second": 37959730824.20342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000022,
+                "end": 6.000016,
+                "seconds": 0.9999939799308777,
+                "bytes": 4744937788,
+                "bits_per_second": 37959730824.20342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000016,
+                  "end": 7.000004,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 4736604700,
+                  "bits_per_second": 37893291581.853004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000016,
+                "end": 7.000004,
+                "seconds": 0.9999880194664001,
+                "bytes": 4736604700,
+                "bits_per_second": 37893291581.853004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000004,
+                  "end": 8.000015,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 4758175744,
+                  "bits_per_second": 38064988483.57848,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000004,
+                "end": 8.000015,
+                "seconds": 1.0000109672546387,
+                "bytes": 4758175744,
+                "bits_per_second": 38064988483.57848,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000031,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4740612096,
+                  "bits_per_second": 37924290963.67715,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000031,
+                "seconds": 1.0000159740447998,
+                "bytes": 4740612096,
+                "bits_per_second": 37924290963.67715,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000031,
+                  "end": 10.000012,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4774428672,
+                  "bits_per_second": 38196155633.18397,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000031,
+                "end": 10.000012,
+                "seconds": 0.9999809861183167,
+                "bytes": 4774428672,
+                "bits_per_second": 38196155633.18397,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040275,
+                  "seconds": 10.040275,
+                  "bytes": 46740351844,
+                  "bits_per_second": 37242288159.63706,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000012,
+                  "seconds": 10.000012,
+                  "bytes": 46739958628,
+                  "bits_per_second": 37391922032.09356,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040275,
+              "seconds": 10.040275,
+              "bytes": 46740351844,
+              "bits_per_second": 37242288159.63706,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000012,
+              "seconds": 10.000012,
+              "bytes": 46739958628,
+              "bits_per_second": 37391922032.09356,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 53.87293306289964,
+              "host_user": 1.9549507299646565,
+              "host_system": 51.91798233293498,
+              "remote_total": 84.71007116240497,
+              "remote_user": 0.4765840963192183,
+              "remote_system": 84.23349673055752
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 42424,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:05 UTC",
+              "timesecs": 1711485065
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00002,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 2929396644,
+                  "bits_per_second": 23434703821.421913,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 397,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00002,
+                "seconds": 1.0000200271606445,
+                "bytes": 2929396644,
+                "bits_per_second": 23434703821.421913,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00002,
+                  "end": 2.000058,
+                  "seconds": 1.0000380277633667,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23424297066.37413,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 398,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.00002,
+                "end": 2.000058,
+                "seconds": 1.0000380277633667,
+                "bytes": 2928148480,
+                "bits_per_second": 23424297066.37413,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393683151.346077,
+                  "retransmits": 655,
+                  "snd_cwnd": 760272,
+                  "rtt": 242,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 2924216320,
+                "bits_per_second": 23393683151.346077,
+                "retransmits": 655,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00006,
+                  "end": 4.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425235312.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 1517848,
+                  "rtt": 400,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00006,
+                "end": 4.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 2928148480,
+                "bits_per_second": 23425235312.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425211576.27405,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 393,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 2928148480,
+                "bits_per_second": 23425211576.27405,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000027,
+                  "seconds": 0.999970018863678,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425890174.806797,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 373,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000027,
+                "seconds": 0.999970018863678,
+                "bytes": 2928148480,
+                "bits_per_second": 23425890174.806797,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000027,
+                  "end": 7.000129,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422797703.897022,
+                  "retransmits": 152,
+                  "snd_cwnd": 1442360,
+                  "rtt": 379,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000027,
+                "end": 7.000129,
+                "seconds": 1.0001020431518555,
+                "bytes": 2928148480,
+                "bits_per_second": 23422797703.897022,
+                "retransmits": 152,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000129,
+                  "end": 8.000058,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416364387.380756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1544808,
+                  "rtt": 397,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000129,
+                "end": 8.000058,
+                "seconds": 0.9999290108680725,
+                "bytes": 2926837760,
+                "bits_per_second": 23416364387.380756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425187840,
+                  "retransmits": 0,
+                  "snd_cwnd": 1569072,
+                  "rtt": 419,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 2928148480,
+                "bits_per_second": 23425187840,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000116,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2921594880,
+                  "bits_per_second": 23371402215.02037,
+                  "retransmits": 0,
+                  "snd_cwnd": 1606816,
+                  "rtt": 410,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000116,
+                "seconds": 1.0000580549240112,
+                "bytes": 2921594880,
+                "bits_per_second": 23371402215.02037,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000116,
+                  "seconds": 10.000116,
+                  "bytes": 29270936484,
+                  "bits_per_second": 23416477556.06035,
+                  "retransmits": 807,
+                  "max_snd_cwnd": 1763184,
+                  "max_rtt": 419,
+                  "min_rtt": 242,
+                  "mean_rtt": 380,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039772,
+                  "seconds": 10.000116,
+                  "bytes": 29268240456,
+                  "bits_per_second": 23321836755.65541,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000116,
+              "seconds": 10.000116,
+              "bytes": 29270936484,
+              "bits_per_second": 23416477556.06035,
+              "retransmits": 807,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039772,
+              "seconds": 10.039772,
+              "bytes": 29268240456,
+              "bits_per_second": 23321836755.65541,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 19.865083177612643,
+              "host_user": 0.41521108861582645,
+              "host_system": 19.449872088996816,
+              "remote_total": 59.10663386005702,
+              "remote_user": 2.4033524078476156,
+              "remote_system": 56.70327318135753
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 38322,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:16 UTC",
+              "timesecs": 1711485076
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000018,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 2577850256,
+                  "bits_per_second": 20622430831.81543,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000018,
+                "seconds": 1.0000180006027222,
+                "bytes": 2577850256,
+                "bits_per_second": 20622430831.81543,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000018,
+                  "end": 2.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 2421676608,
+                  "bits_per_second": 19373587232.123535,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000018,
+                "end": 2.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 2421676608,
+                "bits_per_second": 19373587232.123535,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000009,
+                  "seconds": 1,
+                  "bytes": 2353155072,
+                  "bits_per_second": 18825240576,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000009,
+                "seconds": 1,
+                "bytes": 2353155072,
+                "bits_per_second": 18825240576,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000015,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 2349402240,
+                  "bits_per_second": 18795105892.438976,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000015,
+                "seconds": 1.0000059604644775,
+                "bytes": 2349402240,
+                "bits_per_second": 18795105892.438976,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000015,
+                  "end": 5.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 2327467584,
+                  "bits_per_second": 18619498733.723473,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000015,
+                "end": 5.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 2327467584,
+                "bits_per_second": 18619498733.723473,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000022,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 2343643584,
+                  "bits_per_second": 18749261543.850487,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000022,
+                "seconds": 0.9999939799308777,
+                "bytes": 2343643584,
+                "bits_per_second": 18749261543.850487,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000022,
+                  "end": 7.000011,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2349466944,
+                  "bits_per_second": 18795942812.21649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000022,
+                "end": 7.000011,
+                "seconds": 0.9999889731407166,
+                "bytes": 2349466944,
+                "bits_per_second": 18795942812.21649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000011,
+                  "end": 8.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 2404465344,
+                  "bits_per_second": 19235358159.692505,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000011,
+                "end": 8.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 2404465344,
+                "bits_per_second": 19235358159.692505,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.00003,
+                  "seconds": 1,
+                  "bytes": 2575413312,
+                  "bits_per_second": 20603306496,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.00003,
+                "seconds": 1,
+                "bytes": 2575413312,
+                "bits_per_second": 20603306496,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.000034,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 2567907648,
+                  "bits_per_second": 20543177920.12007,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.000034,
+                "seconds": 1.0000040531158447,
+                "bytes": 2567907648,
+                "bits_per_second": 20543177920.12007,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039536,
+                  "seconds": 10.039536,
+                  "bytes": 24273090960,
+                  "bits_per_second": 19342002227.991413,
+                  "retransmits": 2404,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000034,
+                  "seconds": 10.000034,
+                  "bytes": 24270448592,
+                  "bits_per_second": 19416292858.204285,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039536,
+              "seconds": 10.039536,
+              "bytes": 24273090960,
+              "bits_per_second": 19342002227.991413,
+              "retransmits": 2404,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000034,
+              "seconds": 10.000034,
+              "bytes": 24270448592,
+              "bits_per_second": 19416292858.204285,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 37.45748338542608,
+              "host_user": 1.3319334804012157,
+              "host_system": 36.125549905024855,
+              "remote_total": 15.928314062618693,
+              "remote_user": 0.36963858784471143,
+              "remote_system": 15.558675474773981
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 47958,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:36 UTC",
+              "timesecs": 1711485096
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000048,
+                  "seconds": 1.000048041343689,
+                  "bytes": 4818672896,
+                  "bits_per_second": 38547531292.800804,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 26,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000048,
+                "seconds": 1.000048041343689,
+                "bytes": 4818672896,
+                "bits_per_second": 38547531292.800804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000048,
+                  "end": 2.000066,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38461075357.46222,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000048,
+                "end": 2.000066,
+                "seconds": 1.0000180006027222,
+                "bytes": 4807720960,
+                "bits_per_second": 38461075357.46222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000066,
+                  "end": 3.000236,
+                  "seconds": 1.0001699924468994,
+                  "bytes": 4804968024,
+                  "bits_per_second": 38433210836.44771,
+                  "retransmits": 0,
+                  "snd_cwnd": 899116,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000066,
+                "end": 3.000236,
+                "seconds": 1.0001699924468994,
+                "bytes": 4804968024,
+                "bits_per_second": 38433210836.44771,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000236,
+                  "end": 4.000147,
+                  "seconds": 0.9999110102653503,
+                  "bytes": 4799728368,
+                  "bits_per_second": 38401244260.536964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000236,
+                "end": 4.000147,
+                "seconds": 0.9999110102653503,
+                "bytes": 4799728368,
+                "bits_per_second": 38401244260.536964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000147,
+                  "end": 5.000114,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 4824760320,
+                  "bits_per_second": 38599357148.33815,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 26,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000147,
+                "end": 5.000114,
+                "seconds": 0.9999669790267944,
+                "bytes": 4824760320,
+                "bits_per_second": 38599357148.33815,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000114,
+                  "end": 6.000145,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 4833935360,
+                  "bits_per_second": 38670284317.14876,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 24,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000114,
+                "end": 6.000145,
+                "seconds": 1.0000309944152832,
+                "bytes": 4833935360,
+                "bits_per_second": 38670284317.14876,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000145,
+                  "end": 7.000159,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38408803173.721756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000145,
+                "end": 7.000159,
+                "seconds": 1.0000139474868774,
+                "bytes": 4801167360,
+                "bits_per_second": 38408803173.721756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000159,
+                  "end": 8.00016,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4820828160,
+                  "bits_per_second": 38566588500.03507,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000159,
+                "end": 8.00016,
+                "seconds": 1.0000009536743164,
+                "bytes": 4820828160,
+                "bits_per_second": 38566588500.03507,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00016,
+                  "end": 9.000032,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38372306389.033714,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00016,
+                "end": 9.000032,
+                "seconds": 0.9998720288276672,
+                "bytes": 4795924480,
+                "bits_per_second": 38372306389.033714,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000128,
+                  "seconds": 1.0000959634780884,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38783104478.40319,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000128,
+                "seconds": 1.0000959634780884,
+                "bytes": 4848353280,
+                "bits_per_second": 38783104478.40319,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000128,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38524354254.66554,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1043352,
+                  "max_rtt": 26,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040386,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38369886741.80455,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000128,
+              "seconds": 10.000128,
+              "bytes": 48156059208,
+              "bits_per_second": 38524354254.66554,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040386,
+              "seconds": 10.040386,
+              "bytes": 48156059208,
+              "bits_per_second": 38369886741.80455,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.71680226694355,
+              "host_user": 0.47637317598252343,
+              "host_system": 51.24043901002937,
+              "remote_total": 45.230156070887375,
+              "remote_user": 1.3387075643093247,
+              "remote_system": 43.891456788045936
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 60988,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:48 UTC",
+              "timesecs": 1711485108
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000022,
+                  "seconds": 1.000022053718567,
+                  "bytes": 5308961096,
+                  "bits_per_second": 42470752129.9852,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000022,
+                "seconds": 1.000022053718567,
+                "bytes": 5308961096,
+                "bits_per_second": 42470752129.9852,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000022,
+                  "end": 2.000005,
+                  "seconds": 0.999983012676239,
+                  "bytes": 5317292584,
+                  "bits_per_second": 42539063296.84071,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000022,
+                "end": 2.000005,
+                "seconds": 0.999983012676239,
+                "bytes": 5317292584,
+                "bits_per_second": 42539063296.84071,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000026,
+                  "seconds": 1.000020980834961,
+                  "bytes": 5243928576,
+                  "bits_per_second": 41950548450.46644,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000026,
+                "seconds": 1.000020980834961,
+                "bytes": 5243928576,
+                "bits_per_second": 41950548450.46644,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000023,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5279918676,
+                  "bits_per_second": 42239475291.446014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000023,
+                "seconds": 0.9999970197677612,
+                "bytes": 5279918676,
+                "bits_per_second": 42239475291.446014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.00002,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5323227136,
+                  "bits_per_second": 42585944004.00324,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.00002,
+                "seconds": 0.9999970197677612,
+                "bytes": 5323227136,
+                "bits_per_second": 42585944004.00324,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00002,
+                  "end": 6.000004,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5266341888,
+                  "bits_per_second": 42131408113.00068,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.00002,
+                "end": 6.000004,
+                "seconds": 0.9999840259552002,
+                "bytes": 5266341888,
+                "bits_per_second": 42131408113.00068,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000028,
+                  "seconds": 1.0000239610671997,
+                  "bytes": 5331222528,
+                  "bits_per_second": 42648758314.236046,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000028,
+                "seconds": 1.0000239610671997,
+                "bytes": 5331222528,
+                "bits_per_second": 42648758314.236046,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000028,
+                  "end": 8.000016,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5229510656,
+                  "bits_per_second": 41836586472.62994,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000028,
+                "end": 8.000016,
+                "seconds": 0.9999880194664001,
+                "bytes": 5229510656,
+                "bits_per_second": 41836586472.62994,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000016,
+                  "end": 9.000006,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 5216403456,
+                  "bits_per_second": 41731645531.18451,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000016,
+                "end": 9.000006,
+                "seconds": 0.9999899864196777,
+                "bytes": 5216403456,
+                "bits_per_second": 41731645531.18451,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000006,
+                  "end": 10.000033,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 5329518592,
+                  "bits_per_second": 42635000093.695915,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000006,
+                "end": 10.000033,
+                "seconds": 1.0000269412994385,
+                "bytes": 5329518592,
+                "bits_per_second": 42635000093.695915,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040391,
+                  "seconds": 10.040391,
+                  "bytes": 52847242692,
+                  "bits_per_second": 42107716874.37273,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000033,
+                  "seconds": 10.000033,
+                  "bytes": 52846325188,
+                  "bits_per_second": 42276920636.5619,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040391,
+              "seconds": 10.040391,
+              "bytes": 52847242692,
+              "bits_per_second": 42107716874.37273,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000033,
+              "seconds": 10.000033,
+              "bytes": 52846325188,
+              "bits_per_second": 42276920636.5619,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72172176163449,
+              "host_user": 1.7632532126911542,
+              "host_system": 56.958468548943344,
+              "remote_total": 54.5440108210963,
+              "remote_user": 0.40678669250280086,
+              "remote_system": 54.137214462757875
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 46580,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:07 UTC",
+              "timesecs": 1711485127
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1749200440,
+                  "bits_per_second": 13992791169.571945,
+                  "retransmits": 621,
+                  "snd_cwnd": 812844,
+                  "rtt": 417,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1749200440,
+                "bits_per_second": 13992791169.571945,
+                "retransmits": 621,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000151,
+                  "seconds": 1.0000929832458496,
+                  "bytes": 1770835776,
+                  "bits_per_second": 14165369066.005585,
+                  "retransmits": 57,
+                  "snd_cwnd": 912596,
+                  "rtt": 445,
+                  "rttvar": 23,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000151,
+                "seconds": 1.0000929832458496,
+                "bytes": 1770835776,
+                "bits_per_second": 14165369066.005585,
+                "retransmits": 57,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000151,
+                  "end": 3.000227,
+                  "seconds": 1.0000760555267334,
+                  "bytes": 1781066812,
+                  "bits_per_second": 14247450898.617298,
+                  "retransmits": 87,
+                  "snd_cwnd": 669956,
+                  "rtt": 482,
+                  "rttvar": 128,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000151,
+                "end": 3.000227,
+                "seconds": 1.0000760555267334,
+                "bytes": 1781066812,
+                "bits_per_second": 14247450898.617298,
+                "retransmits": 87,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000227,
+                  "end": 4.000645,
+                  "seconds": 1.000417947769165,
+                  "bytes": 1706121192,
+                  "bits_per_second": 13643267362.841578,
+                  "retransmits": 532,
+                  "snd_cwnd": 843848,
+                  "rtt": 461,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000227,
+                "end": 4.000645,
+                "seconds": 1.000417947769165,
+                "bytes": 1706121192,
+                "bits_per_second": 13643267362.841578,
+                "retransmits": 532,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000645,
+                  "end": 5.000058,
+                  "seconds": 0.999413013458252,
+                  "bytes": 1646996516,
+                  "bits_per_second": 13183710788.803326,
+                  "retransmits": 142,
+                  "snd_cwnd": 838456,
+                  "rtt": 544,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000645,
+                "end": 5.000058,
+                "seconds": 0.999413013458252,
+                "bytes": 1646996516,
+                "bits_per_second": 13183710788.803326,
+                "retransmits": 142,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1782799112,
+                  "bits_per_second": 14262407347.797302,
+                  "retransmits": 132,
+                  "snd_cwnd": 928772,
+                  "rtt": 486,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1782799112,
+                "bits_per_second": 14262407347.797302,
+                "retransmits": 132,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000161,
+                  "seconds": 1.0001039505004883,
+                  "bytes": 1788102904,
+                  "bits_per_second": 14303336393.023293,
+                  "retransmits": 77,
+                  "snd_cwnd": 831716,
+                  "rtt": 416,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000161,
+                "seconds": 1.0001039505004883,
+                "bytes": 1788102904,
+                "bits_per_second": 14303336393.023293,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000161,
+                  "end": 8.000058,
+                  "seconds": 0.9998970031738281,
+                  "bytes": 1783196620,
+                  "bits_per_second": 14267042420.088129,
+                  "retransmits": 96,
+                  "snd_cwnd": 824976,
+                  "rtt": 580,
+                  "rttvar": 185,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000161,
+                "end": 8.000058,
+                "seconds": 0.9998970031738281,
+                "bytes": 1783196620,
+                "bits_per_second": 14267042420.088129,
+                "retransmits": 96,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000076,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 1775786432,
+                  "bits_per_second": 14206035738.794409,
+                  "retransmits": 301,
+                  "snd_cwnd": 634908,
+                  "rtt": 423,
+                  "rttvar": 97,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000076,
+                "seconds": 1.0000180006027222,
+                "bytes": 1775786432,
+                "bits_per_second": 14206035738.794409,
+                "retransmits": 301,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000076,
+                  "end": 10.000063,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1681309440,
+                  "bits_per_second": 13450650295.22876,
+                  "retransmits": 249,
+                  "snd_cwnd": 676696,
+                  "rtt": 360,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000076,
+                "end": 10.000063,
+                "seconds": 0.999987006187439,
+                "bytes": 1681309440,
+                "bits_per_second": 13450650295.22876,
+                "retransmits": 249,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17465415244,
+                  "bits_per_second": 13972244170.061728,
+                  "retransmits": 2294,
+                  "max_snd_cwnd": 928772,
+                  "max_rtt": 580,
+                  "min_rtt": 360,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039945,
+                  "seconds": 10.000063,
+                  "bytes": 17463546188,
+                  "bits_per_second": 13915252474.391047,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17465415244,
+              "bits_per_second": 13972244170.061728,
+              "retransmits": 2294,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039945,
+              "seconds": 10.039945,
+              "bytes": 17463546188,
+              "bits_per_second": 13915252474.391047,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.61059396129923,
+              "host_user": 0.19270043453809127,
+              "host_system": 13.417903445457585,
+              "remote_total": 23.486672814565882,
+              "remote_user": 0.5555645903789477,
+              "remote_system": 22.931108224186932
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 50678,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:19 UTC",
+              "timesecs": 1711485139
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000045,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731201352,
+                  "bits_per_second": 13848988416.117579,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000045,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731201352,
+                "bits_per_second": 13848988416.117579,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000045,
+                  "end": 2.000008,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 1582543756,
+                  "bits_per_second": 12660818681.675653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000045,
+                "end": 2.000008,
+                "seconds": 0.9999629855155945,
+                "bytes": 1582543756,
+                "bits_per_second": 12660818681.675653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000008,
+                  "end": 3.000015,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1576707072,
+                  "bits_per_second": 12613567860.386663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000008,
+                "end": 3.000015,
+                "seconds": 1.0000070333480835,
+                "bytes": 1576707072,
+                "bits_per_second": 12613567860.386663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1528626392,
+                  "bits_per_second": 12228852236.5862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1528626392,
+                "bits_per_second": 12228852236.5862,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000013,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 1714944660,
+                  "bits_per_second": 13719763355.92855,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000013,
+                "seconds": 0.9999849796295166,
+                "bytes": 1714944660,
+                "bits_per_second": 13719763355.92855,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000043,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 1705468032,
+                  "bits_per_second": 13643334400.125362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000043,
+                "seconds": 1.0000300407409668,
+                "bytes": 1705468032,
+                "bits_per_second": 13643334400.125362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000043,
+                  "end": 7.000024,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1737755328,
+                  "bits_per_second": 13902306960.81968,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000043,
+                "end": 7.000024,
+                "seconds": 0.9999809861183167,
+                "bytes": 1737755328,
+                "bits_per_second": 13902306960.81968,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000011,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1737625920,
+                  "bits_per_second": 13901187989.43111,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000011,
+                "seconds": 0.999987006187439,
+                "bytes": 1737625920,
+                "bits_per_second": 13901187989.43111,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000011,
+                  "end": 9.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 1625946816,
+                  "bits_per_second": 13007327983.50187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000011,
+                "end": 9.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 1625946816,
+                "bits_per_second": 13007327983.50187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.00004,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1604133292,
+                  "bits_per_second": 12832937832.346245,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.00004,
+                "seconds": 1.0000100135803223,
+                "bytes": 1604133292,
+                "bits_per_second": 12832937832.346245,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039719,
+                  "seconds": 10.039719,
+                  "bytes": 16547546348,
+                  "bits_per_second": 13185664935.841331,
+                  "retransmits": 2136,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00004,
+                  "seconds": 10.00004,
+                  "bytes": 16544952620,
+                  "bits_per_second": 13235909152.36339,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039719,
+              "seconds": 10.039719,
+              "bytes": 16547546348,
+              "bits_per_second": 13185664935.841331,
+              "retransmits": 2136,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00004,
+              "seconds": 10.00004,
+              "bytes": 16544952620,
+              "bits_per_second": 13235909152.36339,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.747516641197084,
+              "host_user": 1.0158505257156165,
+              "host_system": 25.731666115481467,
+              "remote_total": 11.755923477356498,
+              "remote_user": 0.13796182174123386,
+              "remote_system": 11.617971314101807
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 41706,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:38 UTC",
+              "timesecs": 1711485158
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000041,
+                  "seconds": 1.0000410079956055,
+                  "bytes": 4768399360,
+                  "bits_per_second": 38145630604.14782,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 24,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000041,
+                "seconds": 1.0000410079956055,
+                "bytes": 4768399360,
+                "bits_per_second": 38145630604.14782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000041,
+                  "end": 2.000213,
+                  "seconds": 1.0001720190048218,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38444668706.348434,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000041,
+                "end": 2.000213,
+                "seconds": 1.0001720190048218,
+                "bytes": 4806410240,
+                "bits_per_second": 38444668706.348434,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000213,
+                  "end": 3.00012,
+                  "seconds": 0.9999070167541504,
+                  "bytes": 4761203140,
+                  "bits_per_second": 38093167146.32596,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000213,
+                "end": 3.00012,
+                "seconds": 0.9999070167541504,
+                "bytes": 4761203140,
+                "bits_per_second": 38093167146.32596,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00012,
+                  "end": 4.000102,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 4814274560,
+                  "bits_per_second": 38514889771.22966,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00012,
+                "end": 4.000102,
+                "seconds": 0.9999819993972778,
+                "bytes": 4814274560,
+                "bits_per_second": 38514889771.22966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000102,
+                  "end": 5.000003,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38497036294.209724,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000102,
+                "end": 5.000003,
+                "seconds": 0.9999009966850281,
+                "bytes": 4811653120,
+                "bits_per_second": 38497036294.209724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000003,
+                  "end": 6.000056,
+                  "seconds": 1.00005304813385,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38365360629.214134,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000003,
+                "end": 6.000056,
+                "seconds": 1.00005304813385,
+                "bytes": 4795924480,
+                "bits_per_second": 38365360629.214134,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000108,
+                  "seconds": 1.0000519752502441,
+                  "bytes": 4746117120,
+                  "bits_per_second": 37966963617.564964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000108,
+                "seconds": 1.0000519752502441,
+                "bytes": 4746117120,
+                "bits_per_second": 37966963617.564964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000108,
+                  "end": 8.000094,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38409876890.660965,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 37,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000108,
+                "end": 8.000094,
+                "seconds": 0.9999859929084778,
+                "bytes": 4801167360,
+                "bits_per_second": 38409876890.660965,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000094,
+                  "end": 9.000078,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38462382079.81445,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000094,
+                "end": 9.000078,
+                "seconds": 0.9999840259552002,
+                "bytes": 4807720960,
+                "bits_per_second": 38462382079.81445,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000078,
+                  "end": 10.00019,
+                  "seconds": 1.0001120567321777,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38111466953.55469,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000078,
+                "end": 10.00019,
+                "seconds": 1.0001120567321777,
+                "bytes": 4764467200,
+                "bits_per_second": 38111466953.55469,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00019,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38301142310.296104,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1202416,
+                  "max_rtt": 37,
+                  "min_rtt": 21,
+                  "mean_rtt": 24,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040372,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38147859493.65223,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00019,
+              "seconds": 10.00019,
+              "bytes": 47877337540,
+              "bits_per_second": 38301142310.296104,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040372,
+              "seconds": 10.040372,
+              "bytes": 47877337540,
+              "bits_per_second": 38147859493.65223,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.579098862767125,
+              "host_user": 0.4361726860977011,
+              "host_system": 51.14293609532062,
+              "remote_total": 44.789642459824776,
+              "remote_user": 1.3832780535675204,
+              "remote_system": 43.40635613187544
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 57026,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:50 UTC",
+              "timesecs": 1711485170
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5283402056,
+                  "bits_per_second": 42266158359.07089,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 5283402056,
+                "bits_per_second": 42266158359.07089,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5276569800,
+                  "bits_per_second": 42212643946.36801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5276569800,
+                "bits_per_second": 42212643946.36801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000023,
+                  "end": 3.000005,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42418808492.11961,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000023,
+                "end": 3.000005,
+                "seconds": 0.9999819993972778,
+                "bytes": 5302255616,
+                "bits_per_second": 42418808492.11961,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.00003,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5176033280,
+                  "bits_per_second": 41407229653.44986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.00003,
+                "seconds": 1.0000250339508057,
+                "bytes": 5176033280,
+                "bits_per_second": 41407229653.44986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00003,
+                  "end": 5.000008,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5233967104,
+                  "bits_per_second": 41872657784.00552,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.00003,
+                "end": 5.000008,
+                "seconds": 0.9999780058860779,
+                "bytes": 5233967104,
+                "bits_per_second": 41872657784.00552,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000008,
+                  "end": 6.000007,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5299765248,
+                  "bits_per_second": 42398164945.16853,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000008,
+                "end": 6.000007,
+                "seconds": 0.9999989867210388,
+                "bytes": 5299765248,
+                "bits_per_second": 42398164945.16853,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000007,
+                  "end": 7.000021,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42417453311.12657,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000007,
+                "end": 7.000021,
+                "seconds": 1.0000139474868774,
+                "bytes": 5302255616,
+                "bits_per_second": 42417453311.12657,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000021,
+                  "end": 8.000026,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 5336727552,
+                  "bits_per_second": 42693606658.070244,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000021,
+                "end": 8.000026,
+                "seconds": 1.0000050067901611,
+                "bytes": 5336727552,
+                "bits_per_second": 42693606658.070244,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000026,
+                  "end": 9.000032,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 5314183168,
+                  "bits_per_second": 42513211945.510376,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000026,
+                "end": 9.000032,
+                "seconds": 1.0000059604644775,
+                "bytes": 5314183168,
+                "bits_per_second": 42513211945.510376,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000018,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 5215485952,
+                  "bits_per_second": 41724472054.49879,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000018,
+                "seconds": 0.9999859929084778,
+                "bytes": 5215485952,
+                "bits_per_second": 41724472054.49879,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040334,
+                  "seconds": 10.040334,
+                  "bytes": 52741693968,
+                  "bits_per_second": 42023856152.99252,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000018,
+                  "seconds": 10.000018,
+                  "bytes": 52740645392,
+                  "bits_per_second": 42192440367.20734,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040334,
+              "seconds": 10.040334,
+              "bytes": 52741693968,
+              "bits_per_second": 42023856152.99252,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000018,
+              "seconds": 10.000018,
+              "bytes": 52740645392,
+              "bits_per_second": 42192440367.20734,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72825614611755,
+              "host_user": 1.7371177997142697,
+              "host_system": 56.991148265535564,
+              "remote_total": 54.64429253795493,
+              "remote_user": 0.4133314501365237,
+              "remote_system": 54.23096108781841
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 43702,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:09 UTC",
+              "timesecs": 1711485189
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1470700168,
+                  "bits_per_second": 11764930954.229,
+                  "retransmits": 1151,
+                  "snd_cwnd": 816888,
+                  "rtt": 591,
+                  "rttvar": 85,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1470700168,
+                "bits_per_second": 11764930954.229,
+                "retransmits": 1151,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1666939764,
+                  "bits_per_second": 13335505394.27101,
+                  "retransmits": 59,
+                  "snd_cwnd": 958428,
+                  "rtt": 636,
+                  "rttvar": 81,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1666939764,
+                "bits_per_second": 13335505394.27101,
+                "retransmits": 59,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1704166784,
+                  "bits_per_second": 13633348086.384787,
+                  "retransmits": 118,
+                  "snd_cwnd": 688828,
+                  "rtt": 360,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1704166784,
+                "bits_per_second": 13633348086.384787,
+                "retransmits": 118,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1593611456,
+                  "bits_per_second": 12748891648,
+                  "retransmits": 128,
+                  "snd_cwnd": 804756,
+                  "rtt": 415,
+                  "rttvar": 1,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1593611456,
+                "bits_per_second": 12748891648,
+                "retransmits": 128,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1778151040,
+                  "bits_per_second": 14225194753.797117,
+                  "retransmits": 49,
+                  "snd_cwnd": 953036,
+                  "rtt": 494,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1778151040,
+                "bits_per_second": 14225194753.797117,
+                "retransmits": 49,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000056,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1775902848,
+                  "bits_per_second": 14207251575.818235,
+                  "retransmits": 79,
+                  "snd_cwnd": 850588,
+                  "rtt": 461,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000056,
+                "seconds": 0.9999979734420776,
+                "bytes": 1775902848,
+                "bits_per_second": 14207251575.818235,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000058,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1780742784,
+                  "bits_per_second": 14245913401.831335,
+                  "retransmits": 108,
+                  "snd_cwnd": 943600,
+                  "rtt": 507,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000058,
+                "seconds": 1.0000020265579224,
+                "bytes": 1780742784,
+                "bits_per_second": 14245913401.831335,
+                "retransmits": 108,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000058,
+                  "end": 8.000058,
+                  "seconds": 1,
+                  "bytes": 1778931136,
+                  "bits_per_second": 14231449088,
+                  "retransmits": 110,
+                  "snd_cwnd": 846544,
+                  "rtt": 461,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000058,
+                "end": 8.000058,
+                "seconds": 1,
+                "bytes": 1778931136,
+                "bits_per_second": 14231449088,
+                "retransmits": 110,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1771323712,
+                  "bits_per_second": 14170589696,
+                  "retransmits": 77,
+                  "snd_cwnd": 830368,
+                  "rtt": 478,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1771323712,
+                "bits_per_second": 14170589696,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000215,
+                  "seconds": 1.0001569986343384,
+                  "bytes": 1773207680,
+                  "bits_per_second": 14183434660.128132,
+                  "retransmits": 120,
+                  "snd_cwnd": 501456,
+                  "rtt": 244,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000215,
+                "seconds": 1.0001569986343384,
+                "bytes": 1773207680,
+                "bits_per_second": 14183434660.128132,
+                "retransmits": 120,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000215,
+                  "seconds": 10.000215,
+                  "bytes": 17093677372,
+                  "bits_per_second": 13674647892.670307,
+                  "retransmits": 1999,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 636,
+                  "min_rtt": 244,
+                  "mean_rtt": 464,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039929,
+                  "seconds": 10.000215,
+                  "bytes": 17090819196,
+                  "bits_per_second": 13618278930.85698,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000215,
+              "seconds": 10.000215,
+              "bytes": 17093677372,
+              "bits_per_second": 13674647892.670307,
+              "retransmits": 1999,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039929,
+              "seconds": 10.039929,
+              "bytes": 17090819196,
+              "bits_per_second": 13618278930.85698,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.005006946322178,
+              "host_user": 0.19271754050004394,
+              "host_system": 12.812299324888505,
+              "remote_total": 23.26438245505795,
+              "remote_user": 0.8376646905752849,
+              "remote_system": 22.426726025964516
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 57004,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:21 UTC",
+              "timesecs": 1711485201
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1720841732,
+                  "bits_per_second": 13765949444.112558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1720841732,
+                "bits_per_second": 13765949444.112558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000017,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 1732854844,
+                  "bits_per_second": 13863393214.483341,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000017,
+                "seconds": 0.9999600052833557,
+                "bytes": 1732854844,
+                "bits_per_second": 13863393214.483341,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000017,
+                  "end": 3.000057,
+                  "seconds": 1.000040054321289,
+                  "bytes": 1691401320,
+                  "bits_per_second": 13530668598.25271,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000017,
+                "end": 3.000057,
+                "seconds": 1.000040054321289,
+                "bytes": 1691401320,
+                "bits_per_second": 13530668598.25271,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000067,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1568036736,
+                  "bits_per_second": 12544168275.963392,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000067,
+                "seconds": 1.0000100135803223,
+                "bytes": 1568036736,
+                "bits_per_second": 12544168275.963392,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000067,
+                  "end": 5.000031,
+                  "seconds": 0.9999639987945557,
+                  "bytes": 1557489984,
+                  "bits_per_second": 12460368460.284851,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000067,
+                "end": 5.000031,
+                "seconds": 0.9999639987945557,
+                "bytes": 1557489984,
+                "bits_per_second": 12460368460.284851,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000045,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900295853.805986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000045,
+                "seconds": 1.0000139474868774,
+                "bytes": 1737561216,
+                "bits_per_second": 13900295853.805986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000045,
+                  "end": 7.000026,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1735555392,
+                  "bits_per_second": 13884707138.178734,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000045,
+                "end": 7.000026,
+                "seconds": 0.9999809861183167,
+                "bytes": 1735555392,
+                "bits_per_second": 13884707138.178734,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000033,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1590631612,
+                  "bits_per_second": 12724963396.90308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000033,
+                "seconds": 1.0000070333480835,
+                "bytes": 1590631612,
+                "bits_per_second": 12724963396.90308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000033,
+                  "end": 9.000026,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1589841984,
+                  "bits_per_second": 12718824569.819391,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000033,
+                "end": 9.000026,
+                "seconds": 0.9999930262565613,
+                "bytes": 1589841984,
+                "bits_per_second": 12718824569.819391,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000026,
+                  "seconds": 1,
+                  "bytes": 1480498380,
+                  "bits_per_second": 11843987040,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000026,
+                "seconds": 1,
+                "bytes": 1480498380,
+                "bits_per_second": 11843987040,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03968,
+                  "seconds": 10.03968,
+                  "bytes": 16408142512,
+                  "bits_per_second": 13074633862.43386,
+                  "retransmits": 1734,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000026,
+                  "seconds": 10.000026,
+                  "bytes": 16404713200,
+                  "bits_per_second": 13123736438.285261,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03968,
+              "seconds": 10.03968,
+              "bytes": 16408142512,
+              "bits_per_second": 13074633862.43386,
+              "retransmits": 1734,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000026,
+              "seconds": 10.000026,
+              "bytes": 16404713200,
+              "bits_per_second": 13123736438.285261,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.064632328384384,
+              "host_user": 1.162207899423042,
+              "host_system": 24.902424428961346,
+              "remote_total": 11.69062967191739,
+              "remote_user": 0.12009331046577057,
+              "remote_system": 11.570546012927187
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56708,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:39 UTC",
+              "timesecs": 1711485219
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000229,
+                  "seconds": 1.000229001045227,
+                  "bytes": 3386293120,
+                  "bits_per_second": 27084142663.02109,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000229,
+                "seconds": 1.000229001045227,
+                "bytes": 3386293120,
+                "bits_per_second": 27084142663.02109,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000229,
+                  "end": 2.000133,
+                  "seconds": 0.9999039769172668,
+                  "bytes": 3393454080,
+                  "bits_per_second": 27150239689.71195,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000229,
+                "end": 2.000133,
+                "seconds": 0.9999039769172668,
+                "bytes": 3393454080,
+                "bits_per_second": 27150239689.71195,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000133,
+                  "end": 3.000277,
+                  "seconds": 1.0001440048217773,
+                  "bytes": 3402629120,
+                  "bits_per_second": 27217113564.41186,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000133,
+                "end": 3.000277,
+                "seconds": 1.0001440048217773,
+                "bytes": 3402629120,
+                "bits_per_second": 27217113564.41186,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000277,
+                  "end": 4.000095,
+                  "seconds": 0.9998180270195007,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27309888701.844177,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000277,
+                "end": 4.000095,
+                "seconds": 0.9998180270195007,
+                "bytes": 3413114880,
+                "bits_per_second": 27309888701.844177,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000095,
+                  "end": 5.000135,
+                  "seconds": 1.000040054321289,
+                  "bytes": 3415736320,
+                  "bits_per_second": 27324796083.8385,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000095,
+                "end": 5.000135,
+                "seconds": 1.000040054321289,
+                "bytes": 3415736320,
+                "bits_per_second": 27324796083.8385,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000135,
+                  "end": 6.000236,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27302162333.34541,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000135,
+                "end": 6.000236,
+                "seconds": 1.0001009702682495,
+                "bytes": 3413114880,
+                "bits_per_second": 27302162333.34541,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000236,
+                  "end": 7.000377,
+                  "seconds": 1.0001410245895386,
+                  "bytes": 3403939840,
+                  "bits_per_second": 27227678947.752304,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000236,
+                "end": 7.000377,
+                "seconds": 1.0001410245895386,
+                "bytes": 3403939840,
+                "bits_per_second": 27227678947.752304,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000377,
+                  "end": 8.000122,
+                  "seconds": 0.9997450113296509,
+                  "bytes": 3405250560,
+                  "bits_per_second": 27248952654.205704,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000377,
+                "end": 8.000122,
+                "seconds": 0.9997450113296509,
+                "bytes": 3405250560,
+                "bits_per_second": 27248952654.205704,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000122,
+                  "end": 9.000175,
+                  "seconds": 1.00005304813385,
+                  "bytes": 3457679360,
+                  "bits_per_second": 27659967570.33804,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 32,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000122,
+                "end": 9.000175,
+                "seconds": 1.00005304813385,
+                "bytes": 3457679360,
+                "bits_per_second": 27659967570.33804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000175,
+                  "end": 10.000275,
+                  "seconds": 1.000100016593933,
+                  "bytes": 3503554560,
+                  "bits_per_second": 28025633451.599354,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 30,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000175,
+                "end": 10.000275,
+                "seconds": 1.000100016593933,
+                "bytes": 3503554560,
+                "bits_per_second": 28025633451.599354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000275,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27355061111.819424,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 798016,
+                  "max_rtt": 35,
+                  "min_rtt": 30,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040107,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27246535695.28691,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000275,
+              "seconds": 10.000275,
+              "bytes": 34194766720,
+              "bits_per_second": 27355061111.819424,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040107,
+              "seconds": 10.040107,
+              "bytes": 34194766720,
+              "bits_per_second": 27246535695.28691,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.44527815243438,
+              "host_user": 0.4874417118707169,
+              "host_system": 83.95785625929561,
+              "remote_total": 37.5809576369255,
+              "remote_user": 1.2945095444412822,
+              "remote_system": 36.286448092484214
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37086,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:51 UTC",
+              "timesecs": 1711485231
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000019,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 4331032904,
+                  "bits_per_second": 34647606511.66746,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000019,
+                "seconds": 1.0000189542770386,
+                "bytes": 4331032904,
+                "bits_per_second": 34647606511.66746,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000019,
+                  "end": 2.000003,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4384751616,
+                  "bits_per_second": 35078573274.701004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000019,
+                "end": 2.000003,
+                "seconds": 0.9999840259552002,
+                "bytes": 4384751616,
+                "bits_per_second": 35078573274.701004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000003,
+                  "end": 3.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4398120960,
+                  "bits_per_second": 35184405642.72801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000003,
+                "end": 3.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 4398120960,
+                "bits_per_second": 35184405642.72801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000018,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4399955968,
+                  "bits_per_second": 35199683411.09864,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000018,
+                "seconds": 0.9999989867210388,
+                "bytes": 4399955968,
+                "bits_per_second": 35199683411.09864,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000002,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4368367616,
+                  "bits_per_second": 34947499180.91756,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000002,
+                "seconds": 0.9999840259552002,
+                "bytes": 4368367616,
+                "bits_per_second": 34947499180.91756,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000002,
+                  "end": 6.000018,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4274782208,
+                  "bits_per_second": 34197711388.226234,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000002,
+                "end": 6.000018,
+                "seconds": 1.0000159740447998,
+                "bytes": 4274782208,
+                "bits_per_second": 34197711388.226234,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000016,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 4378853376,
+                  "bits_per_second": 35030898000.14387,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000016,
+                "seconds": 0.9999979734420776,
+                "bytes": 4378853376,
+                "bits_per_second": 35030898000.14387,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000016,
+                  "end": 8.000018,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 4318953472,
+                  "bits_per_second": 34551557755.2669,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000016,
+                "end": 8.000018,
+                "seconds": 1.0000020265579224,
+                "bytes": 4318953472,
+                "bits_per_second": 34551557755.2669,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000018,
+                  "end": 9.000035,
+                  "seconds": 1.0000170469284058,
+                  "bytes": 4416208896,
+                  "bits_per_second": 35329068915.89155,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000018,
+                "end": 9.000035,
+                "seconds": 1.0000170469284058,
+                "bytes": 4416208896,
+                "bits_per_second": 35329068915.89155,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000035,
+                  "end": 10.00001,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 4437573632,
+                  "bits_per_second": 35501475682.14291,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000035,
+                "end": 10.00001,
+                "seconds": 0.9999750256538391,
+                "bytes": 4437573632,
+                "bits_per_second": 35501475682.14291,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040164,
+                  "seconds": 10.040164,
+                  "bytes": 43710042440,
+                  "bits_per_second": 34828150169.65858,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00001,
+                  "seconds": 10.00001,
+                  "bytes": 43708600648,
+                  "bits_per_second": 34966845551.55445,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040164,
+              "seconds": 10.040164,
+              "bytes": 43710042440,
+              "bits_per_second": 34828150169.65858,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00001,
+              "seconds": 10.00001,
+              "bytes": 43708600648,
+              "bits_per_second": 34966845551.55445,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.26294493237891,
+              "host_user": 1.8116036545309533,
+              "host_system": 89.45135119667133,
+              "remote_total": 44.14246868282316,
+              "remote_user": 0.32552835005268926,
+              "remote_system": 43.816940332770464
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55424,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:09 UTC",
+              "timesecs": 1711485249
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000296,
+                  "seconds": 1.0002959966659546,
+                  "bytes": 1501175364,
+                  "bits_per_second": 12005849220.658731,
+                  "retransmits": 40,
+                  "snd_cwnd": 641648,
+                  "rtt": 391,
+                  "rttvar": 37,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000296,
+                "seconds": 1.0002959966659546,
+                "bytes": 1501175364,
+                "bits_per_second": 12005849220.658731,
+                "retransmits": 40,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000296,
+                  "end": 2.000231,
+                  "seconds": 0.99993497133255,
+                  "bytes": 1529610240,
+                  "bits_per_second": 12237677719.874805,
+                  "retransmits": 12,
+                  "snd_cwnd": 787232,
+                  "rtt": 223,
+                  "rttvar": 31,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000296,
+                "end": 2.000231,
+                "seconds": 0.99993497133255,
+                "bytes": 1529610240,
+                "bits_per_second": 12237677719.874805,
+                "retransmits": 12,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000231,
+                  "end": 3.000429,
+                  "seconds": 1.0001980066299438,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12286877836.727018,
+                  "retransmits": 13,
+                  "snd_cwnd": 655128,
+                  "rtt": 228,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000231,
+                "end": 3.000429,
+                "seconds": 1.0001980066299438,
+                "bytes": 1536163840,
+                "bits_per_second": 12286877836.727018,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000429,
+                  "end": 4.000044,
+                  "seconds": 0.9996150135993958,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12367472348.664085,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 193,
+                  "rttvar": 25,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000429,
+                "end": 4.000044,
+                "seconds": 0.9996150135993958,
+                "bytes": 1545338880,
+                "bits_per_second": 12367472348.664085,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000044,
+                  "end": 5.000092,
+                  "seconds": 1.000048041343689,
+                  "bytes": 1523056640,
+                  "bits_per_second": 12183867790.62001,
+                  "retransmits": 2,
+                  "snd_cwnd": 936860,
+                  "rtt": 606,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000044,
+                "end": 5.000092,
+                "seconds": 1.000048041343689,
+                "bytes": 1523056640,
+                "bits_per_second": 12183867790.62001,
+                "retransmits": 2,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000092,
+                  "end": 6.000681,
+                  "seconds": 1.0005890130996704,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12376392702.57152,
+                  "retransmits": 6,
+                  "snd_cwnd": 829020,
+                  "rtt": 197,
+                  "rttvar": 54,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000092,
+                "end": 6.000681,
+                "seconds": 1.0005890130996704,
+                "bytes": 1547960320,
+                "bits_per_second": 12376392702.57152,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000681,
+                  "end": 7.000548,
+                  "seconds": 0.9998670220375061,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12385329535.886497,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 218,
+                  "rttvar": 40,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000681,
+                "end": 7.000548,
+                "seconds": 0.9998670220375061,
+                "bytes": 1547960320,
+                "bits_per_second": 12385329535.886497,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000548,
+                  "end": 8.000077,
+                  "seconds": 0.9995290040969849,
+                  "bytes": 1534853120,
+                  "bits_per_second": 12284610961.43297,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 200,
+                  "rttvar": 33,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000548,
+                "end": 8.000077,
+                "seconds": 0.9995290040969849,
+                "bytes": 1534853120,
+                "bits_per_second": 12284610961.43297,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000077,
+                  "end": 9.000416,
+                  "seconds": 1.0003390312194824,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12285145672.081276,
+                  "retransmits": 0,
+                  "snd_cwnd": 934164,
+                  "rtt": 220,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000077,
+                "end": 9.000416,
+                "seconds": 1.0003390312194824,
+                "bytes": 1536163840,
+                "bits_per_second": 12285145672.081276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000416,
+                  "end": 10.00071,
+                  "seconds": 1.0002939701080322,
+                  "bytes": 1544028160,
+                  "bits_per_second": 12348595162.146137,
+                  "retransmits": 50,
+                  "snd_cwnd": 776448,
+                  "rtt": 184,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000416,
+                "end": 10.00071,
+                "seconds": 1.0002939701080322,
+                "bytes": 1544028160,
+                "bits_per_second": 12348595162.146137,
+                "retransmits": 50,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00071,
+                  "seconds": 10.00071,
+                  "bytes": 15346310724,
+                  "bits_per_second": 12276176970.635086,
+                  "retransmits": 123,
+                  "max_snd_cwnd": 936860,
+                  "max_rtt": 606,
+                  "min_rtt": 184,
+                  "mean_rtt": 266,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040277,
+                  "seconds": 10.00071,
+                  "bytes": 15346244356,
+                  "bits_per_second": 12227745793.069256,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00071,
+              "seconds": 10.00071,
+              "bytes": 15346310724,
+              "bits_per_second": 12276176970.635086,
+              "retransmits": 123,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040277,
+              "seconds": 10.040277,
+              "bytes": 15346244356,
+              "bits_per_second": 12227745793.069256,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 95.82562437024121,
+              "host_user": 0.2560031758234491,
+              "host_system": 95.56962119441776,
+              "remote_total": 24.102997438800752,
+              "remote_user": 1.0351409018247604,
+              "remote_system": 23.06785653697599
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39456,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:21 UTC",
+              "timesecs": 1711485261
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1697801956,
+                  "bits_per_second": 13582334690.976553,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1697801956,
+                "bits_per_second": 13582334690.976553,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000057,
+                  "seconds": 1.0000510215759277,
+                  "bytes": 1744419840,
+                  "bits_per_second": 13954646731.932222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000057,
+                "seconds": 1.0000510215759277,
+                "bytes": 1744419840,
+                "bits_per_second": 13954646731.932222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000015,
+                  "seconds": 0.9999579787254333,
+                  "bytes": 1748195168,
+                  "bits_per_second": 13986149059.809772,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000015,
+                "seconds": 0.9999579787254333,
+                "bytes": 1748195168,
+                "bits_per_second": 13986149059.809772,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1734067200,
+                  "bits_per_second": 13872357345.188877,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1734067200,
+                "bits_per_second": 13872357345.188877,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1729473216,
+                  "bits_per_second": 13835744494.268211,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 1729473216,
+                "bits_per_second": 13835744494.268211,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000014,
+                  "seconds": 0.999983012676239,
+                  "bytes": 1727920320,
+                  "bits_per_second": 13823597385.924335,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000014,
+                "seconds": 0.999983012676239,
+                "bytes": 1727920320,
+                "bits_per_second": 13823597385.924335,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000014,
+                  "end": 7.000057,
+                  "seconds": 1.0000430345535278,
+                  "bytes": 1720414656,
+                  "bits_per_second": 13762724975.275362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000014,
+                "end": 7.000057,
+                "seconds": 1.0000430345535278,
+                "bytes": 1720414656,
+                "bits_per_second": 13762724975.275362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000012,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 1731396632,
+                  "bits_per_second": 13851796407.710308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000012,
+                "seconds": 0.9999549984931946,
+                "bytes": 1731396632,
+                "bits_per_second": 13851796407.710308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000012,
+                  "end": 9.000057,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731026112,
+                  "bits_per_second": 13847586559.1197,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000012,
+                "end": 9.000057,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731026112,
+                "bits_per_second": 13847586559.1197,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000057,
+                  "end": 10.000029,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 1741314048,
+                  "bits_per_second": 13930902646.856724,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000057,
+                "end": 10.000029,
+                "seconds": 0.9999719858169556,
+                "bytes": 1741314048,
+                "bits_per_second": 13930902646.856724,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039465,
+                  "seconds": 10.039465,
+                  "bytes": 17308229084,
+                  "bits_per_second": 13792152537.211893,
+                  "retransmits": 2195,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000029,
+                  "seconds": 10.000029,
+                  "bytes": 17306029148,
+                  "bits_per_second": 13844783168.528812,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039465,
+              "seconds": 10.039465,
+              "bytes": 17308229084,
+              "bits_per_second": 13792152537.211893,
+              "retransmits": 2195,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000029,
+              "seconds": 10.000029,
+              "bytes": 17306029148,
+              "bits_per_second": 13844783168.528812,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.47684113065824,
+              "host_user": 1.8968527601361653,
+              "host_system": 42.57999828989936,
+              "remote_total": 12.529305328982618,
+              "remote_user": 0.09332895016906215,
+              "remote_system": 12.435986036196645
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56016,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:38 UTC",
+              "timesecs": 1711485278
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000293,
+                  "seconds": 1.0002930164337158,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25745482710.471886,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000293,
+                "seconds": 1.0002930164337158,
+                "bytes": 3219128320,
+                "bits_per_second": 25745482710.471886,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000293,
+                  "end": 2.000138,
+                  "seconds": 0.999845027923584,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25757018178.58942,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 37,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000293,
+                "end": 2.000138,
+                "seconds": 0.999845027923584,
+                "bytes": 3219128320,
+                "bits_per_second": 25757018178.58942,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000138,
+                  "end": 3.000088,
+                  "seconds": 0.9999499917030334,
+                  "bytes": 3282042880,
+                  "bits_per_second": 26257656140.665928,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000138,
+                "end": 3.000088,
+                "seconds": 0.9999499917030334,
+                "bytes": 3282042880,
+                "bits_per_second": 26257656140.665928,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000088,
+                  "end": 4.000243,
+                  "seconds": 1.000154972076416,
+                  "bytes": 3465543680,
+                  "bits_per_second": 27720053605.734356,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000088,
+                "end": 4.000243,
+                "seconds": 1.000154972076416,
+                "bytes": 3465543680,
+                "bits_per_second": 27720053605.734356,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000243,
+                  "end": 5.000101,
+                  "seconds": 0.999858021736145,
+                  "bytes": 3481272320,
+                  "bits_per_second": 27854133241.47881,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000243,
+                "end": 5.000101,
+                "seconds": 0.999858021736145,
+                "bytes": 3481272320,
+                "bits_per_second": 27854133241.47881,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000101,
+                  "end": 6.000015,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 3489136640,
+                  "bits_per_second": 27915494117.75862,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000101,
+                "end": 6.000015,
+                "seconds": 0.9999139904975891,
+                "bytes": 3489136640,
+                "bits_per_second": 27915494117.75862,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000015,
+                  "end": 7.000294,
+                  "seconds": 1.0002789497375488,
+                  "bytes": 3472097280,
+                  "bits_per_second": 27769032075.790474,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000015,
+                "end": 7.000294,
+                "seconds": 1.0002789497375488,
+                "bytes": 3472097280,
+                "bits_per_second": 27769032075.790474,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000294,
+                  "end": 8.000249,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 3482583040,
+                  "bits_per_second": 27861918148.299164,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000294,
+                "end": 8.000249,
+                "seconds": 0.9999549984931946,
+                "bytes": 3482583040,
+                "bits_per_second": 27861918148.299164,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000249,
+                  "end": 9.000268,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 3388211200,
+                  "bits_per_second": 27105175840.98793,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000249,
+                "end": 9.000268,
+                "seconds": 1.0000189542770386,
+                "bytes": 3388211200,
+                "bits_per_second": 27105175840.98793,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000268,
+                  "end": 10.000366,
+                  "seconds": 1.0000979900360107,
+                  "bytes": 3389521920,
+                  "bits_per_second": 27113518505.345284,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 31,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000268,
+                "end": 10.000366,
+                "seconds": 1.0000979900360107,
+                "bytes": 3389521920,
+                "bits_per_second": 27113518505.345284,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000366,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27109940256.186626,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 663216,
+                  "max_rtt": 37,
+                  "min_rtt": 31,
+                  "mean_rtt": 33,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039647,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27003870235.676613,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000366,
+              "seconds": 10.000366,
+              "bytes": 33888665600,
+              "bits_per_second": 27109940256.186626,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039647,
+              "seconds": 10.039647,
+              "bytes": 33888665600,
+              "bits_per_second": 27003870235.676613,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.6366144037512,
+              "host_user": 0.5079154773387307,
+              "host_system": 98.12868897353042,
+              "remote_total": 69.33475570009895,
+              "remote_user": 1.8358332803622874,
+              "remote_system": 67.4989133777374
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 41272,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:50 UTC",
+              "timesecs": 1711485290
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000015,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 3679605064,
+                  "bits_per_second": 29436398366.39084,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000015,
+                "seconds": 1.0000150203704834,
+                "bytes": 3679605064,
+                "bits_per_second": 29436398366.39084,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000015,
+                  "end": 2.00001,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 3648388804,
+                  "bits_per_second": 29187256566.469006,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000015,
+                "end": 2.00001,
+                "seconds": 0.9999949932098389,
+                "bytes": 3648388804,
+                "bits_per_second": 29187256566.469006,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000028,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 3632922940,
+                  "bits_per_second": 29062860370.99649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000028,
+                "seconds": 1.0000180006027222,
+                "bytes": 3632922940,
+                "bits_per_second": 29062860370.99649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000028,
+                  "end": 4.000024,
+                  "seconds": 0.9999960064888,
+                  "bytes": 3643932672,
+                  "bits_per_second": 29151577793.152412,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000028,
+                "end": 4.000024,
+                "seconds": 0.9999960064888,
+                "bytes": 3643932672,
+                "bits_per_second": 29151577793.152412,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000024,
+                  "end": 5.000031,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 3619028992,
+                  "bits_per_second": 28952028306.307198,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000024,
+                "end": 5.000031,
+                "seconds": 1.0000070333480835,
+                "bytes": 3619028992,
+                "bits_per_second": 28952028306.307198,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000037,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 3631349760,
+                  "bits_per_second": 29050624924.782085,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000037,
+                "seconds": 1.0000059604644775,
+                "bytes": 3631349760,
+                "bits_per_second": 29050624924.782085,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000037,
+                  "end": 7.000025,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 3610509312,
+                  "bits_per_second": 28884420546.770874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000037,
+                "end": 7.000025,
+                "seconds": 0.9999880194664001,
+                "bytes": 3610509312,
+                "bits_per_second": 28884420546.770874,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000025,
+                  "end": 8.000022,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3608674304,
+                  "bits_per_second": 28869480469.756413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000025,
+                "end": 8.000022,
+                "seconds": 0.9999970197677612,
+                "bytes": 3608674304,
+                "bits_per_second": 28869480469.756413,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000022,
+                  "end": 9.000038,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 3623223296,
+                  "bits_per_second": 28985323355.146187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000022,
+                "end": 9.000038,
+                "seconds": 1.0000159740447998,
+                "bytes": 3623223296,
+                "bits_per_second": 28985323355.146187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000038,
+                  "end": 10.000021,
+                  "seconds": 0.999983012676239,
+                  "bytes": 3621519360,
+                  "bits_per_second": 28972647047.73561,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000038,
+                "end": 10.000021,
+                "seconds": 0.999983012676239,
+                "bytes": 3621519360,
+                "bits_per_second": 28972647047.73561,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039809,
+                  "seconds": 10.039809,
+                  "bytes": 36320203080,
+                  "bits_per_second": 28940951430.45052,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000021,
+                  "seconds": 10.000021,
+                  "bytes": 36319154504,
+                  "bits_per_second": 29055262587.148567,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039809,
+              "seconds": 10.039809,
+              "bytes": 36320203080,
+              "bits_per_second": 28940951430.45052,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000021,
+              "seconds": 10.000021,
+              "bytes": 36319154504,
+              "bits_per_second": 29055262587.148567,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.40432984604324,
+              "host_user": 2.1048623181527053,
+              "host_system": 84.29947744708186,
+              "remote_total": 96.37010529501002,
+              "remote_user": 0.5200516733573617,
+              "remote_system": 95.85006329541284
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 35114,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:07 UTC",
+              "timesecs": 1711485307
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2927638472,
+                  "bits_per_second": 23419748144.30112,
+                  "retransmits": 368,
+                  "snd_cwnd": 2701392,
+                  "rtt": 911,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 2927638472,
+                "bits_per_second": 23419748144.30112,
+                "retransmits": 368,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000132,
+                  "seconds": 1.000074028968811,
+                  "bytes": 2915041280,
+                  "bits_per_second": 23318603987.79267,
+                  "retransmits": 202,
+                  "snd_cwnd": 2724308,
+                  "rtt": 935,
+                  "rttvar": 42,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000132,
+                "seconds": 1.000074028968811,
+                "bytes": 2915041280,
+                "bits_per_second": 23318603987.79267,
+                "retransmits": 202,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000132,
+                  "end": 3.000059,
+                  "seconds": 0.9999269843101501,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416411845.464706,
+                  "retransmits": 13,
+                  "snd_cwnd": 2744528,
+                  "rtt": 900,
+                  "rttvar": 30,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000132,
+                "end": 3.000059,
+                "seconds": 0.9999269843101501,
+                "bytes": 2926837760,
+                "bits_per_second": 23416411845.464706,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000057,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23404263750.09612,
+                  "retransmits": 6,
+                  "snd_cwnd": 2345520,
+                  "rtt": 798,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000057,
+                "seconds": 0.9999979734420776,
+                "bytes": 2925527040,
+                "bits_per_second": 23404263750.09612,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000144,
+                  "seconds": 1.000087022781372,
+                  "bytes": 2929459200,
+                  "bits_per_second": 23433634339.962082,
+                  "retransmits": 4,
+                  "snd_cwnd": 2325300,
+                  "rtt": 778,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000144,
+                "seconds": 1.000087022781372,
+                "bytes": 2929459200,
+                "bits_per_second": 23433634339.962082,
+                "retransmits": 4,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000144,
+                  "end": 6.000058,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416716140.103306,
+                  "retransmits": 0,
+                  "snd_cwnd": 3097704,
+                  "rtt": 1023,
+                  "rttvar": 3,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000144,
+                "end": 6.000058,
+                "seconds": 0.9999139904975891,
+                "bytes": 2926837760,
+                "bits_per_second": 23416716140.103306,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000149,
+                  "seconds": 1.0000909566879272,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23423057356.281742,
+                  "retransmits": 0,
+                  "snd_cwnd": 3165104,
+                  "rtt": 1109,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000149,
+                "seconds": 1.0000909566879272,
+                "bytes": 2928148480,
+                "bits_per_second": 23423057356.281742,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000149,
+                  "end": 8.000068,
+                  "seconds": 0.9999189972877502,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416598888.021595,
+                  "retransmits": 711,
+                  "snd_cwnd": 2543676,
+                  "rtt": 841,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000149,
+                "end": 8.000068,
+                "seconds": 0.9999189972877502,
+                "bytes": 2926837760,
+                "bits_per_second": 23416598888.021595,
+                "retransmits": 711,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000068,
+                  "end": 9.000241,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23421136623.249817,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 1059,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000068,
+                "end": 9.000241,
+                "seconds": 1.0001729726791382,
+                "bytes": 2928148480,
+                "bits_per_second": 23421136623.249817,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000241,
+                  "end": 10.000231,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414936547.34786,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 781,
+                  "rttvar": 78,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000241,
+                "end": 10.000231,
+                "seconds": 0.9999899864196777,
+                "bytes": 2926837760,
+                "bits_per_second": 23414936547.34786,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000231,
+                  "seconds": 10.000231,
+                  "bytes": 29261313992,
+                  "bits_per_second": 23408510457.008446,
+                  "retransmits": 1304,
+                  "max_snd_cwnd": 3165104,
+                  "max_rtt": 1109,
+                  "min_rtt": 778,
+                  "mean_rtt": 913,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000231,
+                  "bytes": 29260124328,
+                  "bits_per_second": 23314036650.131382,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000231,
+              "seconds": 10.000231,
+              "bytes": 29261313992,
+              "bits_per_second": 23408510457.008446,
+              "retransmits": 1304,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 29260124328,
+              "bits_per_second": 23314036650.131382,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.97762289166434,
+              "host_user": 0.5691962216451614,
+              "host_system": 34.40843658477508,
+              "remote_total": 62.9251445256492,
+              "remote_user": 2.6124474135751976,
+              "remote_system": 60.31269711207401
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55052,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:19 UTC",
+              "timesecs": 1711485319
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2924870228,
+                  "bits_per_second": 23398635471.838806,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 2924870228,
+                "bits_per_second": 23398635471.838806,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000028,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2928633648,
+                  "bits_per_second": 23428742411.922653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000028,
+                "seconds": 1.0000139474868774,
+                "bytes": 2928633648,
+                "bits_per_second": 23428742411.922653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000028,
+                  "end": 3.000026,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2912575888,
+                  "bits_per_second": 23300654324.125618,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000028,
+                "end": 3.000026,
+                "seconds": 0.9999979734420776,
+                "bytes": 2912575888,
+                "bits_per_second": 23300654324.125618,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000009,
+                  "seconds": 0.999983012676239,
+                  "bytes": 2928793176,
+                  "bits_per_second": 23430743433.62467,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000009,
+                "seconds": 0.999983012676239,
+                "bytes": 2928793176,
+                "bits_per_second": 23430743433.62467,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000009,
+                  "end": 5.000024,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2927518936,
+                  "bits_per_second": 23419799713.93165,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000009,
+                "end": 5.000024,
+                "seconds": 1.0000150203704834,
+                "bytes": 2927518936,
+                "bits_per_second": 23419799713.93165,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000024,
+                  "end": 6.000039,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2928627108,
+                  "bits_per_second": 23428664956.77242,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000024,
+                "end": 6.000039,
+                "seconds": 1.0000150203704834,
+                "bytes": 2928627108,
+                "bits_per_second": 23428664956.77242,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000039,
+                  "end": 7.000044,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2924520712,
+                  "bits_per_second": 23396048556.894276,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000039,
+                "end": 7.000044,
+                "seconds": 1.0000050067901611,
+                "bytes": 2924520712,
+                "bits_per_second": 23396048556.894276,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000044,
+                  "end": 8.00003,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 2928023612,
+                  "bits_per_second": 23424517005.353558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000044,
+                "end": 8.00003,
+                "seconds": 0.9999859929084778,
+                "bytes": 2928023612,
+                "bits_per_second": 23424517005.353558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000029,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927982060,
+                  "bits_per_second": 23423880214.92501,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000029,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927982060,
+                "bits_per_second": 23423880214.92501,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000013,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2927753088,
+                  "bits_per_second": 23422398854.44862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000013,
+                "seconds": 0.9999840259552002,
+                "bytes": 2927753088,
+                "bits_per_second": 23422398854.44862,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039882,
+                  "seconds": 10.039882,
+                  "bytes": 29263263664,
+                  "bits_per_second": 23317615616.597885,
+                  "retransmits": 2270,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000013,
+                  "seconds": 10.000013,
+                  "bytes": 29259298456,
+                  "bits_per_second": 23407408335.169167,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039882,
+              "seconds": 10.039882,
+              "bytes": 29263263664,
+              "bits_per_second": 23317615616.597885,
+              "retransmits": 2270,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000013,
+              "seconds": 10.000013,
+              "bytes": 29259298456,
+              "bits_per_second": 23407408335.169167,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 88.6667781634535,
+              "host_user": 2.169277119907057,
+              "host_system": 86.4975109631894,
+              "remote_total": 22.440235970749637,
+              "remote_user": 0.4127789042736779,
+              "remote_system": 22.027466720316273
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 50458,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:37 UTC",
+              "timesecs": 1711485337
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000278,
+                  "seconds": 1.0002779960632324,
+                  "bytes": 3395979324,
+                  "bits_per_second": 27160284139.932823,
+                  "retransmits": 0,
+                  "snd_cwnd": 884288,
+                  "rtt": 40,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000278,
+                "seconds": 1.0002779960632324,
+                "bytes": 3395979324,
+                "bits_per_second": 27160284139.932823,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000278,
+                  "end": 2.000255,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27473323289.542732,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000278,
+                "end": 2.000255,
+                "seconds": 0.9999769926071167,
+                "bytes": 3434086400,
+                "bits_per_second": 27473323289.542732,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000255,
+                  "end": 3.000046,
+                  "seconds": 0.9997910261154175,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530873233.52556,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000255,
+                "end": 3.000046,
+                "seconds": 0.9997910261154175,
+                "bytes": 3440640000,
+                "bits_per_second": 27530873233.52556,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000267,
+                  "seconds": 1.0002210140228271,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27298885603.47408,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000267,
+                "seconds": 1.0002210140228271,
+                "bytes": 3413114880,
+                "bits_per_second": 27298885603.47408,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000044,
+                  "seconds": 0.9997770190238953,
+                  "bytes": 3420979200,
+                  "bits_per_second": 27373937467.296288,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000044,
+                "seconds": 0.9997770190238953,
+                "bytes": 3420979200,
+                "bits_per_second": 27373937467.296288,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000044,
+                  "end": 6.000099,
+                  "seconds": 1.000054955482483,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27523607426.874187,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000044,
+                "end": 6.000099,
+                "seconds": 1.000054955482483,
+                "bytes": 3440640000,
+                "bits_per_second": 27523607426.874187,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000099,
+                  "end": 7.000285,
+                  "seconds": 1.0001859664916992,
+                  "bytes": 3441950720,
+                  "bits_per_second": 27530486012.101555,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000099,
+                "end": 7.000285,
+                "seconds": 1.0001859664916992,
+                "bytes": 3441950720,
+                "bits_per_second": 27530486012.101555,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000285,
+                  "end": 8.000245,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27526220903.40532,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000285,
+                "end": 8.000245,
+                "seconds": 0.9999600052833557,
+                "bytes": 3440640000,
+                "bits_per_second": 27526220903.40532,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000245,
+                  "end": 9.000034,
+                  "seconds": 0.9997889995574951,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530929038.209633,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 33,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000245,
+                "end": 9.000034,
+                "seconds": 0.9997889995574951,
+                "bytes": 3440640000,
+                "bits_per_second": 27530929038.209633,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000143,
+                  "seconds": 1.0001089572906494,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27469698176.111774,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000143,
+                "seconds": 1.0001089572906494,
+                "bytes": 3434086400,
+                "bits_per_second": 27469698176.111774,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000143,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27441813121.272366,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1074356,
+                  "max_rtt": 40,
+                  "min_rtt": 31,
+                  "mean_rtt": 34,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039944,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27333026498.155766,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000143,
+              "seconds": 10.000143,
+              "bytes": 34302756924,
+              "bits_per_second": 27441813121.272366,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039944,
+              "seconds": 10.039944,
+              "bytes": 34302756924,
+              "bits_per_second": 27333026498.155766,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.72291319227105,
+              "host_user": 0.5304700943978504,
+              "host_system": 84.19243318754582,
+              "remote_total": 37.30641845607046,
+              "remote_user": 1.3600734652179878,
+              "remote_system": 35.946344990852474
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 53048,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:49 UTC",
+              "timesecs": 1711485349
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000028,
+                  "seconds": 1.0000280141830444,
+                  "bytes": 4393816392,
+                  "bits_per_second": 35149546450.171814,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000028,
+                "seconds": 1.0000280141830444,
+                "bytes": 4393816392,
+                "bits_per_second": 35149546450.171814,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000028,
+                  "end": 2.000009,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159421797.086105,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000028,
+                "end": 2.000009,
+                "seconds": 0.9999809861183167,
+                "bytes": 4394844160,
+                "bits_per_second": 35159421797.086105,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000006,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4315414528,
+                  "bits_per_second": 34523419111.80663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000006,
+                "seconds": 0.9999970197677612,
+                "bytes": 4315414528,
+                "bits_per_second": 34523419111.80663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000006,
+                  "end": 4.000048,
+                  "seconds": 1.0000419616699219,
+                  "bytes": 4349886464,
+                  "bits_per_second": 34797631545.271034,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000006,
+                "end": 4.000048,
+                "seconds": 1.0000419616699219,
+                "bytes": 4349886464,
+                "bits_per_second": 34797631545.271034,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000048,
+                  "end": 5.000028,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4430495744,
+                  "bits_per_second": 35444675808.21641,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000048,
+                "end": 5.000028,
+                "seconds": 0.9999799728393555,
+                "bytes": 4430495744,
+                "bits_per_second": 35444675808.21641,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 4407427072,
+                  "bits_per_second": 35259311495.06316,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 4407427072,
+                "bits_per_second": 35259311495.06316,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000031,
+                  "end": 7.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 4397727744,
+                  "bits_per_second": 35182595762.019264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000031,
+                "end": 7.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 4397727744,
+                "bits_per_second": 35182595762.019264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000027,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4317599700,
+                  "bits_per_second": 34540175856.016464,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000027,
+                "seconds": 1.0000180006027222,
+                "bytes": 4317599700,
+                "bits_per_second": 34540175856.016464,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000027,
+                  "end": 9.000013,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159245758.77319,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000027,
+                "end": 9.000013,
+                "seconds": 0.9999859929084778,
+                "bytes": 4394844160,
+                "bits_per_second": 35159245758.77319,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000013,
+                  "end": 10.000067,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4418043904,
+                  "bits_per_second": 35342442676.19047,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000013,
+                "end": 10.000067,
+                "seconds": 1.0000540018081665,
+                "bytes": 4418043904,
+                "bits_per_second": 35342442676.19047,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040332,
+                  "seconds": 10.040332,
+                  "bytes": 43821410588,
+                  "bits_per_second": 34916304032.97421,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 43820099868,
+                  "bits_per_second": 35055845020.238365,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040332,
+              "seconds": 10.040332,
+              "bytes": 43821410588,
+              "bits_per_second": 34916304032.97421,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 43820099868,
+              "bits_per_second": 35055845020.238365,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.7129817857671,
+              "host_user": 1.930649372470762,
+              "host_system": 89.782322494473,
+              "remote_total": 44.03409922696862,
+              "remote_user": 0.28095210440615037,
+              "remote_system": 43.75314712256247
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 47342,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:07 UTC",
+              "timesecs": 1711485367
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000658,
+                  "seconds": 1.0006580352783203,
+                  "bytes": 1519091984,
+                  "bits_per_second": 12144744201.868994,
+                  "retransmits": 186,
+                  "snd_cwnd": 841152,
+                  "rtt": 194,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000658,
+                "seconds": 1.0006580352783203,
+                "bytes": 1519091984,
+                "bits_per_second": 12144744201.868994,
+                "retransmits": 186,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000658,
+                  "end": 2.00053,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 1496842240,
+                  "bits_per_second": 11976270537.380842,
+                  "retransmits": 69,
+                  "snd_cwnd": 831716,
+                  "rtt": 212,
+                  "rttvar": 24,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000658,
+                "end": 2.00053,
+                "seconds": 0.9998720288276672,
+                "bytes": 1496842240,
+                "bits_per_second": 11976270537.380842,
+                "retransmits": 69,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00053,
+                  "end": 3.000069,
+                  "seconds": 0.9995390176773071,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12347431467.637243,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 240,
+                  "rttvar": 28,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.00053,
+                "end": 3.000069,
+                "seconds": 0.9995390176773071,
+                "bytes": 1542717440,
+                "bits_per_second": 12347431467.637243,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000069,
+                  "end": 4.000792,
+                  "seconds": 1.0007230043411255,
+                  "bytes": 1482424320,
+                  "bits_per_second": 11850826361.095003,
+                  "retransmits": 21,
+                  "snd_cwnd": 683436,
+                  "rtt": 355,
+                  "rttvar": 32,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000069,
+                "end": 4.000792,
+                "seconds": 1.0007230043411255,
+                "bytes": 1482424320,
+                "bits_per_second": 11850826361.095003,
+                "retransmits": 21,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000792,
+                  "end": 5.000133,
+                  "seconds": 0.9993410110473633,
+                  "bytes": 1537474560,
+                  "bits_per_second": 12307907254.911064,
+                  "retransmits": 0,
+                  "snd_cwnd": 789928,
+                  "rtt": 201,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000792,
+                "end": 5.000133,
+                "seconds": 0.9993410110473633,
+                "bytes": 1537474560,
+                "bits_per_second": 12307907254.911064,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000133,
+                  "end": 6.000434,
+                  "seconds": 1.0003010034561157,
+                  "bytes": 1528299520,
+                  "bits_per_second": 12222717079.915821,
+                  "retransmits": 22,
+                  "snd_cwnd": 798016,
+                  "rtt": 187,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000133,
+                "end": 6.000434,
+                "seconds": 1.0003010034561157,
+                "bytes": 1528299520,
+                "bits_per_second": 12222717079.915821,
+                "retransmits": 22,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000434,
+                  "end": 7.000335,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 1551892480,
+                  "bits_per_second": 12416369101.700983,
+                  "retransmits": 0,
+                  "snd_cwnd": 823628,
+                  "rtt": 270,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000434,
+                "end": 7.000335,
+                "seconds": 0.9999009966850281,
+                "bytes": 1551892480,
+                "bits_per_second": 12416369101.700983,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000335,
+                  "end": 8.00007,
+                  "seconds": 0.9997349977493286,
+                  "bytes": 1550581760,
+                  "bits_per_second": 12407942212.612543,
+                  "retransmits": 0,
+                  "snd_cwnd": 924728,
+                  "rtt": 210,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000335,
+                "end": 8.00007,
+                "seconds": 0.9997349977493286,
+                "bytes": 1550581760,
+                "bits_per_second": 12407942212.612543,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00007,
+                  "end": 9.000638,
+                  "seconds": 1.0005680322647095,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12355692607.945854,
+                  "retransmits": 35,
+                  "snd_cwnd": 802060,
+                  "rtt": 187,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00007,
+                "end": 9.000638,
+                "seconds": 1.0005680322647095,
+                "bytes": 1545338880,
+                "bits_per_second": 12355692607.945854,
+                "retransmits": 35,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000638,
+                  "end": 10.000796,
+                  "seconds": 1.0001579523086548,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12339790421.61459,
+                  "retransmits": 0,
+                  "snd_cwnd": 851936,
+                  "rtt": 272,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000638,
+                "end": 10.000796,
+                "seconds": 1.0001579523086548,
+                "bytes": 1542717440,
+                "bits_per_second": 12339790421.61459,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000796,
+                  "seconds": 10.000796,
+                  "bytes": 15297380624,
+                  "bits_per_second": 12236930439.537014,
+                  "retransmits": 333,
+                  "max_snd_cwnd": 924728,
+                  "max_rtt": 355,
+                  "min_rtt": 187,
+                  "mean_rtt": 232,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040404,
+                  "seconds": 10.000796,
+                  "bytes": 15297378960,
+                  "bits_per_second": 12188656121.805456,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000796,
+              "seconds": 10.000796,
+              "bytes": 15297380624,
+              "bits_per_second": 12236930439.537014,
+              "retransmits": 333,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040404,
+              "seconds": 10.040404,
+              "bytes": 15297378960,
+              "bits_per_second": 12188656121.805456,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 94.61572077164762,
+              "host_user": 0.29949784294138804,
+              "host_system": 94.31623284257061,
+              "remote_total": 24.200736107154952,
+              "remote_user": 0.7375246434410879,
+              "remote_system": 23.463211463713865
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 48142,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:19 UTC",
+              "timesecs": 1711485379
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000003,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1743350008,
+                  "bits_per_second": 13946758499.420694,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000003,
+                "seconds": 1.0000029802322388,
+                "bytes": 1743350008,
+                "bits_per_second": 13946758499.420694,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000003,
+                  "end": 2.000012,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 1755937152,
+                  "bits_per_second": 14047371622.71066,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000003,
+                "end": 2.000012,
+                "seconds": 1.0000089406967163,
+                "bytes": 1755937152,
+                "bits_per_second": 14047371622.71066,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000012,
+                  "end": 3.00001,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1733808384,
+                  "bits_per_second": 13870495181.361897,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000012,
+                "end": 3.00001,
+                "seconds": 0.9999979734420776,
+                "bytes": 1733808384,
+                "bits_per_second": 13870495181.361897,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00001,
+                  "end": 4.000018,
+                  "seconds": 1.0000079870224,
+                  "bytes": 1738644752,
+                  "bits_per_second": 13909046924.130655,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.00001,
+                "end": 4.000018,
+                "seconds": 1.0000079870224,
+                "bytes": 1738644752,
+                "bits_per_second": 13909046924.130655,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000023,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900420131.51325,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000023,
+                "seconds": 1.0000050067901611,
+                "bytes": 1737561216,
+                "bits_per_second": 13900420131.51325,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000023,
+                  "end": 6.000056,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1736454280,
+                  "bits_per_second": 13891175539.864704,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000023,
+                "end": 6.000056,
+                "seconds": 1.0000330209732056,
+                "bytes": 1736454280,
+                "bits_per_second": 13891175539.864704,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000026,
+                  "seconds": 0.999970018863678,
+                  "bytes": 1727790912,
+                  "bits_per_second": 13822741717.503777,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000026,
+                "seconds": 0.999970018863678,
+                "bytes": 1727790912,
+                "bits_per_second": 13822741717.503777,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000019,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1724361600,
+                  "bits_per_second": 13794989002.714045,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000019,
+                "seconds": 0.9999930262565613,
+                "bytes": 1724361600,
+                "bits_per_second": 13794989002.714045,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000019,
+                  "end": 9.000026,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1740731712,
+                  "bits_per_second": 13925755751.312475,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000019,
+                "end": 9.000026,
+                "seconds": 1.0000070333480835,
+                "bytes": 1740731712,
+                "bits_per_second": 13925755751.312475,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000039,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1729926144,
+                  "bits_per_second": 13839229327.648127,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000039,
+                "seconds": 1.000012993812561,
+                "bytes": 1729926144,
+                "bits_per_second": 13839229327.648127,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039511,
+                  "seconds": 10.039511,
+                  "bytes": 17371187600,
+                  "bits_per_second": 13842257934.674309,
+                  "retransmits": 2068,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000039,
+                  "seconds": 10.000039,
+                  "bytes": 17368566160,
+                  "bits_per_second": 13894798738.284922,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039511,
+              "seconds": 10.039511,
+              "bytes": 17371187600,
+              "bits_per_second": 13842257934.674309,
+              "retransmits": 2068,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000039,
+              "seconds": 10.000039,
+              "bytes": 17368566160,
+              "bits_per_second": 13894798738.284922,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.48791626719862,
+              "host_user": 1.6040884366461445,
+              "host_system": 42.883837750090144,
+              "remote_total": 12.877414932148609,
+              "remote_user": 0.20340289771075803,
+              "remote_system": 12.674021700497715
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39362,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:36 UTC",
+              "timesecs": 1711485396
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000203,
+                  "seconds": 1.000203013420105,
+                  "bytes": 3477340160,
+                  "bits_per_second": 27813074852.55055,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000203,
+                "seconds": 1.000203013420105,
+                "bytes": 3477340160,
+                "bits_per_second": 27813074852.55055,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000203,
+                  "end": 2.000079,
+                  "seconds": 0.9998760223388672,
+                  "bytes": 3461611520,
+                  "bits_per_second": 27696325885.70528,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000203,
+                "end": 2.000079,
+                "seconds": 0.9998760223388672,
+                "bytes": 3461611520,
+                "bits_per_second": 27696325885.70528,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000079,
+                  "end": 3.000169,
+                  "seconds": 1.0000900030136108,
+                  "bytes": 3432745096,
+                  "bits_per_second": 27459489331.207977,
+                  "retransmits": 0,
+                  "snd_cwnd": 599860,
+                  "rtt": 31,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000079,
+                "end": 3.000169,
+                "seconds": 1.0000900030136108,
+                "bytes": 3432745096,
+                "bits_per_second": 27459489331.207977,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000169,
+                  "end": 4.000043,
+                  "seconds": 0.9998739957809448,
+                  "bytes": 3490447360,
+                  "bits_per_second": 27927097812.1503,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 31,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000169,
+                "end": 4.000043,
+                "seconds": 0.9998739957809448,
+                "bytes": 3490447360,
+                "bits_per_second": 27927097812.1503,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000043,
+                  "end": 5.000105,
+                  "seconds": 1.0000619888305664,
+                  "bytes": 3575644160,
+                  "bits_per_second": 28603380189.91178,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000043,
+                "end": 5.000105,
+                "seconds": 1.0000619888305664,
+                "bytes": 3575644160,
+                "bits_per_second": 28603380189.91178,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000105,
+                  "end": 6.000004,
+                  "seconds": 0.9998990297317505,
+                  "bytes": 3565158400,
+                  "bits_per_second": 28524147290.80354,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000105,
+                "end": 6.000004,
+                "seconds": 0.9998990297317505,
+                "bytes": 3565158400,
+                "bits_per_second": 28524147290.80354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000302,
+                  "seconds": 1.000298023223877,
+                  "bytes": 3586129920,
+                  "bits_per_second": 28680491907.339397,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000302,
+                "seconds": 1.000298023223877,
+                "bytes": 3586129920,
+                "bits_per_second": 28680491907.339397,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000302,
+                  "end": 8.000114,
+                  "seconds": 0.9998120069503784,
+                  "bytes": 3579576320,
+                  "bits_per_second": 28641995055.99782,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000302,
+                "end": 8.000114,
+                "seconds": 0.9998120069503784,
+                "bytes": 3579576320,
+                "bits_per_second": 28641995055.99782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000114,
+                  "end": 9.000032,
+                  "seconds": 0.9999179840087891,
+                  "bytes": 3584819200,
+                  "bits_per_second": 28680905892.925636,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000114,
+                "end": 9.000032,
+                "seconds": 0.9999179840087891,
+                "bytes": 3584819200,
+                "bits_per_second": 28680905892.925636,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000166,
+                  "seconds": 1.000133991241455,
+                  "bytes": 3587440640,
+                  "bits_per_second": 28695680150.192276,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000166,
+                "seconds": 1.000133991241455,
+                "bytes": 3587440640,
+                "bits_per_second": 28695680150.192276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000166,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28272260901.26904,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 769708,
+                  "max_rtt": 33,
+                  "min_rtt": 31,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040211,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28159498063.138317,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000166,
+              "seconds": 10.000166,
+              "bytes": 35340912776,
+              "bits_per_second": 28272260901.26904,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040211,
+              "seconds": 10.040211,
+              "bytes": 35340912776,
+              "bits_per_second": 28159498063.138317,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.19888011381254,
+              "host_user": 0.5898692408770353,
+              "host_system": 97.6090108729355,
+              "remote_total": 71.89727658532618,
+              "remote_user": 1.9320023444980647,
+              "remote_system": 69.96528325535468
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37670,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:48 UTC",
+              "timesecs": 1711485408
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000002,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 3779153100,
+                  "bits_per_second": 30233163530.742928,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000002,
+                "seconds": 1.0000020265579224,
+                "bytes": 3779153100,
+                "bits_per_second": 30233163530.742928,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000002,
+                  "end": 2.000029,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30331340786.265507,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000002,
+                "end": 2.000029,
+                "seconds": 1.0000269412994385,
+                "bytes": 3791519744,
+                "bits_per_second": 30331340786.265507,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000029,
+                  "end": 3.000014,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30332613559.093388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000029,
+                "end": 3.000014,
+                "seconds": 0.9999849796295166,
+                "bytes": 3791519744,
+                "bits_per_second": 30332613559.093388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000014,
+                  "end": 4.000004,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 3793747968,
+                  "bits_per_second": 30350287659.043278,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000014,
+                "end": 4.000004,
+                "seconds": 0.9999899864196777,
+                "bytes": 3793747968,
+                "bits_per_second": 30350287659.043278,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000004,
+                  "end": 5.000013,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 3797024768,
+                  "bits_per_second": 30375926562.05313,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000004,
+                "end": 5.000013,
+                "seconds": 1.0000089406967163,
+                "bytes": 3797024768,
+                "bits_per_second": 30375926562.05313,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000018,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 3796106948,
+                  "bits_per_second": 30368703534.273937,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000018,
+                "seconds": 1.0000050067901611,
+                "bytes": 3796106948,
+                "bits_per_second": 30368703534.273937,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 3778281788,
+                  "bits_per_second": 30226526351.846264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 3778281788,
+                "bits_per_second": 30226526351.846264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000013,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3812884480,
+                  "bits_per_second": 30502952208.001095,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000013,
+                "seconds": 1.0000040531158447,
+                "bytes": 3812884480,
+                "bits_per_second": 30502952208.001095,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000013,
+                  "end": 9.000017,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3806855168,
+                  "bits_per_second": 30454717907.5003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000013,
+                "end": 9.000017,
+                "seconds": 1.0000040531158447,
+                "bytes": 3806855168,
+                "bits_per_second": 30454717907.5003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000017,
+                  "end": 10.000014,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3791650816,
+                  "bits_per_second": 30333296928.269413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000017,
+                "end": 10.000014,
+                "seconds": 0.9999970197677612,
+                "bytes": 3791650816,
+                "bits_per_second": 30333296928.269413,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040168,
+                  "seconds": 10.040168,
+                  "bytes": 37939793100,
+                  "bits_per_second": 30230404989.239223,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000014,
+                  "seconds": 10.000014,
+                  "bytes": 37938744524,
+                  "bits_per_second": 30350953127.86562,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040168,
+              "seconds": 10.040168,
+              "bytes": 37939793100,
+              "bits_per_second": 30230404989.239223,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000014,
+              "seconds": 10.000014,
+              "bytes": 37938744524,
+              "bits_per_second": 30350953127.86562,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 89.35457193175537,
+              "host_user": 2.1531064410889655,
+              "host_system": 87.20146549066642,
+              "remote_total": 96.25175156651449,
+              "remote_user": 0.5483803525296743,
+              "remote_system": 95.70338087979988
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39876,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:05 UTC",
+              "timesecs": 1711485425
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000173,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2929832972,
+                  "bits_per_second": 23434610228.684185,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1011,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000173,
+                "seconds": 1.0001729726791382,
+                "bytes": 2929832972,
+                "bits_per_second": 23434610228.684185,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000173,
+                  "end": 2.000056,
+                  "seconds": 0.9998829960823059,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23417442012.457832,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1030,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000173,
+                "end": 2.000056,
+                "seconds": 0.9998829960823059,
+                "bytes": 2926837760,
+                "bits_per_second": 23417442012.457832,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000045,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393988522.219513,
+                  "retransmits": 1071,
+                  "snd_cwnd": 2109620,
+                  "rtt": 718,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000045,
+                "seconds": 0.9999889731407166,
+                "bytes": 2924216320,
+                "bits_per_second": 23393988522.219513,
+                "retransmits": 1071,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000045,
+                  "end": 4.000057,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414420167.144268,
+                  "retransmits": 0,
+                  "snd_cwnd": 2934596,
+                  "rtt": 882,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000045,
+                "end": 4.000057,
+                "seconds": 1.0000120401382446,
+                "bytes": 2926837760,
+                "bits_per_second": 23414420167.144268,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000134,
+                  "seconds": 1.0000770092010498,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23402414118.786076,
+                  "retransmits": 680,
+                  "snd_cwnd": 2067832,
+                  "rtt": 699,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000134,
+                "seconds": 1.0000770092010498,
+                "bytes": 2925527040,
+                "bits_per_second": 23402414118.786076,
+                "retransmits": 680,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000134,
+                  "end": 6.000072,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23405667209.938972,
+                  "retransmits": 576,
+                  "snd_cwnd": 2143320,
+                  "rtt": 731,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000134,
+                "end": 6.000072,
+                "seconds": 0.9999380111694336,
+                "bytes": 2925527040,
+                "bits_per_second": 23405667209.938972,
+                "retransmits": 576,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000072,
+                  "end": 7.000057,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23415053782.782707,
+                  "retransmits": 0,
+                  "snd_cwnd": 2985820,
+                  "rtt": 1004,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000072,
+                "end": 7.000057,
+                "seconds": 0.9999849796295166,
+                "bytes": 2926837760,
+                "bits_per_second": 23415053782.782707,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000151,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422984764.712734,
+                  "retransmits": 0,
+                  "snd_cwnd": 3150276,
+                  "rtt": 1131,
+                  "rttvar": 47,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000151,
+                "seconds": 1.0000940561294556,
+                "bytes": 2928148480,
+                "bits_per_second": 23422984764.712734,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000151,
+                  "end": 9.00006,
+                  "seconds": 0.999908983707428,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416833393.35924,
+                  "retransmits": 536,
+                  "snd_cwnd": 2446620,
+                  "rtt": 816,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000151,
+                "end": 9.00006,
+                "seconds": 0.999908983707428,
+                "bytes": 2926837760,
+                "bits_per_second": 23416833393.35924,
+                "retransmits": 536,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00006,
+                  "end": 10.000062,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425140367.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 3163756,
+                  "rtt": 1040,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.00006,
+                "end": 10.000062,
+                "seconds": 1.0000020265579224,
+                "bytes": 2928148480,
+                "bits_per_second": 23425140367.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 29268751372,
+                  "bits_per_second": 23414855925.493263,
+                  "retransmits": 2863,
+                  "max_snd_cwnd": 3301252,
+                  "max_rtt": 1131,
+                  "min_rtt": 699,
+                  "mean_rtt": 906,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040299,
+                  "seconds": 10.000062,
+                  "bytes": 29268042576,
+                  "bits_per_second": 23320454959.35928,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 29268751372,
+              "bits_per_second": 23414855925.493263,
+              "retransmits": 2863,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040299,
+              "seconds": 10.040299,
+              "bytes": 29268042576,
+              "bits_per_second": 23320454959.35928,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 36.61979232353807,
+              "host_user": 0.5177138138716962,
+              "host_system": 36.10208842470637,
+              "remote_total": 63.645622998347704,
+              "remote_user": 2.779808989119691,
+              "remote_system": 60.86582297594884
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 49506,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:17 UTC",
+              "timesecs": 1711485437
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00003,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 2928081096,
+                  "bits_per_second": 23423945095.33297,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00003,
+                "seconds": 1.0000300407409668,
+                "bytes": 2928081096,
+                "bits_per_second": 23423945095.33297,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00003,
+                  "end": 2.00001,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2924874236,
+                  "bits_per_second": 23399462512.79474,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00003,
+                "end": 2.00001,
+                "seconds": 0.9999799728393555,
+                "bytes": 2924874236,
+                "bits_per_second": 23399462512.79474,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 2928934064,
+                  "bits_per_second": 23431098222.587284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 2928934064,
+                "bits_per_second": 23431098222.587284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2927109320,
+                  "bits_per_second": 23417343542.901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 2927109320,
+                "bits_per_second": 23417343542.901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000006,
+                  "end": 5.000015,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 2928650940,
+                  "bits_per_second": 23428998048.434082,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000006,
+                "end": 5.000015,
+                "seconds": 1.0000089406967163,
+                "bytes": 2928650940,
+                "bits_per_second": 23428998048.434082,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000015,
+                  "end": 6.00002,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2928599620,
+                  "bits_per_second": 23428679657.517204,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000015,
+                "end": 6.00002,
+                "seconds": 1.0000050067901611,
+                "bytes": 2928599620,
+                "bits_per_second": 23428679657.517204,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000018,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2903162060,
+                  "bits_per_second": 23225343547.503967,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000018,
+                "seconds": 0.9999979734420776,
+                "bytes": 2903162060,
+                "bits_per_second": 23225343547.503967,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000018,
+                  "end": 8.000028,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 2520932544,
+                  "bits_per_second": 20167258405.538074,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000018,
+                "end": 8.000028,
+                "seconds": 1.0000100135803223,
+                "bytes": 2520932544,
+                "bits_per_second": 20167258405.538074,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000028,
+                  "end": 9.000012,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2699663148,
+                  "bits_per_second": 21597650185.83164,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000028,
+                "end": 9.000012,
+                "seconds": 0.9999840259552002,
+                "bytes": 2699663148,
+                "bits_per_second": 21597650185.83164,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000012,
+                  "end": 10.000011,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927449024,
+                  "bits_per_second": 23419615922.60409,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000012,
+                "end": 10.000011,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927449024,
+                "bits_per_second": 23419615922.60409,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039579,
+                  "seconds": 10.039579,
+                  "bytes": 28621053072,
+                  "bits_per_second": 22806576309.225716,
+                  "retransmits": 2146,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000011,
+                  "seconds": 10.000011,
+                  "bytes": 28617456052,
+                  "bits_per_second": 22893939658.266373,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039579,
+              "seconds": 10.039579,
+              "bytes": 28621053072,
+              "bits_per_second": 22806576309.225716,
+              "retransmits": 2146,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000011,
+              "seconds": 10.000011,
+              "bytes": 28617456052,
+              "bits_per_second": 22893939658.266373,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.71637462053445,
+              "host_user": 2.3097157068484533,
+              "host_system": 84.40665891368599,
+              "remote_total": 20.40828750936386,
+              "remote_user": 0.3775983988088474,
+              "remote_system": 20.030689110555013
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 38034,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:34 UTC",
+              "timesecs": 1711485454
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1174382536,
+                  "bits_per_second": 9394514890.15193,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2566,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1174382536,
+                "bits_per_second": 9394514890.15193,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000058,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2504,
+                  "rttvar": 111,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000058,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374766195.07232,
+                  "retransmits": 13,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2578,
+                  "rttvar": 100,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1171783680,
+                "bits_per_second": 9374766195.07232,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.000059,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373763239.835724,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2548,
+                  "rttvar": 49,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.000059,
+                "seconds": 1.0000540018081665,
+                "bytes": 1171783680,
+                "bits_per_second": 9373763239.835724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000059,
+                  "end": 5.000059,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2544,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000059,
+                "end": 5.000059,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000092,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373959902.721222,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2626,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000092,
+                "seconds": 1.0000330209732056,
+                "bytes": 1171783680,
+                "bits_per_second": 9373959902.721222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000092,
+                  "end": 7.000102,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374175570.939966,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2637,
+                  "rttvar": 87,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000092,
+                "end": 7.000102,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171783680,
+                "bits_per_second": 9374175570.939966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000102,
+                  "end": 8.000204,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373312957.602478,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2584,
+                  "rttvar": 65,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000102,
+                "end": 8.000204,
+                "seconds": 1.0001020431518555,
+                "bytes": 1171783680,
+                "bits_per_second": 9373312957.602478,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000204,
+                  "end": 9.000059,
+                  "seconds": 0.9998549818992615,
+                  "bytes": 1170472960,
+                  "bits_per_second": 9365141795.07627,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2646,
+                  "rttvar": 50,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000204,
+                "end": 9.000059,
+                "seconds": 0.9998549818992615,
+                "bytes": 1170472960,
+                "bits_per_second": 9365141795.07627,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000059,
+                  "end": 10.000063,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374231445.153997,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2624,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000059,
+                "end": 10.000063,
+                "seconds": 1.0000040531158447,
+                "bytes": 1171783680,
+                "bits_per_second": 9374231445.153997,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9375240884.782425,
+                  "retransmits": 13,
+                  "max_snd_cwnd": 3298556,
+                  "max_rtt": 2646,
+                  "min_rtt": 2504,
+                  "mean_rtt": 2585,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042436,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9335683044.23349,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 11719124936,
+              "bits_per_second": 9375240884.782425,
+              "retransmits": 13,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042436,
+              "seconds": 10.042436,
+              "bytes": 11719124936,
+              "bits_per_second": 9335683044.23349,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 8.581878883067088,
+              "host_user": 0.24757613109832505,
+              "host_system": 8.334302751968762,
+              "remote_total": 17.882794832888134,
+              "remote_user": 0.6213889785332932,
+              "remote_system": 17.261397456752558
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 59786,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:44 UTC",
+              "timesecs": 1711485464
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00001,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171526660,
+                  "bits_per_second": 9372119431.529282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00001,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171526660,
+                "bits_per_second": 9372119431.529282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00001,
+                  "end": 2.00001,
+                  "seconds": 1,
+                  "bytes": 1171728636,
+                  "bits_per_second": 9373829088,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00001,
+                "end": 2.00001,
+                "seconds": 1,
+                "bytes": 1171728636,
+                "bits_per_second": 9373829088,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171634728,
+                  "bits_per_second": 9372928100.426619,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171634728,
+                "bits_per_second": 9372928100.426619,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000003,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1171698712,
+                  "bits_per_second": 9373805362.822794,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000003,
+                "seconds": 0.9999769926071167,
+                "bytes": 1171698712,
+                "bits_per_second": 9373805362.822794,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000003,
+                  "end": 5.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171728612,
+                  "bits_per_second": 9373679160.429152,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000003,
+                "end": 5.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171728612,
+                "bits_per_second": 9373679160.429152,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000019,
+                  "end": 6.000033,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1171430044,
+                  "bits_per_second": 9371309645.78169,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000019,
+                "end": 6.000033,
+                "seconds": 1.0000139474868774,
+                "bytes": 1171430044,
+                "bits_per_second": 9371309645.78169,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000033,
+                  "end": 7.000019,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171711552,
+                  "bits_per_second": 9373823716.006702,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000033,
+                "end": 7.000019,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171711552,
+                "bits_per_second": 9373823716.006702,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.000005,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171704164,
+                  "bits_per_second": 9373764611.178816,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.000005,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171704164,
+                "bits_per_second": 9373764611.178816,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000005,
+                  "end": 9.000005,
+                  "seconds": 1,
+                  "bytes": 1171264340,
+                  "bits_per_second": 9370114720,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000005,
+                "end": 9.000005,
+                "seconds": 1,
+                "bytes": 1171264340,
+                "bits_per_second": 9370114720,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000005,
+                  "end": 10.000025,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 1171724928,
+                  "bits_per_second": 9373611697.172722,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000005,
+                "end": 10.000025,
+                "seconds": 1.0000200271606445,
+                "bytes": 1171724928,
+                "bits_per_second": 9373611697.172722,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040362,
+                  "seconds": 10.040362,
+                  "bytes": 11719168912,
+                  "bits_per_second": 9337646520.713099,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000025,
+                  "seconds": 10.000025,
+                  "bytes": 11716152376,
+                  "bits_per_second": 9372898468.553827,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040362,
+              "seconds": 10.040362,
+              "bytes": 11719168912,
+              "bits_per_second": 9337646520.713099,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000025,
+              "seconds": 10.000025,
+              "bytes": 11716152376,
+              "bits_per_second": 9372898468.553827,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.12079215423493,
+              "host_user": 1.449299942928998,
+              "host_system": 32.671502129797744,
+              "remote_total": 9.21759648553234,
+              "remote_user": 0.13056616222089867,
+              "remote_system": 9.087020816528113
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 42748,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:01 UTC",
+              "timesecs": 1711485481
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000059,
+                  "seconds": 1.0000590085983276,
+                  "bytes": 1180082728,
+                  "bits_per_second": 9440104776.649063,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2528,
+                  "rttvar": 68,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000059,
+                "seconds": 1.0000590085983276,
+                "bytes": 1180082728,
+                "bits_per_second": 9440104776.649063,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000059,
+                  "end": 2.000103,
+                  "seconds": 1.0000439882278442,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9415798295.719233,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2635,
+                  "rttvar": 38,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000059,
+                "end": 2.000103,
+                "seconds": 1.0000439882278442,
+                "bytes": 1177026560,
+                "bits_per_second": 9415798295.719233,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000103,
+                  "end": 3.000059,
+                  "seconds": 0.9999560117721558,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9406140479.450544,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2580,
+                  "rttvar": 45,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000103,
+                "end": 3.000059,
+                "seconds": 0.9999560117721558,
+                "bytes": 1175715840,
+                "bits_per_second": 9406140479.450544,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2614,
+                  "rttvar": 61,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000059,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416203500.008564,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2540,
+                  "rttvar": 36,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000059,
+                "seconds": 1.0000009536743164,
+                "bytes": 1177026560,
+                "bits_per_second": 9416203500.008564,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2532,
+                  "rttvar": 66,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416193397.538671,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2621,
+                  "rttvar": 26,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 1177026560,
+                "bits_per_second": 9416193397.538671,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.00006,
+                  "end": 8.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9405745781.28863,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2647,
+                  "rttvar": 79,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.00006,
+                "end": 8.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 1175715840,
+                "bits_per_second": 9405745781.28863,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416212480,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2616,
+                  "rttvar": 57,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1177026560,
+                "bits_per_second": 9416212480,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000062,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416174315.154686,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2608,
+                  "rttvar": 75,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000062,
+                "seconds": 1.0000040531158447,
+                "bytes": 1177026560,
+                "bits_per_second": 9416174315.154686,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 11770700328,
+                  "bits_per_second": 9416501880.088345,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 3302888,
+                  "max_rtt": 2647,
+                  "min_rtt": 2528,
+                  "mean_rtt": 2592,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042832,
+                  "seconds": 10.000062,
+                  "bytes": 11770469264,
+                  "bits_per_second": 9376215206.228682,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 11770700328,
+              "bits_per_second": 9416501880.088345,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042832,
+              "seconds": 10.042832,
+              "bytes": 11770469264,
+              "bits_per_second": 9376215206.228682,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 9.991931328513951,
+              "host_user": 0.30260245650629003,
+              "host_system": 9.689348708938175,
+              "remote_total": 19.41962833866342,
+              "remote_user": 0.6099473016485951,
+              "remote_system": 18.809681037014826
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 58986,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:11 UTC",
+              "timesecs": 1711485491
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1176615352,
+                  "bits_per_second": 9412866710.942337,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1176615352,
+                "bits_per_second": 9412866710.942337,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000016,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1176524120,
+                  "bits_per_second": 9412098711.193554,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000016,
+                "seconds": 1.0000100135803223,
+                "bytes": 1176524120,
+                "bits_per_second": 9412098711.193554,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000009,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1176810760,
+                  "bits_per_second": 9414551734.668388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000009,
+                "seconds": 0.9999930262565613,
+                "bytes": 1176810760,
+                "bits_per_second": 9414551734.668388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000007,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1176810048,
+                  "bits_per_second": 9414499463.028471,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000007,
+                "seconds": 0.9999979734420776,
+                "bytes": 1176810048,
+                "bits_per_second": 9414499463.028471,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000007,
+                  "end": 5.000007,
+                  "seconds": 1,
+                  "bytes": 1176803976,
+                  "bits_per_second": 9414431808,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000007,
+                "end": 5.000007,
+                "seconds": 1,
+                "bytes": 1176803976,
+                "bits_per_second": 9414431808,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000007,
+                  "end": 6.000009,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1176724064,
+                  "bits_per_second": 9413773434.442867,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000007,
+                "end": 6.000009,
+                "seconds": 1.0000020265579224,
+                "bytes": 1176724064,
+                "bits_per_second": 9413773434.442867,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000009,
+                  "end": 7.000003,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1176792016,
+                  "bits_per_second": 9414392803.29542,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000009,
+                "end": 7.000003,
+                "seconds": 0.9999939799308777,
+                "bytes": 1176792016,
+                "bits_per_second": 9414392803.29542,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000003,
+                  "end": 8.000015,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 1176820328,
+                  "bits_per_second": 9414449272.72926,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000003,
+                "end": 8.000015,
+                "seconds": 1.0000120401382446,
+                "bytes": 1176820328,
+                "bits_per_second": 9414449272.72926,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000011,
+                  "seconds": 0.9999960064888,
+                  "bytes": 1176491696,
+                  "bits_per_second": 9411971154.81222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000011,
+                "seconds": 0.9999960064888,
+                "bytes": 1176491696,
+                "bits_per_second": 9411971154.81222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000011,
+                  "end": 10.000015,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1176819760,
+                  "bits_per_second": 9414519921.860134,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000011,
+                "end": 10.000015,
+                "seconds": 1.0000040531158447,
+                "bytes": 1176819760,
+                "bits_per_second": 9414519921.860134,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040305,
+                  "seconds": 10.040305,
+                  "bytes": 11770238744,
+                  "bits_per_second": 9378391388.707813,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000015,
+                  "seconds": 10.000015,
+                  "bytes": 11767212120,
+                  "bits_per_second": 9413755575.366638,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040305,
+              "seconds": 10.040305,
+              "bytes": 11770238744,
+              "bits_per_second": 9378391388.707813,
+              "retransmits": 0,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000015,
+              "seconds": 10.000015,
+              "bytes": 11767212120,
+              "bits_per_second": 9413755575.366638,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 48.724054060084946,
+              "host_user": 3.9110899538590087,
+              "host_system": 44.81297402368786,
+              "remote_total": 7.595950273368541,
+              "remote_user": 0.15972436790366432,
+              "remote_system": 7.436225905464877
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    }
+  ]
+}

--- a/tests/input2.json
+++ b/tests/input2.json
@@ -1,1 +1,15204 @@
-{"tft-tests": [{"flow_test": {"tft_metadata": {"test_case_id": "invalid_test_case_id", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 56762, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:32 UTC", "timesecs": 1711484912}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "snd_cwnd": 477192, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "snd_cwnd": 477192, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "snd_cwnd": 477192, "rtt": 27, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "snd_cwnd": 502804, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "snd_cwnd": 528416, "rtt": 29, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "snd_cwnd": 528416, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "snd_cwnd": 528416, "rtt": 30, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "snd_cwnd": 591772, "rtt": 26, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "snd_cwnd": 621428, "rtt": 27, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "snd_cwnd": 621428, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "max_snd_cwnd": 621428, "max_rtt": 30, "min_rtt": 25, "mean_rtt": 26, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040752, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "sender": true}, "sum_received": {"start": 0, "end": 10.040752, "seconds": 10.040752, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}, "cpu_utilization_percent": {"host_total": 51.95896032207571, "host_user": 0.46109579260875955, "host_system": 51.4978546106554, "remote_total": 46.34560190202221, "remote_user": 1.2743335369337774, "remote_system": 45.07127657478376}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 54270, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:43 UTC", "timesecs": 1711484923}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}], "sum": {"start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}], "sum": {"start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}], "sum": {"start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}], "sum": {"start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}], "sum": {"start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}], "sum": {"start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}], "sum": {"start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}], "sum": {"start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "sender": false}, "sum_received": {"start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}, "cpu_utilization_percent": {"host_total": 59.961165048543684, "host_user": 1.7074681645153693, "host_system": 58.25370680355615, "remote_total": 54.92808068462117, "remote_user": 0.35009864909523675, "remote_system": 54.57798203552594}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 43488, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:03 UTC", "timesecs": 1711484943}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "snd_cwnd": 858676, "rtt": 477, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "snd_cwnd": 864068, "rtt": 582, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "snd_cwnd": 897768, "rtt": 469, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "snd_cwnd": 843848, "rtt": 459, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "snd_cwnd": 931468, "rtt": 278, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "snd_cwnd": 773752, "rtt": 389, "rttvar": 21, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "snd_cwnd": 706352, "rtt": 351, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "snd_cwnd": 957080, "rtt": 494, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "snd_cwnd": 668608, "rtt": 406, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "snd_cwnd": 835760, "rtt": 417, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "max_snd_cwnd": 957080, "max_rtt": 582, "min_rtt": 278, "mean_rtt": 432, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040323, "seconds": 10.000067, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "sender": true}, "sum_received": {"start": 0, "end": 10.040323, "seconds": 10.040323, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}, "cpu_utilization_percent": {"host_total": 13.428581942246796, "host_user": 0.18264039451277397, "host_system": 13.245951466295686, "remote_total": 23.0189867907264, "remote_user": 0.650631880001117, "remote_system": 22.368346697024506}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 52702, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:14 UTC", "timesecs": 1711484954}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}], "sum": {"start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}], "sum": {"start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}], "sum": {"start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}], "sum": {"start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}], "sum": {"start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}], "sum": {"start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "sender": false}, "sum_received": {"start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}, "cpu_utilization_percent": {"host_total": 27.136162389258295, "host_user": 1.0734065668100488, "host_system": 26.062755822448246, "remote_total": 12.134681085322041, "remote_user": 0.20150770671204546, "remote_system": 11.933173378609997}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 37248, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:34 UTC", "timesecs": 1711484974}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "snd_cwnd": 477192, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "max_snd_cwnd": 1412704, "max_rtt": 24, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040463, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040463, "seconds": 10.040463, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}, "cpu_utilization_percent": {"host_total": 51.42879332323217, "host_user": 0.48554830964161494, "host_system": 50.94323509492755, "remote_total": 45.16438235241609, "remote_user": 1.4607549345618025, "remote_system": 43.703627417854285}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 42348, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:45 UTC", "timesecs": 1711484985}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}], "sum": {"start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}], "sum": {"start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}], "sum": {"start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}], "sum": {"start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}], "sum": {"start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}, "cpu_utilization_percent": {"host_total": 58.9131700562321, "host_user": 1.8313076617106898, "host_system": 57.08186239452141, "remote_total": 54.91579537328721, "remote_user": 0.4710685503353111, "remote_system": 54.44472682295189}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 45258, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:05 UTC", "timesecs": 1711485005}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "snd_cwnd": 958428, "rtt": 667, "rttvar": 176, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "snd_cwnd": 913944, "rtt": 617, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "snd_cwnd": 698264, "rtt": 354, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "snd_cwnd": 789928, "rtt": 504, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "snd_cwnd": 698264, "rtt": 352, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "snd_cwnd": 947644, "rtt": 487, "rttvar": 19, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "snd_cwnd": 706352, "rtt": 362, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "snd_cwnd": 684784, "rtt": 352, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "snd_cwnd": 877548, "rtt": 463, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "snd_cwnd": 858676, "rtt": 461, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "max_snd_cwnd": 958428, "max_rtt": 667, "min_rtt": 352, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039933, "seconds": 10.000063, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "sender": true}, "sum_received": {"start": 0, "end": 10.039933, "seconds": 10.039933, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}, "cpu_utilization_percent": {"host_total": 12.965573157783645, "host_user": 0.2766736708792456, "host_system": 12.688899486904399, "remote_total": 23.378925135581515, "remote_user": 0.7967034489409502, "remote_system": 22.582213415818792}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 46944, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:16 UTC", "timesecs": 1711485016}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}], "sum": {"start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}], "sum": {"start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}], "sum": {"start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}], "sum": {"start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}], "sum": {"start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}], "sum": {"start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}], "sum": {"start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}], "sum": {"start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}, "cpu_utilization_percent": {"host_total": 26.49645360241422, "host_user": 1.0953846141637273, "host_system": 25.40107890796627, "remote_total": 12.308727742765743, "remote_user": 0.1856302180705536, "remote_system": 12.12309752469519}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 39718, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:35 UTC", "timesecs": 1711485035}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "snd_cwnd": 551332, "rtt": 31, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "snd_cwnd": 551332, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "snd_cwnd": 707700, "rtt": 27, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "snd_cwnd": 808800, "rtt": 30, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "snd_cwnd": 808800, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "max_snd_cwnd": 808800, "max_rtt": 31, "min_rtt": 26, "mean_rtt": 28, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}, "cpu_utilization_percent": {"host_total": 50.79991850744037, "host_user": 0.5093780915545499, "host_system": 50.29054041588581, "remote_total": 69.18971718930246, "remote_user": 1.6048329699753412, "remote_system": 67.58487595116893}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 45210, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:46 UTC", "timesecs": 1711485046}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}], "sum": {"start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}], "sum": {"start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}], "sum": {"start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}], "sum": {"start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}], "sum": {"start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}], "sum": {"start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}, "cpu_utilization_percent": {"host_total": 53.87293306289964, "host_user": 1.9549507299646565, "host_system": 51.91798233293498, "remote_total": 84.71007116240497, "remote_user": 0.4765840963192183, "remote_system": 84.23349673055752}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 42424, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:05 UTC", "timesecs": 1711485065}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 397, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 398, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "snd_cwnd": 760272, "rtt": 242, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "snd_cwnd": 1517848, "rtt": 400, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 393, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 373, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "snd_cwnd": 1442360, "rtt": 379, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "snd_cwnd": 1544808, "rtt": 397, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "snd_cwnd": 1569072, "rtt": 419, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "snd_cwnd": 1606816, "rtt": 410, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "max_snd_cwnd": 1763184, "max_rtt": 419, "min_rtt": 242, "mean_rtt": 380, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039772, "seconds": 10.000116, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "sender": true}, "sum_received": {"start": 0, "end": 10.039772, "seconds": 10.039772, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}, "cpu_utilization_percent": {"host_total": 19.865083177612643, "host_user": 0.41521108861582645, "host_system": 19.449872088996816, "remote_total": 59.10663386005702, "remote_user": 2.4033524078476156, "remote_system": 56.70327318135753}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 38322, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:16 UTC", "timesecs": 1711485076}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}], "sum": {"start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}], "sum": {"start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}], "sum": {"start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}], "sum": {"start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "sender": false}, "sum_received": {"start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}, "cpu_utilization_percent": {"host_total": 37.45748338542608, "host_user": 1.3319334804012157, "host_system": 36.125549905024855, "remote_total": 15.928314062618693, "remote_user": 0.36963858784471143, "remote_system": 15.558675474773981}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 47958, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:36 UTC", "timesecs": 1711485096}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "snd_cwnd": 579640, "rtt": 26, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "snd_cwnd": 579640, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "snd_cwnd": 899116, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 26, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 24, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "max_snd_cwnd": 1043352, "max_rtt": 26, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040386, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040386, "seconds": 10.040386, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}, "cpu_utilization_percent": {"host_total": 51.71680226694355, "host_user": 0.47637317598252343, "host_system": 51.24043901002937, "remote_total": 45.230156070887375, "remote_user": 1.3387075643093247, "remote_system": 43.891456788045936}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 60988, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:48 UTC", "timesecs": 1711485108}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}], "sum": {"start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}], "sum": {"start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}], "sum": {"start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}], "sum": {"start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}], "sum": {"start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}], "sum": {"start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72172176163449, "host_user": 1.7632532126911542, "host_system": 56.958468548943344, "remote_total": 54.5440108210963, "remote_user": 0.40678669250280086, "remote_system": 54.137214462757875}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 46580, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:07 UTC", "timesecs": 1711485127}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "snd_cwnd": 812844, "rtt": 417, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "snd_cwnd": 912596, "rtt": 445, "rttvar": 23, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "snd_cwnd": 669956, "rtt": 482, "rttvar": 128, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "snd_cwnd": 843848, "rtt": 461, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "snd_cwnd": 838456, "rtt": 544, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "snd_cwnd": 928772, "rtt": 486, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "snd_cwnd": 831716, "rtt": 416, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "snd_cwnd": 824976, "rtt": 580, "rttvar": 185, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "snd_cwnd": 634908, "rtt": 423, "rttvar": 97, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "snd_cwnd": 676696, "rtt": 360, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "max_snd_cwnd": 928772, "max_rtt": 580, "min_rtt": 360, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039945, "seconds": 10.000063, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "sender": true}, "sum_received": {"start": 0, "end": 10.039945, "seconds": 10.039945, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}, "cpu_utilization_percent": {"host_total": 13.61059396129923, "host_user": 0.19270043453809127, "host_system": 13.417903445457585, "remote_total": 23.486672814565882, "remote_user": 0.5555645903789477, "remote_system": 22.931108224186932}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 50678, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:19 UTC", "timesecs": 1711485139}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}], "sum": {"start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}], "sum": {"start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}], "sum": {"start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}], "sum": {"start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "sender": false}, "sum_received": {"start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}, "cpu_utilization_percent": {"host_total": 26.747516641197084, "host_user": 1.0158505257156165, "host_system": 25.731666115481467, "remote_total": 11.755923477356498, "remote_user": 0.13796182174123386, "remote_system": 11.617971314101807}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 41706, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:38 UTC", "timesecs": 1711485158}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "snd_cwnd": 525720, "rtt": 24, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 37, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "max_snd_cwnd": 1202416, "max_rtt": 37, "min_rtt": 21, "mean_rtt": 24, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040372, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040372, "seconds": 10.040372, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}, "cpu_utilization_percent": {"host_total": 51.579098862767125, "host_user": 0.4361726860977011, "host_system": 51.14293609532062, "remote_total": 44.789642459824776, "remote_user": 1.3832780535675204, "remote_system": 43.40635613187544}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 57026, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:50 UTC", "timesecs": 1711485170}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}], "sum": {"start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}], "sum": {"start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}], "sum": {"start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}], "sum": {"start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}], "sum": {"start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}], "sum": {"start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}], "sum": {"start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}], "sum": {"start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72825614611755, "host_user": 1.7371177997142697, "host_system": 56.991148265535564, "remote_total": 54.64429253795493, "remote_user": 0.4133314501365237, "remote_system": 54.23096108781841}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 43702, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:09 UTC", "timesecs": 1711485189}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "snd_cwnd": 816888, "rtt": 591, "rttvar": 85, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "snd_cwnd": 958428, "rtt": 636, "rttvar": 81, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "snd_cwnd": 688828, "rtt": 360, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "snd_cwnd": 804756, "rtt": 415, "rttvar": 1, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "snd_cwnd": 953036, "rtt": 494, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "snd_cwnd": 850588, "rtt": 461, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "snd_cwnd": 943600, "rtt": 507, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "snd_cwnd": 846544, "rtt": 461, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "snd_cwnd": 830368, "rtt": 478, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "snd_cwnd": 501456, "rtt": 244, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "max_snd_cwnd": 958428, "max_rtt": 636, "min_rtt": 244, "mean_rtt": 464, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039929, "seconds": 10.000215, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "sender": true}, "sum_received": {"start": 0, "end": 10.039929, "seconds": 10.039929, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}, "cpu_utilization_percent": {"host_total": 13.005006946322178, "host_user": 0.19271754050004394, "host_system": 12.812299324888505, "remote_total": 23.26438245505795, "remote_user": 0.8376646905752849, "remote_system": 22.426726025964516}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 57004, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:21 UTC", "timesecs": 1711485201}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}], "sum": {"start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}], "sum": {"start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}], "sum": {"start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}], "sum": {"start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}], "sum": {"start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}], "sum": {"start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "sender": false}, "sum_received": {"start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}, "cpu_utilization_percent": {"host_total": 26.064632328384384, "host_user": 1.162207899423042, "host_system": 24.902424428961346, "remote_total": 11.69062967191739, "remote_user": 0.12009331046577057, "remote_system": 11.570546012927187}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56708, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:39 UTC", "timesecs": 1711485219}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "snd_cwnd": 798016, "rtt": 32, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "snd_cwnd": 798016, "rtt": 30, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "max_snd_cwnd": 798016, "max_rtt": 35, "min_rtt": 30, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040107, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040107, "seconds": 10.040107, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}, "cpu_utilization_percent": {"host_total": 84.44527815243438, "host_user": 0.4874417118707169, "host_system": 83.95785625929561, "remote_total": 37.5809576369255, "remote_user": 1.2945095444412822, "remote_system": 36.286448092484214}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37086, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:51 UTC", "timesecs": 1711485231}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}], "sum": {"start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}], "sum": {"start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}], "sum": {"start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}], "sum": {"start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}], "sum": {"start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}], "sum": {"start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}, "cpu_utilization_percent": {"host_total": 91.26294493237891, "host_user": 1.8116036545309533, "host_system": 89.45135119667133, "remote_total": 44.14246868282316, "remote_user": 0.32552835005268926, "remote_system": 43.816940332770464}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55424, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:09 UTC", "timesecs": 1711485249}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "snd_cwnd": 641648, "rtt": 391, "rttvar": 37, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "snd_cwnd": 787232, "rtt": 223, "rttvar": 31, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "snd_cwnd": 655128, "rtt": 228, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "snd_cwnd": 849240, "rtt": 193, "rttvar": 25, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "snd_cwnd": 936860, "rtt": 606, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "snd_cwnd": 829020, "rtt": 197, "rttvar": 54, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "snd_cwnd": 917988, "rtt": 218, "rttvar": 40, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "snd_cwnd": 917988, "rtt": 200, "rttvar": 33, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "snd_cwnd": 934164, "rtt": 220, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "snd_cwnd": 776448, "rtt": 184, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "max_snd_cwnd": 936860, "max_rtt": 606, "min_rtt": 184, "mean_rtt": 266, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040277, "seconds": 10.00071, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "sender": true}, "sum_received": {"start": 0, "end": 10.040277, "seconds": 10.040277, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}, "cpu_utilization_percent": {"host_total": 95.82562437024121, "host_user": 0.2560031758234491, "host_system": 95.56962119441776, "remote_total": 24.102997438800752, "remote_user": 1.0351409018247604, "remote_system": 23.06785653697599}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39456, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:21 UTC", "timesecs": 1711485261}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}], "sum": {"start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}], "sum": {"start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}], "sum": {"start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}], "sum": {"start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}], "sum": {"start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "sender": false}, "sum_received": {"start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}, "cpu_utilization_percent": {"host_total": 44.47684113065824, "host_user": 1.8968527601361653, "host_system": 42.57999828989936, "remote_total": 12.529305328982618, "remote_user": 0.09332895016906215, "remote_system": 12.435986036196645}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56016, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:38 UTC", "timesecs": 1711485278}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "snd_cwnd": 663216, "rtt": 37, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "snd_cwnd": 663216, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "snd_cwnd": 663216, "rtt": 31, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "max_snd_cwnd": 663216, "max_rtt": 37, "min_rtt": 31, "mean_rtt": 33, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039647, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039647, "seconds": 10.039647, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}, "cpu_utilization_percent": {"host_total": 98.6366144037512, "host_user": 0.5079154773387307, "host_system": 98.12868897353042, "remote_total": 69.33475570009895, "remote_user": 1.8358332803622874, "remote_system": 67.4989133777374}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 41272, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:50 UTC", "timesecs": 1711485290}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}], "sum": {"start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}], "sum": {"start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}], "sum": {"start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}], "sum": {"start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}], "sum": {"start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}], "sum": {"start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}], "sum": {"start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}, "cpu_utilization_percent": {"host_total": 86.40432984604324, "host_user": 2.1048623181527053, "host_system": 84.29947744708186, "remote_total": 96.37010529501002, "remote_user": 0.5200516733573617, "remote_system": 95.85006329541284}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 35114, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:07 UTC", "timesecs": 1711485307}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "snd_cwnd": 2701392, "rtt": 911, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "snd_cwnd": 2724308, "rtt": 935, "rttvar": 42, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "snd_cwnd": 2744528, "rtt": 900, "rttvar": 30, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "snd_cwnd": 2345520, "rtt": 798, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "snd_cwnd": 2325300, "rtt": 778, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "snd_cwnd": 3097704, "rtt": 1023, "rttvar": 3, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "snd_cwnd": 3165104, "rtt": 1109, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "snd_cwnd": 2543676, "rtt": 841, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 1059, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 781, "rttvar": 78, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "max_snd_cwnd": 3165104, "max_rtt": 1109, "min_rtt": 778, "mean_rtt": 913, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000231, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}, "cpu_utilization_percent": {"host_total": 34.97762289166434, "host_user": 0.5691962216451614, "host_system": 34.40843658477508, "remote_total": 62.9251445256492, "remote_user": 2.6124474135751976, "remote_system": 60.31269711207401}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55052, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:19 UTC", "timesecs": 1711485319}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}], "sum": {"start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}], "sum": {"start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}], "sum": {"start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}], "sum": {"start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}], "sum": {"start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "sender": false}, "sum_received": {"start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}, "cpu_utilization_percent": {"host_total": 88.6667781634535, "host_user": 2.169277119907057, "host_system": 86.4975109631894, "remote_total": 22.440235970749637, "remote_user": 0.4127789042736779, "remote_system": 22.027466720316273}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 50458, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:37 UTC", "timesecs": 1711485337}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "snd_cwnd": 884288, "rtt": 40, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "snd_cwnd": 974604, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "snd_cwnd": 974604, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 33, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "max_snd_cwnd": 1074356, "max_rtt": 40, "min_rtt": 31, "mean_rtt": 34, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039944, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039944, "seconds": 10.039944, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}, "cpu_utilization_percent": {"host_total": 84.72291319227105, "host_user": 0.5304700943978504, "host_system": 84.19243318754582, "remote_total": 37.30641845607046, "remote_user": 1.3600734652179878, "remote_system": 35.946344990852474}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 53048, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:49 UTC", "timesecs": 1711485349}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}], "sum": {"start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}], "sum": {"start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}], "sum": {"start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}], "sum": {"start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}], "sum": {"start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}], "sum": {"start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}, "cpu_utilization_percent": {"host_total": 91.7129817857671, "host_user": 1.930649372470762, "host_system": 89.782322494473, "remote_total": 44.03409922696862, "remote_user": 0.28095210440615037, "remote_system": 43.75314712256247}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 47342, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:07 UTC", "timesecs": 1711485367}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "snd_cwnd": 841152, "rtt": 194, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "snd_cwnd": 831716, "rtt": 212, "rttvar": 24, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "snd_cwnd": 849240, "rtt": 240, "rttvar": 28, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "snd_cwnd": 683436, "rtt": 355, "rttvar": 32, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "snd_cwnd": 789928, "rtt": 201, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "snd_cwnd": 798016, "rtt": 187, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "snd_cwnd": 823628, "rtt": 270, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "snd_cwnd": 924728, "rtt": 210, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "snd_cwnd": 802060, "rtt": 187, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "snd_cwnd": 851936, "rtt": 272, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "max_snd_cwnd": 924728, "max_rtt": 355, "min_rtt": 187, "mean_rtt": 232, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040404, "seconds": 10.000796, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "sender": true}, "sum_received": {"start": 0, "end": 10.040404, "seconds": 10.040404, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}, "cpu_utilization_percent": {"host_total": 94.61572077164762, "host_user": 0.29949784294138804, "host_system": 94.31623284257061, "remote_total": 24.200736107154952, "remote_user": 0.7375246434410879, "remote_system": 23.463211463713865}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 48142, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:19 UTC", "timesecs": 1711485379}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}], "sum": {"start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}], "sum": {"start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}], "sum": {"start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}], "sum": {"start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}], "sum": {"start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}], "sum": {"start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "sender": false}, "sum_received": {"start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}, "cpu_utilization_percent": {"host_total": 44.48791626719862, "host_user": 1.6040884366461445, "host_system": 42.883837750090144, "remote_total": 12.877414932148609, "remote_user": 0.20340289771075803, "remote_system": 12.674021700497715}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39362, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:36 UTC", "timesecs": 1711485396}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "snd_cwnd": 412488, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "snd_cwnd": 412488, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "snd_cwnd": 599860, "rtt": 31, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "snd_cwnd": 769708, "rtt": 31, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "snd_cwnd": 769708, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "max_snd_cwnd": 769708, "max_rtt": 33, "min_rtt": 31, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040211, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040211, "seconds": 10.040211, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}, "cpu_utilization_percent": {"host_total": 98.19888011381254, "host_user": 0.5898692408770353, "host_system": 97.6090108729355, "remote_total": 71.89727658532618, "remote_user": 1.9320023444980647, "remote_system": 69.96528325535468}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37670, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:48 UTC", "timesecs": 1711485408}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}], "sum": {"start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}], "sum": {"start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}], "sum": {"start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}], "sum": {"start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}], "sum": {"start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}], "sum": {"start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}, "cpu_utilization_percent": {"host_total": 89.35457193175537, "host_user": 2.1531064410889655, "host_system": 87.20146549066642, "remote_total": 96.25175156651449, "remote_user": 0.5483803525296743, "remote_system": 95.70338087979988}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39876, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:05 UTC", "timesecs": 1711485425}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1011, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1030, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "snd_cwnd": 2109620, "rtt": 718, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "snd_cwnd": 2934596, "rtt": 882, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "snd_cwnd": 2067832, "rtt": 699, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "snd_cwnd": 2143320, "rtt": 731, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "snd_cwnd": 2985820, "rtt": 1004, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "snd_cwnd": 3150276, "rtt": 1131, "rttvar": 47, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "snd_cwnd": 2446620, "rtt": 816, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "snd_cwnd": 3163756, "rtt": 1040, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "max_snd_cwnd": 3301252, "max_rtt": 1131, "min_rtt": 699, "mean_rtt": 906, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040299, "seconds": 10.000062, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "sender": true}, "sum_received": {"start": 0, "end": 10.040299, "seconds": 10.040299, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}, "cpu_utilization_percent": {"host_total": 36.61979232353807, "host_user": 0.5177138138716962, "host_system": 36.10208842470637, "remote_total": 63.645622998347704, "remote_user": 2.779808989119691, "remote_system": 60.86582297594884}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 49506, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:17 UTC", "timesecs": 1711485437}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}], "sum": {"start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}], "sum": {"start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}], "sum": {"start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}], "sum": {"start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}], "sum": {"start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}], "sum": {"start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}], "sum": {"start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "sender": false}, "sum_received": {"start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}, "cpu_utilization_percent": {"host_total": 86.71637462053445, "host_user": 2.3097157068484533, "host_system": 84.40665891368599, "remote_total": 20.40828750936386, "remote_user": 0.3775983988088474, "remote_system": 20.030689110555013}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 38034, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:34 UTC", "timesecs": 1711485454}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2566, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2504, "rttvar": 111, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "snd_cwnd": 3298556, "rtt": 2578, "rttvar": 100, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2548, "rttvar": 49, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2544, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2626, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2637, "rttvar": 87, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2584, "rttvar": 65, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2646, "rttvar": 50, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2624, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "max_snd_cwnd": 3298556, "max_rtt": 2646, "min_rtt": 2504, "mean_rtt": 2585, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042436, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "sender": true}, "sum_received": {"start": 0, "end": 10.042436, "seconds": 10.042436, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}, "cpu_utilization_percent": {"host_total": 8.581878883067088, "host_user": 0.24757613109832505, "host_system": 8.334302751968762, "remote_total": 17.882794832888134, "remote_user": 0.6213889785332932, "remote_system": 17.261397456752558}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 59786, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:44 UTC", "timesecs": 1711485464}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}], "sum": {"start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}], "sum": {"start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}], "sum": {"start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}], "sum": {"start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}], "sum": {"start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}], "sum": {"start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}, "cpu_utilization_percent": {"host_total": 34.12079215423493, "host_user": 1.449299942928998, "host_system": 32.671502129797744, "remote_total": 9.21759648553234, "remote_user": 0.13056616222089867, "remote_system": 9.087020816528113}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 42748, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:01 UTC", "timesecs": 1711485481}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2528, "rttvar": 68, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2635, "rttvar": 38, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2580, "rttvar": 45, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2614, "rttvar": 61, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2540, "rttvar": 36, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2532, "rttvar": 66, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2621, "rttvar": 26, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2647, "rttvar": 79, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2616, "rttvar": 57, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2608, "rttvar": 75, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "max_snd_cwnd": 3302888, "max_rtt": 2647, "min_rtt": 2528, "mean_rtt": 2592, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042832, "seconds": 10.000062, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.042832, "seconds": 10.042832, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}, "cpu_utilization_percent": {"host_total": 9.991931328513951, "host_user": 0.30260245650629003, "host_system": 9.689348708938175, "remote_total": 19.41962833866342, "remote_user": 0.6099473016485951, "remote_system": 18.809681037014826}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 58986, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:11 UTC", "timesecs": 1711485491}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}], "sum": {"start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}], "sum": {"start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}], "sum": {"start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}], "sum": {"start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}], "sum": {"start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "sender": false}, "sum_received": {"start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}, "cpu_utilization_percent": {"host_total": 48.724054060084946, "host_user": 3.9110899538590087, "host_system": 44.81297402368786, "remote_total": 7.595950273368541, "remote_user": 0.15972436790366432, "remote_system": 7.436225905464877}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}]}
+{
+  "tft-tests": [
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "invalid_test_case_id",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 56762,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:32 UTC",
+              "timesecs": 1711484912
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000191,
+                  "seconds": 1.0001909732818604,
+                  "bytes": 4895539200,
+                  "bits_per_second": 39156835690.5809,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000191,
+                "seconds": 1.0001909732818604,
+                "bytes": 4895539200,
+                "bits_per_second": 39156835690.5809,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000191,
+                  "end": 2.000081,
+                  "seconds": 0.9998900294303894,
+                  "bytes": 4911267840,
+                  "bits_per_second": 39294463954.583626,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000191,
+                "end": 2.000081,
+                "seconds": 0.9998900294303894,
+                "bytes": 4911267840,
+                "bits_per_second": 39294463954.583626,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000081,
+                  "end": 3.000218,
+                  "seconds": 1.0001369714736938,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38781514278.83715,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 27,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000081,
+                "end": 3.000218,
+                "seconds": 1.0001369714736938,
+                "bytes": 4848353280,
+                "bits_per_second": 38781514278.83715,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000218,
+                  "end": 4.000267,
+                  "seconds": 1.0000489950180054,
+                  "bytes": 4840488960,
+                  "bits_per_second": 38722014494.20265,
+                  "retransmits": 0,
+                  "snd_cwnd": 502804,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000218,
+                "end": 4.000267,
+                "seconds": 1.0000489950180054,
+                "bytes": 4840488960,
+                "bits_per_second": 38722014494.20265,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000247,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4881121280,
+                  "bits_per_second": 39049752295.66235,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 29,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000247,
+                "seconds": 0.9999799728393555,
+                "bytes": 4881121280,
+                "bits_per_second": 39049752295.66235,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000247,
+                  "end": 6.00002,
+                  "seconds": 0.9997730255126953,
+                  "bytes": 4856217600,
+                  "bits_per_second": 38858560701.89271,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000247,
+                "end": 6.00002,
+                "seconds": 0.9997730255126953,
+                "bytes": 4856217600,
+                "bits_per_second": 38858560701.89271,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000117,
+                  "seconds": 1.0000970363616943,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38825001843.07837,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 30,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000117,
+                "seconds": 1.0000970363616943,
+                "bytes": 4853596160,
+                "bits_per_second": 38825001843.07837,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000117,
+                  "end": 8.000116,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4864081920,
+                  "bits_per_second": 38912694789.414955,
+                  "retransmits": 0,
+                  "snd_cwnd": 591772,
+                  "rtt": 26,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000117,
+                "end": 8.000116,
+                "seconds": 0.9999989867210388,
+                "bytes": 4864081920,
+                "bits_per_second": 38912694789.414955,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000116,
+                  "end": 9.000019,
+                  "seconds": 0.9999030232429504,
+                  "bytes": 4836556800,
+                  "bits_per_second": 38696207032.668144,
+                  "retransmits": 99,
+                  "snd_cwnd": 621428,
+                  "rtt": 27,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000116,
+                "end": 9.000019,
+                "seconds": 0.9999030232429504,
+                "bytes": 4836556800,
+                "bits_per_second": 38696207032.668144,
+                "retransmits": 99,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000019,
+                  "end": 10.000269,
+                  "seconds": 1.000249981880188,
+                  "bytes": 4773642240,
+                  "bits_per_second": 38179593713.378716,
+                  "retransmits": 0,
+                  "snd_cwnd": 621428,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000019,
+                "end": 10.000269,
+                "seconds": 1.000249981880188,
+                "bytes": 4773642240,
+                "bits_per_second": 38179593713.378716,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000269,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38847647222.28973,
+                  "retransmits": 99,
+                  "max_snd_cwnd": 621428,
+                  "max_rtt": 30,
+                  "min_rtt": 25,
+                  "mean_rtt": 26,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040752,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38691018585.06216,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000269,
+              "seconds": 10.000269,
+              "bytes": 48560865280,
+              "bits_per_second": 38847647222.28973,
+              "retransmits": 99,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040752,
+              "seconds": 10.040752,
+              "bytes": 48560865280,
+              "bits_per_second": 38691018585.06216,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.95896032207571,
+              "host_user": 0.46109579260875955,
+              "host_system": 51.4978546106554,
+              "remote_total": 46.34560190202221,
+              "remote_user": 1.2743335369337774,
+              "remote_system": 45.07127657478376
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 54270,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:43 UTC",
+              "timesecs": 1711484923
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000023,
+                  "seconds": 1.0000230073928833,
+                  "bytes": 5267935560,
+                  "bits_per_second": 42142514890.60282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000023,
+                "seconds": 1.0000230073928833,
+                "bytes": 5267935560,
+                "bits_per_second": 42142514890.60282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000023,
+                  "end": 2.000011,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5283380932,
+                  "bits_per_second": 42267553843.84901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000023,
+                "end": 2.000011,
+                "seconds": 0.9999880194664001,
+                "bytes": 5283380932,
+                "bits_per_second": 42267553843.84901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000011,
+                  "end": 3.000025,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5144593776,
+                  "bits_per_second": 41156176182.772766,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000011,
+                "end": 3.000025,
+                "seconds": 1.0000139474868774,
+                "bytes": 5144593776,
+                "bits_per_second": 41156176182.772766,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000025,
+                  "end": 4.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5313921024,
+                  "bits_per_second": 42511454343.92459,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000025,
+                "end": 4.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5313921024,
+                "bits_per_second": 42511454343.92459,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.000026,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 5324144640,
+                  "bits_per_second": 42593030182.8783,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.000026,
+                "seconds": 1.0000029802322388,
+                "bytes": 5324144640,
+                "bits_per_second": 42593030182.8783,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000026,
+                  "end": 6.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 5340397568,
+                  "bits_per_second": 42724036185.13606,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000026,
+                "end": 6.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 5340397568,
+                "bits_per_second": 42724036185.13606,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000006,
+                  "end": 7.000013,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 5317722112,
+                  "bits_per_second": 42541477686.97944,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000006,
+                "end": 7.000013,
+                "seconds": 1.0000070333480835,
+                "bytes": 5317722112,
+                "bits_per_second": 42541477686.97944,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000013,
+                  "end": 8.000023,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 5339086848,
+                  "bits_per_second": 42712267081.28284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000013,
+                "end": 8.000023,
+                "seconds": 1.0000100135803223,
+                "bytes": 5339086848,
+                "bits_per_second": 42712267081.28284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000023,
+                  "end": 9.000043,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5329256448,
+                  "bits_per_second": 42633197762.099625,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000023,
+                "end": 9.000043,
+                "seconds": 1.0000200271606445,
+                "bytes": 5329256448,
+                "bits_per_second": 42633197762.099625,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000043,
+                  "end": 10.000027,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5294784512,
+                  "bits_per_second": 42358952739.80874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000043,
+                "end": 10.000027,
+                "seconds": 0.9999840259552002,
+                "bytes": 5294784512,
+                "bits_per_second": 42358952739.80874,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040745,
+                  "seconds": 10.040745,
+                  "bytes": 52956665212,
+                  "bits_per_second": 42193415099.77596,
+                  "retransmits": 220,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000027,
+                  "seconds": 10.000027,
+                  "bytes": 52955223420,
+                  "bits_per_second": 42364064353.02625,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040745,
+              "seconds": 10.040745,
+              "bytes": 52956665212,
+              "bits_per_second": 42193415099.77596,
+              "retransmits": 220,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000027,
+              "seconds": 10.000027,
+              "bytes": 52955223420,
+              "bits_per_second": 42364064353.02625,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 59.961165048543684,
+              "host_user": 1.7074681645153693,
+              "host_system": 58.25370680355615,
+              "remote_total": 54.92808068462117,
+              "remote_user": 0.35009864909523675,
+              "remote_system": 54.57798203552594
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 43488,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:03 UTC",
+              "timesecs": 1711484943
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1552629896,
+                  "bits_per_second": 12420331432.172485,
+                  "retransmits": 1162,
+                  "snd_cwnd": 858676,
+                  "rtt": 477,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1552629896,
+                "bits_per_second": 12420331432.172485,
+                "retransmits": 1162,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000057,
+                  "seconds": 1,
+                  "bytes": 1785895104,
+                  "bits_per_second": 14287160832,
+                  "retransmits": 250,
+                  "snd_cwnd": 864068,
+                  "rtt": 582,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000057,
+                "seconds": 1,
+                "bytes": 1785895104,
+                "bits_per_second": 14287160832,
+                "retransmits": 250,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1781226624,
+                  "bits_per_second": 14249799402.332296,
+                  "retransmits": 41,
+                  "snd_cwnd": 897768,
+                  "rtt": 469,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1781226624,
+                "bits_per_second": 14249799402.332296,
+                "retransmits": 41,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000058,
+                  "end": 4.000033,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 1770754368,
+                  "bits_per_second": 14166388740.29625,
+                  "retransmits": 43,
+                  "snd_cwnd": 843848,
+                  "rtt": 459,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000058,
+                "end": 4.000033,
+                "seconds": 0.9999750256538391,
+                "bytes": 1770754368,
+                "bits_per_second": 14166388740.29625,
+                "retransmits": 43,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000033,
+                  "end": 5.00012,
+                  "seconds": 1.000087022781372,
+                  "bytes": 1756157248,
+                  "bits_per_second": 14048035484.879292,
+                  "retransmits": 508,
+                  "snd_cwnd": 931468,
+                  "rtt": 278,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000033,
+                "end": 5.00012,
+                "seconds": 1.000087022781372,
+                "bytes": 1756157248,
+                "bits_per_second": 14048035484.879292,
+                "retransmits": 508,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00012,
+                  "end": 6.000058,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 1776470548,
+                  "bits_per_second": 14212645409.268175,
+                  "retransmits": 774,
+                  "snd_cwnd": 773752,
+                  "rtt": 389,
+                  "rttvar": 21,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.00012,
+                "end": 6.000058,
+                "seconds": 0.9999380111694336,
+                "bytes": 1776470548,
+                "bits_per_second": 14212645409.268175,
+                "retransmits": 774,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000214,
+                  "seconds": 1.000156044960022,
+                  "bytes": 1780520960,
+                  "bits_per_second": 14241945296.215616,
+                  "retransmits": 107,
+                  "snd_cwnd": 706352,
+                  "rtt": 351,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000214,
+                "seconds": 1.000156044960022,
+                "bytes": 1780520960,
+                "bits_per_second": 14241945296.215616,
+                "retransmits": 107,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000214,
+                  "end": 8.000165,
+                  "seconds": 0.9999510049819946,
+                  "bytes": 1782724608,
+                  "bits_per_second": 14262495655.23143,
+                  "retransmits": 103,
+                  "snd_cwnd": 957080,
+                  "rtt": 494,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000214,
+                "end": 8.000165,
+                "seconds": 0.9999510049819946,
+                "bytes": 1782724608,
+                "bits_per_second": 14262495655.23143,
+                "retransmits": 103,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000165,
+                  "end": 9.000061,
+                  "seconds": 0.9998959898948669,
+                  "bytes": 1708298368,
+                  "bits_per_second": 13667808534.202581,
+                  "retransmits": 636,
+                  "snd_cwnd": 668608,
+                  "rtt": 406,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000165,
+                "end": 9.000061,
+                "seconds": 0.9998959898948669,
+                "bytes": 1708298368,
+                "bits_per_second": 13667808534.202581,
+                "retransmits": 636,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000061,
+                  "end": 10.000067,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1711744320,
+                  "bits_per_second": 13693872938.156792,
+                  "retransmits": 37,
+                  "snd_cwnd": 835760,
+                  "rtt": 417,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000061,
+                "end": 10.000067,
+                "seconds": 1.0000059604644775,
+                "bytes": 1711744320,
+                "bits_per_second": 13693872938.156792,
+                "retransmits": 37,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 17406422044,
+                  "bits_per_second": 13925044337.40294,
+                  "retransmits": 3661,
+                  "max_snd_cwnd": 957080,
+                  "max_rtt": 582,
+                  "min_rtt": 278,
+                  "mean_rtt": 432,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040323,
+                  "seconds": 10.000067,
+                  "bytes": 17404804444,
+                  "bits_per_second": 13867923925.554983,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 17406422044,
+              "bits_per_second": 13925044337.40294,
+              "retransmits": 3661,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040323,
+              "seconds": 10.040323,
+              "bytes": 17404804444,
+              "bits_per_second": 13867923925.554983,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.428581942246796,
+              "host_user": 0.18264039451277397,
+              "host_system": 13.245951466295686,
+              "remote_total": 23.0189867907264,
+              "remote_user": 0.650631880001117,
+              "remote_system": 22.368346697024506
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 52702,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:14 UTC",
+              "timesecs": 1711484954
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 1769360536,
+                  "bits_per_second": 14154529944.193699,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 1769360536,
+                "bits_per_second": 14154529944.193699,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000056,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 1654294820,
+                  "bits_per_second": 13233948381.508026,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000056,
+                "seconds": 1.0000309944152832,
+                "bytes": 1654294820,
+                "bits_per_second": 13233948381.508026,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000002,
+                  "seconds": 0.9999459981918335,
+                  "bytes": 1693522048,
+                  "bits_per_second": 13548908049.533356,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000002,
+                "seconds": 0.9999459981918335,
+                "bytes": 1693522048,
+                "bits_per_second": 13548908049.533356,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000002,
+                  "end": 4.000058,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1778357520,
+                  "bits_per_second": 14226063096.928802,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000002,
+                "end": 4.000058,
+                "seconds": 1.0000560283660889,
+                "bytes": 1778357520,
+                "bits_per_second": 14226063096.928802,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000058,
+                  "seconds": 1,
+                  "bytes": 1699132892,
+                  "bits_per_second": 13593063136,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000058,
+                "seconds": 1,
+                "bytes": 1699132892,
+                "bits_per_second": 13593063136,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1776734848,
+                  "bits_per_second": 14214631996.442686,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1776734848,
+                "bits_per_second": 14214631996.442686,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000005,
+                  "end": 7.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1770689664,
+                  "bits_per_second": 14165319741.388792,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000005,
+                "end": 7.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 1770689664,
+                "bits_per_second": 14165319741.388792,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.00003,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1596714580,
+                  "bits_per_second": 12773576548.933342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.00003,
+                "seconds": 1.0000109672546387,
+                "bytes": 1596714580,
+                "bits_per_second": 12773576548.933342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000056,
+                  "seconds": 1.000025987625122,
+                  "bytes": 1650146112,
+                  "bits_per_second": 13200825837.886824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000056,
+                "seconds": 1.000025987625122,
+                "bytes": 1650146112,
+                "bits_per_second": 13200825837.886824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000056,
+                  "end": 10.00005,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1544969596,
+                  "bits_per_second": 12359831175.038013,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000056,
+                "end": 10.00005,
+                "seconds": 0.9999939799308777,
+                "bytes": 1544969596,
+                "bits_per_second": 12359831175.038013,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039981,
+                  "seconds": 10.039981,
+                  "bytes": 16936819512,
+                  "bits_per_second": 13495499254.032454,
+                  "retransmits": 2334,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00005,
+                  "seconds": 10.00005,
+                  "bytes": 16933922616,
+                  "bits_per_second": 13547070357.448214,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039981,
+              "seconds": 10.039981,
+              "bytes": 16936819512,
+              "bits_per_second": 13495499254.032454,
+              "retransmits": 2334,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00005,
+              "seconds": 10.00005,
+              "bytes": 16933922616,
+              "bits_per_second": 13547070357.448214,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 27.136162389258295,
+              "host_user": 1.0734065668100488,
+              "host_system": 26.062755822448246,
+              "remote_total": 12.134681085322041,
+              "remote_user": 0.20150770671204546,
+              "remote_system": 11.933173378609997
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 37248,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:34 UTC",
+              "timesecs": 1711484974
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000223,
+                  "seconds": 1.0002230405807495,
+                  "bytes": 4827381760,
+                  "bits_per_second": 38610442384.50756,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000223,
+                "seconds": 1.0002230405807495,
+                "bytes": 4827381760,
+                "bits_per_second": 38610442384.50756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000223,
+                  "end": 2.000162,
+                  "seconds": 0.9999390244483948,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38799677831.7579,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000223,
+                "end": 2.000162,
+                "seconds": 0.9999390244483948,
+                "bytes": 4849664000,
+                "bits_per_second": 38799677831.7579,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000162,
+                  "end": 3.000191,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 4826247500,
+                  "bits_per_second": 38608861584.00477,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000162,
+                "end": 3.000191,
+                "seconds": 1.0000289678573608,
+                "bytes": 4826247500,
+                "bits_per_second": 38608861584.00477,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000191,
+                  "end": 4.00012,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4861460480,
+                  "bits_per_second": 38894444922.881874,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000191,
+                "end": 4.00012,
+                "seconds": 0.9999290108680725,
+                "bytes": 4861460480,
+                "bits_per_second": 38894444922.881874,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00012,
+                  "end": 5.000266,
+                  "seconds": 1.0001460313796997,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38487604562.00447,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.00012,
+                "end": 5.000266,
+                "seconds": 1.0001460313796997,
+                "bytes": 4811653120,
+                "bits_per_second": 38487604562.00447,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000266,
+                  "end": 6.000154,
+                  "seconds": 0.999888002872467,
+                  "bytes": 4818206720,
+                  "bits_per_second": 38549971246.046036,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000266,
+                "end": 6.000154,
+                "seconds": 0.999888002872467,
+                "bytes": 4818206720,
+                "bits_per_second": 38549971246.046036,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000154,
+                  "end": 7.000089,
+                  "seconds": 0.99993497133255,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38831294427.33196,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000154,
+                "end": 7.000089,
+                "seconds": 0.99993497133255,
+                "bytes": 4853596160,
+                "bits_per_second": 38831294427.33196,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000089,
+                  "end": 8.000143,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4870635520,
+                  "bits_per_second": 38962980088.62366,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000089,
+                "end": 8.000143,
+                "seconds": 1.0000540018081665,
+                "bytes": 4870635520,
+                "bits_per_second": 38962980088.62366,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000143,
+                  "end": 9.000159,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38796692259.89976,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000143,
+                "end": 9.000159,
+                "seconds": 1.0000159740447998,
+                "bytes": 4849664000,
+                "bits_per_second": 38796692259.89976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000159,
+                  "end": 10.000248,
+                  "seconds": 1.0000890493392944,
+                  "bytes": 4823449600,
+                  "bits_per_second": 38584160905.964096,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000159,
+                "end": 10.000248,
+                "seconds": 1.0000890493392944,
+                "bytes": 4823449600,
+                "bits_per_second": 38584160905.964096,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000248,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38712607015.34602,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1412704,
+                  "max_rtt": 24,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040463,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38557551666.69106,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000248,
+              "seconds": 10.000248,
+              "bytes": 48391958860,
+              "bits_per_second": 38712607015.34602,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040463,
+              "seconds": 10.040463,
+              "bytes": 48391958860,
+              "bits_per_second": 38557551666.69106,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.42879332323217,
+              "host_user": 0.48554830964161494,
+              "host_system": 50.94323509492755,
+              "remote_total": 45.16438235241609,
+              "remote_user": 1.4607549345618025,
+              "remote_system": 43.703627417854285
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 42348,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:45 UTC",
+              "timesecs": 1711484985
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5317084948,
+                  "bits_per_second": 42536086312.49434,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 5317084948,
+                "bits_per_second": 42536086312.49434,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000016,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 5316804608,
+                  "bits_per_second": 42534350665.67468,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000016,
+                "seconds": 1.0000020265579224,
+                "bytes": 5316804608,
+                "bits_per_second": 42534350665.67468,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000013,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5298323456,
+                  "bits_per_second": 42386713970.25147,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000013,
+                "seconds": 0.9999970197677612,
+                "bytes": 5298323456,
+                "bits_per_second": 42386713970.25147,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000013,
+                  "end": 4.000027,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5347213312,
+                  "bits_per_second": 42777109862.82153,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000013,
+                "end": 4.000027,
+                "seconds": 1.0000139474868774,
+                "bytes": 5347213312,
+                "bits_per_second": 42777109862.82153,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000027,
+                  "end": 5.000006,
+                  "seconds": 0.9999790191650391,
+                  "bytes": 5329387520,
+                  "bits_per_second": 42635994698.76817,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000027,
+                "end": 5.000006,
+                "seconds": 0.9999790191650391,
+                "bytes": 5329387520,
+                "bits_per_second": 42635994698.76817,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000006,
+                  "end": 6.000018,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 5332271104,
+                  "bits_per_second": 42657655227.93386,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000006,
+                "end": 6.000018,
+                "seconds": 1.0000120401382446,
+                "bytes": 5332271104,
+                "bits_per_second": 42657655227.93386,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000031,
+                  "seconds": 1.000012993812561,
+                  "bytes": 5274468352,
+                  "bits_per_second": 42195198539.4992,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000031,
+                "seconds": 1.000012993812561,
+                "bytes": 5274468352,
+                "bits_per_second": 42195198539.4992,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000031,
+                  "end": 8.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5300420608,
+                  "bits_per_second": 42404297508.9502,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000031,
+                "end": 8.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 5300420608,
+                "bits_per_second": 42404297508.9502,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000009,
+                  "end": 9.000029,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5310644224,
+                  "bits_per_second": 42484302952.03991,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000009,
+                "end": 9.000029,
+                "seconds": 1.0000200271606445,
+                "bytes": 5310644224,
+                "bits_per_second": 42484302952.03991,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000028,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5294129152,
+                  "bits_per_second": 42353076131.48099,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000028,
+                "seconds": 0.9999989867210388,
+                "bytes": 5294129152,
+                "bits_per_second": 42353076131.48099,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040317,
+                  "seconds": 10.040317,
+                  "bytes": 53121271572,
+                  "bits_per_second": 42326370031.54382,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 53120747284,
+                  "bits_per_second": 42496478837.05926,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040317,
+              "seconds": 10.040317,
+              "bytes": 53121271572,
+              "bits_per_second": 42326370031.54382,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 53120747284,
+              "bits_per_second": 42496478837.05926,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.9131700562321,
+              "host_user": 1.8313076617106898,
+              "host_system": 57.08186239452141,
+              "remote_total": 54.91579537328721,
+              "remote_user": 0.4710685503353111,
+              "remote_system": 54.44472682295189
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 45258,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:05 UTC",
+              "timesecs": 1711485005
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1756790944,
+                  "bits_per_second": 14053511676.447533,
+                  "retransmits": 563,
+                  "snd_cwnd": 958428,
+                  "rtt": 667,
+                  "rttvar": 176,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1756790944,
+                "bits_per_second": 14053511676.447533,
+                "retransmits": 563,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1762679616,
+                  "bits_per_second": 14101451216.70384,
+                  "retransmits": 117,
+                  "snd_cwnd": 913944,
+                  "rtt": 617,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1762679616,
+                "bits_per_second": 14101451216.70384,
+                "retransmits": 117,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000057,
+                  "seconds": 1,
+                  "bytes": 1743596572,
+                  "bits_per_second": 13948772576,
+                  "retransmits": 76,
+                  "snd_cwnd": 698264,
+                  "rtt": 354,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000057,
+                "seconds": 1,
+                "bytes": 1743596572,
+                "bits_per_second": 13948772576,
+                "retransmits": 76,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1585909824,
+                  "bits_per_second": 12687278592,
+                  "retransmits": 93,
+                  "snd_cwnd": 789928,
+                  "rtt": 504,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1585909824,
+                "bits_per_second": 12687278592,
+                "retransmits": 93,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1719381848,
+                  "bits_per_second": 13755041666.170042,
+                  "retransmits": 79,
+                  "snd_cwnd": 698264,
+                  "rtt": 352,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1719381848,
+                "bits_per_second": 13755041666.170042,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.00008,
+                  "seconds": 1.000022053718567,
+                  "bytes": 1698620928,
+                  "bits_per_second": 13588667743.34589,
+                  "retransmits": 427,
+                  "snd_cwnd": 947644,
+                  "rtt": 487,
+                  "rttvar": 19,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.00008,
+                "seconds": 1.000022053718567,
+                "bytes": 1698620928,
+                "bits_per_second": 13588667743.34589,
+                "retransmits": 427,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00008,
+                  "end": 7.000196,
+                  "seconds": 1.000115990638733,
+                  "bytes": 1755761024,
+                  "bits_per_second": 14044459166.210653,
+                  "retransmits": 62,
+                  "snd_cwnd": 706352,
+                  "rtt": 362,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00008,
+                "end": 7.000196,
+                "seconds": 1.000115990638733,
+                "bytes": 1755761024,
+                "bits_per_second": 14044459166.210653,
+                "retransmits": 62,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000196,
+                  "end": 8.000057,
+                  "seconds": 0.9998610019683838,
+                  "bytes": 1783120320,
+                  "bits_per_second": 14266945637.36077,
+                  "retransmits": 88,
+                  "snd_cwnd": 684784,
+                  "rtt": 352,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000196,
+                "end": 8.000057,
+                "seconds": 0.9998610019683838,
+                "bytes": 1783120320,
+                "bits_per_second": 14266945637.36077,
+                "retransmits": 88,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000057,
+                  "end": 9.000034,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1733497792,
+                  "bits_per_second": 13868301409.459152,
+                  "retransmits": 177,
+                  "snd_cwnd": 877548,
+                  "rtt": 463,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000057,
+                "end": 9.000034,
+                "seconds": 0.9999769926071167,
+                "bytes": 1733497792,
+                "bits_per_second": 13868301409.459152,
+                "retransmits": 177,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000063,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 1775311360,
+                  "bits_per_second": 14202079476.187506,
+                  "retransmits": 53,
+                  "snd_cwnd": 858676,
+                  "rtt": 461,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000063,
+                "seconds": 1.0000289678573608,
+                "bytes": 1775311360,
+                "bits_per_second": 14202079476.187506,
+                "retransmits": 53,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17314670228,
+                  "bits_per_second": 13851648917.011822,
+                  "retransmits": 1735,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 667,
+                  "min_rtt": 352,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039933,
+                  "seconds": 10.000063,
+                  "bytes": 17312453588,
+                  "bits_per_second": 13794875792.896229,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17314670228,
+              "bits_per_second": 13851648917.011822,
+              "retransmits": 1735,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039933,
+              "seconds": 10.039933,
+              "bytes": 17312453588,
+              "bits_per_second": 13794875792.896229,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 12.965573157783645,
+              "host_user": 0.2766736708792456,
+              "host_system": 12.688899486904399,
+              "remote_total": 23.378925135581515,
+              "remote_user": 0.7967034489409502,
+              "remote_system": 22.582213415818792
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 46944,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:16 UTC",
+              "timesecs": 1711485016
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000056,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1588301472,
+                  "bits_per_second": 12705699896.394789,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000056,
+                "seconds": 1.0000560283660889,
+                "bytes": 1588301472,
+                "bits_per_second": 12705699896.394789,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000056,
+                  "end": 2.000025,
+                  "seconds": 0.9999690055847168,
+                  "bytes": 1717632384,
+                  "bits_per_second": 13741484981.292118,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000056,
+                "end": 2.000025,
+                "seconds": 0.9999690055847168,
+                "bytes": 1717632384,
+                "bits_per_second": 13741484981.292118,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000025,
+                  "end": 3.000046,
+                  "seconds": 1.000020980834961,
+                  "bytes": 1637153304,
+                  "bits_per_second": 13096951647.019003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000025,
+                "end": 3.000046,
+                "seconds": 1.000020980834961,
+                "bytes": 1637153304,
+                "bits_per_second": 13096951647.019003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000057,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1548560832,
+                  "bits_per_second": 12388350789.802336,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000057,
+                "seconds": 1.0000109672546387,
+                "bytes": 1548560832,
+                "bits_per_second": 12388350789.802336,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000057,
+                  "seconds": 1,
+                  "bytes": 1661339904,
+                  "bits_per_second": 13290719232,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000057,
+                "seconds": 1,
+                "bytes": 1661339904,
+                "bits_per_second": 13290719232,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000057,
+                  "seconds": 1,
+                  "bytes": 1734958228,
+                  "bits_per_second": 13879665824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000057,
+                "seconds": 1,
+                "bytes": 1734958228,
+                "bits_per_second": 13879665824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000024,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 1733693804,
+                  "bits_per_second": 13870008433.176832,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000024,
+                "seconds": 0.9999669790267944,
+                "bytes": 1733693804,
+                "bits_per_second": 13870008433.176832,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000056,
+                  "seconds": 1.0000319480895996,
+                  "bytes": 1624242608,
+                  "bits_per_second": 12993525745.675262,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000056,
+                "seconds": 1.0000319480895996,
+                "bytes": 1624242608,
+                "bits_per_second": 12993525745.675262,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000056,
+                  "end": 9.000015,
+                  "seconds": 0.9999589920043945,
+                  "bytes": 1732061376,
+                  "bits_per_second": 13857059258.225166,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000056,
+                "end": 9.000015,
+                "seconds": 0.9999589920043945,
+                "bytes": 1732061376,
+                "bits_per_second": 13857059258.225166,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000015,
+                  "end": 10.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1706050368,
+                  "bits_per_second": 13648225601.514744,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000015,
+                "end": 10.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1706050368,
+                "bits_per_second": 13648225601.514744,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03969,
+                  "seconds": 10.03969,
+                  "bytes": 16687168488,
+                  "bits_per_second": 13296959159.49596,
+                  "retransmits": 2081,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 16683994280,
+                  "bits_per_second": 13347158051.957455,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03969,
+              "seconds": 10.03969,
+              "bytes": 16687168488,
+              "bits_per_second": 13296959159.49596,
+              "retransmits": 2081,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 16683994280,
+              "bits_per_second": 13347158051.957455,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.49645360241422,
+              "host_user": 1.0953846141637273,
+              "host_system": 25.40107890796627,
+              "remote_total": 12.308727742765743,
+              "remote_user": 0.1856302180705536,
+              "remote_system": 12.12309752469519
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 39718,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:35 UTC",
+              "timesecs": 1711485035
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000101,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 4825423936,
+                  "bits_per_second": 38599494086.72777,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 31,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000101,
+                "seconds": 1.0001009702682495,
+                "bytes": 4825423936,
+                "bits_per_second": 38599494086.72777,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000101,
+                  "end": 2.000064,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38452705227.057976,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000101,
+                "end": 2.000064,
+                "seconds": 0.9999629855155945,
+                "bytes": 4806410240,
+                "bits_per_second": 38452705227.057976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000064,
+                  "end": 3.000036,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 4803788800,
+                  "bits_per_second": 38431387023.910736,
+                  "retransmits": 0,
+                  "snd_cwnd": 707700,
+                  "rtt": 27,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000064,
+                "end": 3.000036,
+                "seconds": 0.9999719858169556,
+                "bytes": 4803788800,
+                "bits_per_second": 38431387023.910736,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000036,
+                  "end": 4.000268,
+                  "seconds": 1.0002319812774658,
+                  "bytes": 4790681600,
+                  "bits_per_second": 38316564074.51789,
+                  "retransmits": 78,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000036,
+                "end": 4.000268,
+                "seconds": 1.0002319812774658,
+                "bytes": 4790681600,
+                "bits_per_second": 38316564074.51789,
+                "retransmits": 78,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000268,
+                  "end": 5.000265,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4696309760,
+                  "bits_per_second": 37570590049.083694,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 30,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000268,
+                "end": 5.000265,
+                "seconds": 0.9999970197677612,
+                "bytes": 4696309760,
+                "bits_per_second": 37570590049.083694,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000265,
+                  "end": 6.000018,
+                  "seconds": 0.9997529983520508,
+                  "bytes": 4778885120,
+                  "bits_per_second": 38240526433.04741,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000265,
+                "end": 6.000018,
+                "seconds": 0.9997529983520508,
+                "bytes": 4778885120,
+                "bits_per_second": 38240526433.04741,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000112,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38112152918.41128,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000112,
+                "seconds": 1.0000940561294556,
+                "bytes": 4764467200,
+                "bits_per_second": 38112152918.41128,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000112,
+                  "end": 8.000259,
+                  "seconds": 1.0001469850540161,
+                  "bytes": 4839178240,
+                  "bits_per_second": 38707736461.265396,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000112,
+                "end": 8.000259,
+                "seconds": 1.0001469850540161,
+                "bytes": 4839178240,
+                "bits_per_second": 38707736461.265396,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000259,
+                  "end": 9.000227,
+                  "seconds": 0.9999679923057556,
+                  "bytes": 4712038400,
+                  "bits_per_second": 37697513810.49582,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000259,
+                "end": 9.000227,
+                "seconds": 0.9999679923057556,
+                "bytes": 4712038400,
+                "bits_per_second": 37697513810.49582,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000227,
+                  "end": 10.000156,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4784128000,
+                  "bits_per_second": 38275741161.63895,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000227,
+                "end": 10.000156,
+                "seconds": 0.9999290108680725,
+                "bytes": 4784128000,
+                "bits_per_second": 38275741161.63895,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000156,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38240452485.74122,
+                  "retransmits": 78,
+                  "max_snd_cwnd": 808800,
+                  "max_rtt": 31,
+                  "min_rtt": 26,
+                  "mean_rtt": 28,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38087381686.64706,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000156,
+              "seconds": 10.000156,
+              "bytes": 47801311296,
+              "bits_per_second": 38240452485.74122,
+              "retransmits": 78,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 47801311296,
+              "bits_per_second": 38087381686.64706,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 50.79991850744037,
+              "host_user": 0.5093780915545499,
+              "host_system": 50.29054041588581,
+              "remote_total": 69.18971718930246,
+              "remote_user": 1.6048329699753412,
+              "remote_system": 67.58487595116893
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 45210,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:46 UTC",
+              "timesecs": 1711485046
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000004,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 4517548360,
+                  "bits_per_second": 36140240399.41901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000004,
+                "seconds": 1.0000040531158447,
+                "bytes": 4517548360,
+                "bits_per_second": 36140240399.41901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000004,
+                  "end": 2.000005,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4473749504,
+                  "bits_per_second": 35789961900.03255,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000004,
+                "end": 2.000005,
+                "seconds": 1.0000009536743164,
+                "bytes": 4473749504,
+                "bits_per_second": 35789961900.03255,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4472438784,
+                  "bits_per_second": 35779011244.710175,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 4472438784,
+                "bits_per_second": 35779011244.710175,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000014,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 4757520384,
+                  "bits_per_second": 38060353632.204094,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000014,
+                "seconds": 0.9999949932098389,
+                "bytes": 4757520384,
+                "bits_per_second": 38060353632.204094,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000014,
+                  "end": 5.000022,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4763942596,
+                  "bits_per_second": 38111236372.7014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000014,
+                "end": 5.000022,
+                "seconds": 1.0000079870224,
+                "bytes": 4763942596,
+                "bits_per_second": 38111236372.7014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000022,
+                  "end": 6.000016,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4744937788,
+                  "bits_per_second": 37959730824.20342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000022,
+                "end": 6.000016,
+                "seconds": 0.9999939799308777,
+                "bytes": 4744937788,
+                "bits_per_second": 37959730824.20342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000016,
+                  "end": 7.000004,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 4736604700,
+                  "bits_per_second": 37893291581.853004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000016,
+                "end": 7.000004,
+                "seconds": 0.9999880194664001,
+                "bytes": 4736604700,
+                "bits_per_second": 37893291581.853004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000004,
+                  "end": 8.000015,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 4758175744,
+                  "bits_per_second": 38064988483.57848,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000004,
+                "end": 8.000015,
+                "seconds": 1.0000109672546387,
+                "bytes": 4758175744,
+                "bits_per_second": 38064988483.57848,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000031,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4740612096,
+                  "bits_per_second": 37924290963.67715,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000031,
+                "seconds": 1.0000159740447998,
+                "bytes": 4740612096,
+                "bits_per_second": 37924290963.67715,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000031,
+                  "end": 10.000012,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4774428672,
+                  "bits_per_second": 38196155633.18397,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000031,
+                "end": 10.000012,
+                "seconds": 0.9999809861183167,
+                "bytes": 4774428672,
+                "bits_per_second": 38196155633.18397,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040275,
+                  "seconds": 10.040275,
+                  "bytes": 46740351844,
+                  "bits_per_second": 37242288159.63706,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000012,
+                  "seconds": 10.000012,
+                  "bytes": 46739958628,
+                  "bits_per_second": 37391922032.09356,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040275,
+              "seconds": 10.040275,
+              "bytes": 46740351844,
+              "bits_per_second": 37242288159.63706,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000012,
+              "seconds": 10.000012,
+              "bytes": 46739958628,
+              "bits_per_second": 37391922032.09356,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 53.87293306289964,
+              "host_user": 1.9549507299646565,
+              "host_system": 51.91798233293498,
+              "remote_total": 84.71007116240497,
+              "remote_user": 0.4765840963192183,
+              "remote_system": 84.23349673055752
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 42424,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:05 UTC",
+              "timesecs": 1711485065
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00002,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 2929396644,
+                  "bits_per_second": 23434703821.421913,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 397,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00002,
+                "seconds": 1.0000200271606445,
+                "bytes": 2929396644,
+                "bits_per_second": 23434703821.421913,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00002,
+                  "end": 2.000058,
+                  "seconds": 1.0000380277633667,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23424297066.37413,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 398,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.00002,
+                "end": 2.000058,
+                "seconds": 1.0000380277633667,
+                "bytes": 2928148480,
+                "bits_per_second": 23424297066.37413,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393683151.346077,
+                  "retransmits": 655,
+                  "snd_cwnd": 760272,
+                  "rtt": 242,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 2924216320,
+                "bits_per_second": 23393683151.346077,
+                "retransmits": 655,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00006,
+                  "end": 4.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425235312.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 1517848,
+                  "rtt": 400,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00006,
+                "end": 4.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 2928148480,
+                "bits_per_second": 23425235312.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425211576.27405,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 393,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 2928148480,
+                "bits_per_second": 23425211576.27405,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000027,
+                  "seconds": 0.999970018863678,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425890174.806797,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 373,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000027,
+                "seconds": 0.999970018863678,
+                "bytes": 2928148480,
+                "bits_per_second": 23425890174.806797,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000027,
+                  "end": 7.000129,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422797703.897022,
+                  "retransmits": 152,
+                  "snd_cwnd": 1442360,
+                  "rtt": 379,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000027,
+                "end": 7.000129,
+                "seconds": 1.0001020431518555,
+                "bytes": 2928148480,
+                "bits_per_second": 23422797703.897022,
+                "retransmits": 152,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000129,
+                  "end": 8.000058,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416364387.380756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1544808,
+                  "rtt": 397,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000129,
+                "end": 8.000058,
+                "seconds": 0.9999290108680725,
+                "bytes": 2926837760,
+                "bits_per_second": 23416364387.380756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425187840,
+                  "retransmits": 0,
+                  "snd_cwnd": 1569072,
+                  "rtt": 419,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 2928148480,
+                "bits_per_second": 23425187840,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000116,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2921594880,
+                  "bits_per_second": 23371402215.02037,
+                  "retransmits": 0,
+                  "snd_cwnd": 1606816,
+                  "rtt": 410,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000116,
+                "seconds": 1.0000580549240112,
+                "bytes": 2921594880,
+                "bits_per_second": 23371402215.02037,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000116,
+                  "seconds": 10.000116,
+                  "bytes": 29270936484,
+                  "bits_per_second": 23416477556.06035,
+                  "retransmits": 807,
+                  "max_snd_cwnd": 1763184,
+                  "max_rtt": 419,
+                  "min_rtt": 242,
+                  "mean_rtt": 380,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039772,
+                  "seconds": 10.000116,
+                  "bytes": 29268240456,
+                  "bits_per_second": 23321836755.65541,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000116,
+              "seconds": 10.000116,
+              "bytes": 29270936484,
+              "bits_per_second": 23416477556.06035,
+              "retransmits": 807,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039772,
+              "seconds": 10.039772,
+              "bytes": 29268240456,
+              "bits_per_second": 23321836755.65541,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 19.865083177612643,
+              "host_user": 0.41521108861582645,
+              "host_system": 19.449872088996816,
+              "remote_total": 59.10663386005702,
+              "remote_user": 2.4033524078476156,
+              "remote_system": 56.70327318135753
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 38322,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:16 UTC",
+              "timesecs": 1711485076
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000018,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 2577850256,
+                  "bits_per_second": 20622430831.81543,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000018,
+                "seconds": 1.0000180006027222,
+                "bytes": 2577850256,
+                "bits_per_second": 20622430831.81543,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000018,
+                  "end": 2.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 2421676608,
+                  "bits_per_second": 19373587232.123535,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000018,
+                "end": 2.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 2421676608,
+                "bits_per_second": 19373587232.123535,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000009,
+                  "seconds": 1,
+                  "bytes": 2353155072,
+                  "bits_per_second": 18825240576,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000009,
+                "seconds": 1,
+                "bytes": 2353155072,
+                "bits_per_second": 18825240576,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000015,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 2349402240,
+                  "bits_per_second": 18795105892.438976,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000015,
+                "seconds": 1.0000059604644775,
+                "bytes": 2349402240,
+                "bits_per_second": 18795105892.438976,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000015,
+                  "end": 5.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 2327467584,
+                  "bits_per_second": 18619498733.723473,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000015,
+                "end": 5.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 2327467584,
+                "bits_per_second": 18619498733.723473,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000022,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 2343643584,
+                  "bits_per_second": 18749261543.850487,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000022,
+                "seconds": 0.9999939799308777,
+                "bytes": 2343643584,
+                "bits_per_second": 18749261543.850487,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000022,
+                  "end": 7.000011,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2349466944,
+                  "bits_per_second": 18795942812.21649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000022,
+                "end": 7.000011,
+                "seconds": 0.9999889731407166,
+                "bytes": 2349466944,
+                "bits_per_second": 18795942812.21649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000011,
+                  "end": 8.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 2404465344,
+                  "bits_per_second": 19235358159.692505,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000011,
+                "end": 8.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 2404465344,
+                "bits_per_second": 19235358159.692505,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.00003,
+                  "seconds": 1,
+                  "bytes": 2575413312,
+                  "bits_per_second": 20603306496,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.00003,
+                "seconds": 1,
+                "bytes": 2575413312,
+                "bits_per_second": 20603306496,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.000034,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 2567907648,
+                  "bits_per_second": 20543177920.12007,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.000034,
+                "seconds": 1.0000040531158447,
+                "bytes": 2567907648,
+                "bits_per_second": 20543177920.12007,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039536,
+                  "seconds": 10.039536,
+                  "bytes": 24273090960,
+                  "bits_per_second": 19342002227.991413,
+                  "retransmits": 2404,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000034,
+                  "seconds": 10.000034,
+                  "bytes": 24270448592,
+                  "bits_per_second": 19416292858.204285,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039536,
+              "seconds": 10.039536,
+              "bytes": 24273090960,
+              "bits_per_second": 19342002227.991413,
+              "retransmits": 2404,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000034,
+              "seconds": 10.000034,
+              "bytes": 24270448592,
+              "bits_per_second": 19416292858.204285,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 37.45748338542608,
+              "host_user": 1.3319334804012157,
+              "host_system": 36.125549905024855,
+              "remote_total": 15.928314062618693,
+              "remote_user": 0.36963858784471143,
+              "remote_system": 15.558675474773981
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 47958,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:36 UTC",
+              "timesecs": 1711485096
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000048,
+                  "seconds": 1.000048041343689,
+                  "bytes": 4818672896,
+                  "bits_per_second": 38547531292.800804,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 26,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000048,
+                "seconds": 1.000048041343689,
+                "bytes": 4818672896,
+                "bits_per_second": 38547531292.800804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000048,
+                  "end": 2.000066,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38461075357.46222,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000048,
+                "end": 2.000066,
+                "seconds": 1.0000180006027222,
+                "bytes": 4807720960,
+                "bits_per_second": 38461075357.46222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000066,
+                  "end": 3.000236,
+                  "seconds": 1.0001699924468994,
+                  "bytes": 4804968024,
+                  "bits_per_second": 38433210836.44771,
+                  "retransmits": 0,
+                  "snd_cwnd": 899116,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000066,
+                "end": 3.000236,
+                "seconds": 1.0001699924468994,
+                "bytes": 4804968024,
+                "bits_per_second": 38433210836.44771,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000236,
+                  "end": 4.000147,
+                  "seconds": 0.9999110102653503,
+                  "bytes": 4799728368,
+                  "bits_per_second": 38401244260.536964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000236,
+                "end": 4.000147,
+                "seconds": 0.9999110102653503,
+                "bytes": 4799728368,
+                "bits_per_second": 38401244260.536964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000147,
+                  "end": 5.000114,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 4824760320,
+                  "bits_per_second": 38599357148.33815,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 26,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000147,
+                "end": 5.000114,
+                "seconds": 0.9999669790267944,
+                "bytes": 4824760320,
+                "bits_per_second": 38599357148.33815,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000114,
+                  "end": 6.000145,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 4833935360,
+                  "bits_per_second": 38670284317.14876,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 24,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000114,
+                "end": 6.000145,
+                "seconds": 1.0000309944152832,
+                "bytes": 4833935360,
+                "bits_per_second": 38670284317.14876,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000145,
+                  "end": 7.000159,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38408803173.721756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000145,
+                "end": 7.000159,
+                "seconds": 1.0000139474868774,
+                "bytes": 4801167360,
+                "bits_per_second": 38408803173.721756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000159,
+                  "end": 8.00016,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4820828160,
+                  "bits_per_second": 38566588500.03507,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000159,
+                "end": 8.00016,
+                "seconds": 1.0000009536743164,
+                "bytes": 4820828160,
+                "bits_per_second": 38566588500.03507,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00016,
+                  "end": 9.000032,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38372306389.033714,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00016,
+                "end": 9.000032,
+                "seconds": 0.9998720288276672,
+                "bytes": 4795924480,
+                "bits_per_second": 38372306389.033714,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000128,
+                  "seconds": 1.0000959634780884,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38783104478.40319,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000128,
+                "seconds": 1.0000959634780884,
+                "bytes": 4848353280,
+                "bits_per_second": 38783104478.40319,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000128,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38524354254.66554,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1043352,
+                  "max_rtt": 26,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040386,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38369886741.80455,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000128,
+              "seconds": 10.000128,
+              "bytes": 48156059208,
+              "bits_per_second": 38524354254.66554,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040386,
+              "seconds": 10.040386,
+              "bytes": 48156059208,
+              "bits_per_second": 38369886741.80455,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.71680226694355,
+              "host_user": 0.47637317598252343,
+              "host_system": 51.24043901002937,
+              "remote_total": 45.230156070887375,
+              "remote_user": 1.3387075643093247,
+              "remote_system": 43.891456788045936
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 60988,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:48 UTC",
+              "timesecs": 1711485108
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000022,
+                  "seconds": 1.000022053718567,
+                  "bytes": 5308961096,
+                  "bits_per_second": 42470752129.9852,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000022,
+                "seconds": 1.000022053718567,
+                "bytes": 5308961096,
+                "bits_per_second": 42470752129.9852,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000022,
+                  "end": 2.000005,
+                  "seconds": 0.999983012676239,
+                  "bytes": 5317292584,
+                  "bits_per_second": 42539063296.84071,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000022,
+                "end": 2.000005,
+                "seconds": 0.999983012676239,
+                "bytes": 5317292584,
+                "bits_per_second": 42539063296.84071,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000026,
+                  "seconds": 1.000020980834961,
+                  "bytes": 5243928576,
+                  "bits_per_second": 41950548450.46644,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000026,
+                "seconds": 1.000020980834961,
+                "bytes": 5243928576,
+                "bits_per_second": 41950548450.46644,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000023,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5279918676,
+                  "bits_per_second": 42239475291.446014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000023,
+                "seconds": 0.9999970197677612,
+                "bytes": 5279918676,
+                "bits_per_second": 42239475291.446014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.00002,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5323227136,
+                  "bits_per_second": 42585944004.00324,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.00002,
+                "seconds": 0.9999970197677612,
+                "bytes": 5323227136,
+                "bits_per_second": 42585944004.00324,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00002,
+                  "end": 6.000004,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5266341888,
+                  "bits_per_second": 42131408113.00068,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.00002,
+                "end": 6.000004,
+                "seconds": 0.9999840259552002,
+                "bytes": 5266341888,
+                "bits_per_second": 42131408113.00068,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000028,
+                  "seconds": 1.0000239610671997,
+                  "bytes": 5331222528,
+                  "bits_per_second": 42648758314.236046,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000028,
+                "seconds": 1.0000239610671997,
+                "bytes": 5331222528,
+                "bits_per_second": 42648758314.236046,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000028,
+                  "end": 8.000016,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5229510656,
+                  "bits_per_second": 41836586472.62994,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000028,
+                "end": 8.000016,
+                "seconds": 0.9999880194664001,
+                "bytes": 5229510656,
+                "bits_per_second": 41836586472.62994,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000016,
+                  "end": 9.000006,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 5216403456,
+                  "bits_per_second": 41731645531.18451,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000016,
+                "end": 9.000006,
+                "seconds": 0.9999899864196777,
+                "bytes": 5216403456,
+                "bits_per_second": 41731645531.18451,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000006,
+                  "end": 10.000033,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 5329518592,
+                  "bits_per_second": 42635000093.695915,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000006,
+                "end": 10.000033,
+                "seconds": 1.0000269412994385,
+                "bytes": 5329518592,
+                "bits_per_second": 42635000093.695915,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040391,
+                  "seconds": 10.040391,
+                  "bytes": 52847242692,
+                  "bits_per_second": 42107716874.37273,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000033,
+                  "seconds": 10.000033,
+                  "bytes": 52846325188,
+                  "bits_per_second": 42276920636.5619,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040391,
+              "seconds": 10.040391,
+              "bytes": 52847242692,
+              "bits_per_second": 42107716874.37273,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000033,
+              "seconds": 10.000033,
+              "bytes": 52846325188,
+              "bits_per_second": 42276920636.5619,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72172176163449,
+              "host_user": 1.7632532126911542,
+              "host_system": 56.958468548943344,
+              "remote_total": 54.5440108210963,
+              "remote_user": 0.40678669250280086,
+              "remote_system": 54.137214462757875
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 46580,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:07 UTC",
+              "timesecs": 1711485127
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1749200440,
+                  "bits_per_second": 13992791169.571945,
+                  "retransmits": 621,
+                  "snd_cwnd": 812844,
+                  "rtt": 417,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1749200440,
+                "bits_per_second": 13992791169.571945,
+                "retransmits": 621,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000151,
+                  "seconds": 1.0000929832458496,
+                  "bytes": 1770835776,
+                  "bits_per_second": 14165369066.005585,
+                  "retransmits": 57,
+                  "snd_cwnd": 912596,
+                  "rtt": 445,
+                  "rttvar": 23,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000151,
+                "seconds": 1.0000929832458496,
+                "bytes": 1770835776,
+                "bits_per_second": 14165369066.005585,
+                "retransmits": 57,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000151,
+                  "end": 3.000227,
+                  "seconds": 1.0000760555267334,
+                  "bytes": 1781066812,
+                  "bits_per_second": 14247450898.617298,
+                  "retransmits": 87,
+                  "snd_cwnd": 669956,
+                  "rtt": 482,
+                  "rttvar": 128,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000151,
+                "end": 3.000227,
+                "seconds": 1.0000760555267334,
+                "bytes": 1781066812,
+                "bits_per_second": 14247450898.617298,
+                "retransmits": 87,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000227,
+                  "end": 4.000645,
+                  "seconds": 1.000417947769165,
+                  "bytes": 1706121192,
+                  "bits_per_second": 13643267362.841578,
+                  "retransmits": 532,
+                  "snd_cwnd": 843848,
+                  "rtt": 461,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000227,
+                "end": 4.000645,
+                "seconds": 1.000417947769165,
+                "bytes": 1706121192,
+                "bits_per_second": 13643267362.841578,
+                "retransmits": 532,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000645,
+                  "end": 5.000058,
+                  "seconds": 0.999413013458252,
+                  "bytes": 1646996516,
+                  "bits_per_second": 13183710788.803326,
+                  "retransmits": 142,
+                  "snd_cwnd": 838456,
+                  "rtt": 544,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000645,
+                "end": 5.000058,
+                "seconds": 0.999413013458252,
+                "bytes": 1646996516,
+                "bits_per_second": 13183710788.803326,
+                "retransmits": 142,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1782799112,
+                  "bits_per_second": 14262407347.797302,
+                  "retransmits": 132,
+                  "snd_cwnd": 928772,
+                  "rtt": 486,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1782799112,
+                "bits_per_second": 14262407347.797302,
+                "retransmits": 132,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000161,
+                  "seconds": 1.0001039505004883,
+                  "bytes": 1788102904,
+                  "bits_per_second": 14303336393.023293,
+                  "retransmits": 77,
+                  "snd_cwnd": 831716,
+                  "rtt": 416,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000161,
+                "seconds": 1.0001039505004883,
+                "bytes": 1788102904,
+                "bits_per_second": 14303336393.023293,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000161,
+                  "end": 8.000058,
+                  "seconds": 0.9998970031738281,
+                  "bytes": 1783196620,
+                  "bits_per_second": 14267042420.088129,
+                  "retransmits": 96,
+                  "snd_cwnd": 824976,
+                  "rtt": 580,
+                  "rttvar": 185,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000161,
+                "end": 8.000058,
+                "seconds": 0.9998970031738281,
+                "bytes": 1783196620,
+                "bits_per_second": 14267042420.088129,
+                "retransmits": 96,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000076,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 1775786432,
+                  "bits_per_second": 14206035738.794409,
+                  "retransmits": 301,
+                  "snd_cwnd": 634908,
+                  "rtt": 423,
+                  "rttvar": 97,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000076,
+                "seconds": 1.0000180006027222,
+                "bytes": 1775786432,
+                "bits_per_second": 14206035738.794409,
+                "retransmits": 301,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000076,
+                  "end": 10.000063,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1681309440,
+                  "bits_per_second": 13450650295.22876,
+                  "retransmits": 249,
+                  "snd_cwnd": 676696,
+                  "rtt": 360,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000076,
+                "end": 10.000063,
+                "seconds": 0.999987006187439,
+                "bytes": 1681309440,
+                "bits_per_second": 13450650295.22876,
+                "retransmits": 249,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17465415244,
+                  "bits_per_second": 13972244170.061728,
+                  "retransmits": 2294,
+                  "max_snd_cwnd": 928772,
+                  "max_rtt": 580,
+                  "min_rtt": 360,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039945,
+                  "seconds": 10.000063,
+                  "bytes": 17463546188,
+                  "bits_per_second": 13915252474.391047,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17465415244,
+              "bits_per_second": 13972244170.061728,
+              "retransmits": 2294,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039945,
+              "seconds": 10.039945,
+              "bytes": 17463546188,
+              "bits_per_second": 13915252474.391047,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.61059396129923,
+              "host_user": 0.19270043453809127,
+              "host_system": 13.417903445457585,
+              "remote_total": 23.486672814565882,
+              "remote_user": 0.5555645903789477,
+              "remote_system": 22.931108224186932
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 50678,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:19 UTC",
+              "timesecs": 1711485139
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000045,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731201352,
+                  "bits_per_second": 13848988416.117579,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000045,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731201352,
+                "bits_per_second": 13848988416.117579,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000045,
+                  "end": 2.000008,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 1582543756,
+                  "bits_per_second": 12660818681.675653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000045,
+                "end": 2.000008,
+                "seconds": 0.9999629855155945,
+                "bytes": 1582543756,
+                "bits_per_second": 12660818681.675653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000008,
+                  "end": 3.000015,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1576707072,
+                  "bits_per_second": 12613567860.386663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000008,
+                "end": 3.000015,
+                "seconds": 1.0000070333480835,
+                "bytes": 1576707072,
+                "bits_per_second": 12613567860.386663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1528626392,
+                  "bits_per_second": 12228852236.5862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1528626392,
+                "bits_per_second": 12228852236.5862,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000013,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 1714944660,
+                  "bits_per_second": 13719763355.92855,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000013,
+                "seconds": 0.9999849796295166,
+                "bytes": 1714944660,
+                "bits_per_second": 13719763355.92855,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000043,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 1705468032,
+                  "bits_per_second": 13643334400.125362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000043,
+                "seconds": 1.0000300407409668,
+                "bytes": 1705468032,
+                "bits_per_second": 13643334400.125362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000043,
+                  "end": 7.000024,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1737755328,
+                  "bits_per_second": 13902306960.81968,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000043,
+                "end": 7.000024,
+                "seconds": 0.9999809861183167,
+                "bytes": 1737755328,
+                "bits_per_second": 13902306960.81968,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000011,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1737625920,
+                  "bits_per_second": 13901187989.43111,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000011,
+                "seconds": 0.999987006187439,
+                "bytes": 1737625920,
+                "bits_per_second": 13901187989.43111,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000011,
+                  "end": 9.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 1625946816,
+                  "bits_per_second": 13007327983.50187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000011,
+                "end": 9.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 1625946816,
+                "bits_per_second": 13007327983.50187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.00004,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1604133292,
+                  "bits_per_second": 12832937832.346245,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.00004,
+                "seconds": 1.0000100135803223,
+                "bytes": 1604133292,
+                "bits_per_second": 12832937832.346245,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039719,
+                  "seconds": 10.039719,
+                  "bytes": 16547546348,
+                  "bits_per_second": 13185664935.841331,
+                  "retransmits": 2136,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00004,
+                  "seconds": 10.00004,
+                  "bytes": 16544952620,
+                  "bits_per_second": 13235909152.36339,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039719,
+              "seconds": 10.039719,
+              "bytes": 16547546348,
+              "bits_per_second": 13185664935.841331,
+              "retransmits": 2136,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00004,
+              "seconds": 10.00004,
+              "bytes": 16544952620,
+              "bits_per_second": 13235909152.36339,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.747516641197084,
+              "host_user": 1.0158505257156165,
+              "host_system": 25.731666115481467,
+              "remote_total": 11.755923477356498,
+              "remote_user": 0.13796182174123386,
+              "remote_system": 11.617971314101807
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 41706,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:38 UTC",
+              "timesecs": 1711485158
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000041,
+                  "seconds": 1.0000410079956055,
+                  "bytes": 4768399360,
+                  "bits_per_second": 38145630604.14782,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 24,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000041,
+                "seconds": 1.0000410079956055,
+                "bytes": 4768399360,
+                "bits_per_second": 38145630604.14782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000041,
+                  "end": 2.000213,
+                  "seconds": 1.0001720190048218,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38444668706.348434,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000041,
+                "end": 2.000213,
+                "seconds": 1.0001720190048218,
+                "bytes": 4806410240,
+                "bits_per_second": 38444668706.348434,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000213,
+                  "end": 3.00012,
+                  "seconds": 0.9999070167541504,
+                  "bytes": 4761203140,
+                  "bits_per_second": 38093167146.32596,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000213,
+                "end": 3.00012,
+                "seconds": 0.9999070167541504,
+                "bytes": 4761203140,
+                "bits_per_second": 38093167146.32596,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00012,
+                  "end": 4.000102,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 4814274560,
+                  "bits_per_second": 38514889771.22966,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00012,
+                "end": 4.000102,
+                "seconds": 0.9999819993972778,
+                "bytes": 4814274560,
+                "bits_per_second": 38514889771.22966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000102,
+                  "end": 5.000003,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38497036294.209724,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000102,
+                "end": 5.000003,
+                "seconds": 0.9999009966850281,
+                "bytes": 4811653120,
+                "bits_per_second": 38497036294.209724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000003,
+                  "end": 6.000056,
+                  "seconds": 1.00005304813385,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38365360629.214134,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000003,
+                "end": 6.000056,
+                "seconds": 1.00005304813385,
+                "bytes": 4795924480,
+                "bits_per_second": 38365360629.214134,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000108,
+                  "seconds": 1.0000519752502441,
+                  "bytes": 4746117120,
+                  "bits_per_second": 37966963617.564964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000108,
+                "seconds": 1.0000519752502441,
+                "bytes": 4746117120,
+                "bits_per_second": 37966963617.564964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000108,
+                  "end": 8.000094,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38409876890.660965,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 37,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000108,
+                "end": 8.000094,
+                "seconds": 0.9999859929084778,
+                "bytes": 4801167360,
+                "bits_per_second": 38409876890.660965,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000094,
+                  "end": 9.000078,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38462382079.81445,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000094,
+                "end": 9.000078,
+                "seconds": 0.9999840259552002,
+                "bytes": 4807720960,
+                "bits_per_second": 38462382079.81445,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000078,
+                  "end": 10.00019,
+                  "seconds": 1.0001120567321777,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38111466953.55469,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000078,
+                "end": 10.00019,
+                "seconds": 1.0001120567321777,
+                "bytes": 4764467200,
+                "bits_per_second": 38111466953.55469,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00019,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38301142310.296104,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1202416,
+                  "max_rtt": 37,
+                  "min_rtt": 21,
+                  "mean_rtt": 24,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040372,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38147859493.65223,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00019,
+              "seconds": 10.00019,
+              "bytes": 47877337540,
+              "bits_per_second": 38301142310.296104,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040372,
+              "seconds": 10.040372,
+              "bytes": 47877337540,
+              "bits_per_second": 38147859493.65223,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.579098862767125,
+              "host_user": 0.4361726860977011,
+              "host_system": 51.14293609532062,
+              "remote_total": 44.789642459824776,
+              "remote_user": 1.3832780535675204,
+              "remote_system": 43.40635613187544
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 57026,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:50 UTC",
+              "timesecs": 1711485170
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5283402056,
+                  "bits_per_second": 42266158359.07089,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 5283402056,
+                "bits_per_second": 42266158359.07089,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5276569800,
+                  "bits_per_second": 42212643946.36801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5276569800,
+                "bits_per_second": 42212643946.36801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000023,
+                  "end": 3.000005,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42418808492.11961,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000023,
+                "end": 3.000005,
+                "seconds": 0.9999819993972778,
+                "bytes": 5302255616,
+                "bits_per_second": 42418808492.11961,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.00003,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5176033280,
+                  "bits_per_second": 41407229653.44986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.00003,
+                "seconds": 1.0000250339508057,
+                "bytes": 5176033280,
+                "bits_per_second": 41407229653.44986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00003,
+                  "end": 5.000008,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5233967104,
+                  "bits_per_second": 41872657784.00552,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.00003,
+                "end": 5.000008,
+                "seconds": 0.9999780058860779,
+                "bytes": 5233967104,
+                "bits_per_second": 41872657784.00552,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000008,
+                  "end": 6.000007,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5299765248,
+                  "bits_per_second": 42398164945.16853,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000008,
+                "end": 6.000007,
+                "seconds": 0.9999989867210388,
+                "bytes": 5299765248,
+                "bits_per_second": 42398164945.16853,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000007,
+                  "end": 7.000021,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42417453311.12657,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000007,
+                "end": 7.000021,
+                "seconds": 1.0000139474868774,
+                "bytes": 5302255616,
+                "bits_per_second": 42417453311.12657,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000021,
+                  "end": 8.000026,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 5336727552,
+                  "bits_per_second": 42693606658.070244,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000021,
+                "end": 8.000026,
+                "seconds": 1.0000050067901611,
+                "bytes": 5336727552,
+                "bits_per_second": 42693606658.070244,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000026,
+                  "end": 9.000032,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 5314183168,
+                  "bits_per_second": 42513211945.510376,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000026,
+                "end": 9.000032,
+                "seconds": 1.0000059604644775,
+                "bytes": 5314183168,
+                "bits_per_second": 42513211945.510376,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000018,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 5215485952,
+                  "bits_per_second": 41724472054.49879,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000018,
+                "seconds": 0.9999859929084778,
+                "bytes": 5215485952,
+                "bits_per_second": 41724472054.49879,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040334,
+                  "seconds": 10.040334,
+                  "bytes": 52741693968,
+                  "bits_per_second": 42023856152.99252,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000018,
+                  "seconds": 10.000018,
+                  "bytes": 52740645392,
+                  "bits_per_second": 42192440367.20734,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040334,
+              "seconds": 10.040334,
+              "bytes": 52741693968,
+              "bits_per_second": 42023856152.99252,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000018,
+              "seconds": 10.000018,
+              "bytes": 52740645392,
+              "bits_per_second": 42192440367.20734,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72825614611755,
+              "host_user": 1.7371177997142697,
+              "host_system": 56.991148265535564,
+              "remote_total": 54.64429253795493,
+              "remote_user": 0.4133314501365237,
+              "remote_system": 54.23096108781841
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 43702,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:09 UTC",
+              "timesecs": 1711485189
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1470700168,
+                  "bits_per_second": 11764930954.229,
+                  "retransmits": 1151,
+                  "snd_cwnd": 816888,
+                  "rtt": 591,
+                  "rttvar": 85,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1470700168,
+                "bits_per_second": 11764930954.229,
+                "retransmits": 1151,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1666939764,
+                  "bits_per_second": 13335505394.27101,
+                  "retransmits": 59,
+                  "snd_cwnd": 958428,
+                  "rtt": 636,
+                  "rttvar": 81,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1666939764,
+                "bits_per_second": 13335505394.27101,
+                "retransmits": 59,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1704166784,
+                  "bits_per_second": 13633348086.384787,
+                  "retransmits": 118,
+                  "snd_cwnd": 688828,
+                  "rtt": 360,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1704166784,
+                "bits_per_second": 13633348086.384787,
+                "retransmits": 118,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1593611456,
+                  "bits_per_second": 12748891648,
+                  "retransmits": 128,
+                  "snd_cwnd": 804756,
+                  "rtt": 415,
+                  "rttvar": 1,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1593611456,
+                "bits_per_second": 12748891648,
+                "retransmits": 128,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1778151040,
+                  "bits_per_second": 14225194753.797117,
+                  "retransmits": 49,
+                  "snd_cwnd": 953036,
+                  "rtt": 494,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1778151040,
+                "bits_per_second": 14225194753.797117,
+                "retransmits": 49,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000056,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1775902848,
+                  "bits_per_second": 14207251575.818235,
+                  "retransmits": 79,
+                  "snd_cwnd": 850588,
+                  "rtt": 461,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000056,
+                "seconds": 0.9999979734420776,
+                "bytes": 1775902848,
+                "bits_per_second": 14207251575.818235,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000058,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1780742784,
+                  "bits_per_second": 14245913401.831335,
+                  "retransmits": 108,
+                  "snd_cwnd": 943600,
+                  "rtt": 507,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000058,
+                "seconds": 1.0000020265579224,
+                "bytes": 1780742784,
+                "bits_per_second": 14245913401.831335,
+                "retransmits": 108,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000058,
+                  "end": 8.000058,
+                  "seconds": 1,
+                  "bytes": 1778931136,
+                  "bits_per_second": 14231449088,
+                  "retransmits": 110,
+                  "snd_cwnd": 846544,
+                  "rtt": 461,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000058,
+                "end": 8.000058,
+                "seconds": 1,
+                "bytes": 1778931136,
+                "bits_per_second": 14231449088,
+                "retransmits": 110,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1771323712,
+                  "bits_per_second": 14170589696,
+                  "retransmits": 77,
+                  "snd_cwnd": 830368,
+                  "rtt": 478,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1771323712,
+                "bits_per_second": 14170589696,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000215,
+                  "seconds": 1.0001569986343384,
+                  "bytes": 1773207680,
+                  "bits_per_second": 14183434660.128132,
+                  "retransmits": 120,
+                  "snd_cwnd": 501456,
+                  "rtt": 244,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000215,
+                "seconds": 1.0001569986343384,
+                "bytes": 1773207680,
+                "bits_per_second": 14183434660.128132,
+                "retransmits": 120,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000215,
+                  "seconds": 10.000215,
+                  "bytes": 17093677372,
+                  "bits_per_second": 13674647892.670307,
+                  "retransmits": 1999,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 636,
+                  "min_rtt": 244,
+                  "mean_rtt": 464,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039929,
+                  "seconds": 10.000215,
+                  "bytes": 17090819196,
+                  "bits_per_second": 13618278930.85698,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000215,
+              "seconds": 10.000215,
+              "bytes": 17093677372,
+              "bits_per_second": 13674647892.670307,
+              "retransmits": 1999,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039929,
+              "seconds": 10.039929,
+              "bytes": 17090819196,
+              "bits_per_second": 13618278930.85698,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.005006946322178,
+              "host_user": 0.19271754050004394,
+              "host_system": 12.812299324888505,
+              "remote_total": 23.26438245505795,
+              "remote_user": 0.8376646905752849,
+              "remote_system": 22.426726025964516
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 57004,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:21 UTC",
+              "timesecs": 1711485201
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1720841732,
+                  "bits_per_second": 13765949444.112558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1720841732,
+                "bits_per_second": 13765949444.112558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000017,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 1732854844,
+                  "bits_per_second": 13863393214.483341,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000017,
+                "seconds": 0.9999600052833557,
+                "bytes": 1732854844,
+                "bits_per_second": 13863393214.483341,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000017,
+                  "end": 3.000057,
+                  "seconds": 1.000040054321289,
+                  "bytes": 1691401320,
+                  "bits_per_second": 13530668598.25271,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000017,
+                "end": 3.000057,
+                "seconds": 1.000040054321289,
+                "bytes": 1691401320,
+                "bits_per_second": 13530668598.25271,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000067,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1568036736,
+                  "bits_per_second": 12544168275.963392,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000067,
+                "seconds": 1.0000100135803223,
+                "bytes": 1568036736,
+                "bits_per_second": 12544168275.963392,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000067,
+                  "end": 5.000031,
+                  "seconds": 0.9999639987945557,
+                  "bytes": 1557489984,
+                  "bits_per_second": 12460368460.284851,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000067,
+                "end": 5.000031,
+                "seconds": 0.9999639987945557,
+                "bytes": 1557489984,
+                "bits_per_second": 12460368460.284851,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000045,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900295853.805986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000045,
+                "seconds": 1.0000139474868774,
+                "bytes": 1737561216,
+                "bits_per_second": 13900295853.805986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000045,
+                  "end": 7.000026,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1735555392,
+                  "bits_per_second": 13884707138.178734,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000045,
+                "end": 7.000026,
+                "seconds": 0.9999809861183167,
+                "bytes": 1735555392,
+                "bits_per_second": 13884707138.178734,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000033,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1590631612,
+                  "bits_per_second": 12724963396.90308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000033,
+                "seconds": 1.0000070333480835,
+                "bytes": 1590631612,
+                "bits_per_second": 12724963396.90308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000033,
+                  "end": 9.000026,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1589841984,
+                  "bits_per_second": 12718824569.819391,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000033,
+                "end": 9.000026,
+                "seconds": 0.9999930262565613,
+                "bytes": 1589841984,
+                "bits_per_second": 12718824569.819391,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000026,
+                  "seconds": 1,
+                  "bytes": 1480498380,
+                  "bits_per_second": 11843987040,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000026,
+                "seconds": 1,
+                "bytes": 1480498380,
+                "bits_per_second": 11843987040,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03968,
+                  "seconds": 10.03968,
+                  "bytes": 16408142512,
+                  "bits_per_second": 13074633862.43386,
+                  "retransmits": 1734,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000026,
+                  "seconds": 10.000026,
+                  "bytes": 16404713200,
+                  "bits_per_second": 13123736438.285261,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03968,
+              "seconds": 10.03968,
+              "bytes": 16408142512,
+              "bits_per_second": 13074633862.43386,
+              "retransmits": 1734,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000026,
+              "seconds": 10.000026,
+              "bytes": 16404713200,
+              "bits_per_second": 13123736438.285261,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.064632328384384,
+              "host_user": 1.162207899423042,
+              "host_system": 24.902424428961346,
+              "remote_total": 11.69062967191739,
+              "remote_user": 0.12009331046577057,
+              "remote_system": 11.570546012927187
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56708,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:39 UTC",
+              "timesecs": 1711485219
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000229,
+                  "seconds": 1.000229001045227,
+                  "bytes": 3386293120,
+                  "bits_per_second": 27084142663.02109,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000229,
+                "seconds": 1.000229001045227,
+                "bytes": 3386293120,
+                "bits_per_second": 27084142663.02109,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000229,
+                  "end": 2.000133,
+                  "seconds": 0.9999039769172668,
+                  "bytes": 3393454080,
+                  "bits_per_second": 27150239689.71195,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000229,
+                "end": 2.000133,
+                "seconds": 0.9999039769172668,
+                "bytes": 3393454080,
+                "bits_per_second": 27150239689.71195,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000133,
+                  "end": 3.000277,
+                  "seconds": 1.0001440048217773,
+                  "bytes": 3402629120,
+                  "bits_per_second": 27217113564.41186,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000133,
+                "end": 3.000277,
+                "seconds": 1.0001440048217773,
+                "bytes": 3402629120,
+                "bits_per_second": 27217113564.41186,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000277,
+                  "end": 4.000095,
+                  "seconds": 0.9998180270195007,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27309888701.844177,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000277,
+                "end": 4.000095,
+                "seconds": 0.9998180270195007,
+                "bytes": 3413114880,
+                "bits_per_second": 27309888701.844177,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000095,
+                  "end": 5.000135,
+                  "seconds": 1.000040054321289,
+                  "bytes": 3415736320,
+                  "bits_per_second": 27324796083.8385,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000095,
+                "end": 5.000135,
+                "seconds": 1.000040054321289,
+                "bytes": 3415736320,
+                "bits_per_second": 27324796083.8385,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000135,
+                  "end": 6.000236,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27302162333.34541,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000135,
+                "end": 6.000236,
+                "seconds": 1.0001009702682495,
+                "bytes": 3413114880,
+                "bits_per_second": 27302162333.34541,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000236,
+                  "end": 7.000377,
+                  "seconds": 1.0001410245895386,
+                  "bytes": 3403939840,
+                  "bits_per_second": 27227678947.752304,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000236,
+                "end": 7.000377,
+                "seconds": 1.0001410245895386,
+                "bytes": 3403939840,
+                "bits_per_second": 27227678947.752304,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000377,
+                  "end": 8.000122,
+                  "seconds": 0.9997450113296509,
+                  "bytes": 3405250560,
+                  "bits_per_second": 27248952654.205704,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000377,
+                "end": 8.000122,
+                "seconds": 0.9997450113296509,
+                "bytes": 3405250560,
+                "bits_per_second": 27248952654.205704,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000122,
+                  "end": 9.000175,
+                  "seconds": 1.00005304813385,
+                  "bytes": 3457679360,
+                  "bits_per_second": 27659967570.33804,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 32,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000122,
+                "end": 9.000175,
+                "seconds": 1.00005304813385,
+                "bytes": 3457679360,
+                "bits_per_second": 27659967570.33804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000175,
+                  "end": 10.000275,
+                  "seconds": 1.000100016593933,
+                  "bytes": 3503554560,
+                  "bits_per_second": 28025633451.599354,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 30,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000175,
+                "end": 10.000275,
+                "seconds": 1.000100016593933,
+                "bytes": 3503554560,
+                "bits_per_second": 28025633451.599354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000275,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27355061111.819424,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 798016,
+                  "max_rtt": 35,
+                  "min_rtt": 30,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040107,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27246535695.28691,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000275,
+              "seconds": 10.000275,
+              "bytes": 34194766720,
+              "bits_per_second": 27355061111.819424,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040107,
+              "seconds": 10.040107,
+              "bytes": 34194766720,
+              "bits_per_second": 27246535695.28691,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.44527815243438,
+              "host_user": 0.4874417118707169,
+              "host_system": 83.95785625929561,
+              "remote_total": 37.5809576369255,
+              "remote_user": 1.2945095444412822,
+              "remote_system": 36.286448092484214
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37086,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:51 UTC",
+              "timesecs": 1711485231
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000019,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 4331032904,
+                  "bits_per_second": 34647606511.66746,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000019,
+                "seconds": 1.0000189542770386,
+                "bytes": 4331032904,
+                "bits_per_second": 34647606511.66746,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000019,
+                  "end": 2.000003,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4384751616,
+                  "bits_per_second": 35078573274.701004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000019,
+                "end": 2.000003,
+                "seconds": 0.9999840259552002,
+                "bytes": 4384751616,
+                "bits_per_second": 35078573274.701004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000003,
+                  "end": 3.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4398120960,
+                  "bits_per_second": 35184405642.72801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000003,
+                "end": 3.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 4398120960,
+                "bits_per_second": 35184405642.72801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000018,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4399955968,
+                  "bits_per_second": 35199683411.09864,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000018,
+                "seconds": 0.9999989867210388,
+                "bytes": 4399955968,
+                "bits_per_second": 35199683411.09864,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000002,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4368367616,
+                  "bits_per_second": 34947499180.91756,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000002,
+                "seconds": 0.9999840259552002,
+                "bytes": 4368367616,
+                "bits_per_second": 34947499180.91756,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000002,
+                  "end": 6.000018,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4274782208,
+                  "bits_per_second": 34197711388.226234,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000002,
+                "end": 6.000018,
+                "seconds": 1.0000159740447998,
+                "bytes": 4274782208,
+                "bits_per_second": 34197711388.226234,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000016,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 4378853376,
+                  "bits_per_second": 35030898000.14387,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000016,
+                "seconds": 0.9999979734420776,
+                "bytes": 4378853376,
+                "bits_per_second": 35030898000.14387,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000016,
+                  "end": 8.000018,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 4318953472,
+                  "bits_per_second": 34551557755.2669,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000016,
+                "end": 8.000018,
+                "seconds": 1.0000020265579224,
+                "bytes": 4318953472,
+                "bits_per_second": 34551557755.2669,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000018,
+                  "end": 9.000035,
+                  "seconds": 1.0000170469284058,
+                  "bytes": 4416208896,
+                  "bits_per_second": 35329068915.89155,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000018,
+                "end": 9.000035,
+                "seconds": 1.0000170469284058,
+                "bytes": 4416208896,
+                "bits_per_second": 35329068915.89155,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000035,
+                  "end": 10.00001,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 4437573632,
+                  "bits_per_second": 35501475682.14291,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000035,
+                "end": 10.00001,
+                "seconds": 0.9999750256538391,
+                "bytes": 4437573632,
+                "bits_per_second": 35501475682.14291,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040164,
+                  "seconds": 10.040164,
+                  "bytes": 43710042440,
+                  "bits_per_second": 34828150169.65858,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00001,
+                  "seconds": 10.00001,
+                  "bytes": 43708600648,
+                  "bits_per_second": 34966845551.55445,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040164,
+              "seconds": 10.040164,
+              "bytes": 43710042440,
+              "bits_per_second": 34828150169.65858,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00001,
+              "seconds": 10.00001,
+              "bytes": 43708600648,
+              "bits_per_second": 34966845551.55445,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.26294493237891,
+              "host_user": 1.8116036545309533,
+              "host_system": 89.45135119667133,
+              "remote_total": 44.14246868282316,
+              "remote_user": 0.32552835005268926,
+              "remote_system": 43.816940332770464
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55424,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:09 UTC",
+              "timesecs": 1711485249
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000296,
+                  "seconds": 1.0002959966659546,
+                  "bytes": 1501175364,
+                  "bits_per_second": 12005849220.658731,
+                  "retransmits": 40,
+                  "snd_cwnd": 641648,
+                  "rtt": 391,
+                  "rttvar": 37,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000296,
+                "seconds": 1.0002959966659546,
+                "bytes": 1501175364,
+                "bits_per_second": 12005849220.658731,
+                "retransmits": 40,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000296,
+                  "end": 2.000231,
+                  "seconds": 0.99993497133255,
+                  "bytes": 1529610240,
+                  "bits_per_second": 12237677719.874805,
+                  "retransmits": 12,
+                  "snd_cwnd": 787232,
+                  "rtt": 223,
+                  "rttvar": 31,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000296,
+                "end": 2.000231,
+                "seconds": 0.99993497133255,
+                "bytes": 1529610240,
+                "bits_per_second": 12237677719.874805,
+                "retransmits": 12,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000231,
+                  "end": 3.000429,
+                  "seconds": 1.0001980066299438,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12286877836.727018,
+                  "retransmits": 13,
+                  "snd_cwnd": 655128,
+                  "rtt": 228,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000231,
+                "end": 3.000429,
+                "seconds": 1.0001980066299438,
+                "bytes": 1536163840,
+                "bits_per_second": 12286877836.727018,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000429,
+                  "end": 4.000044,
+                  "seconds": 0.9996150135993958,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12367472348.664085,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 193,
+                  "rttvar": 25,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000429,
+                "end": 4.000044,
+                "seconds": 0.9996150135993958,
+                "bytes": 1545338880,
+                "bits_per_second": 12367472348.664085,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000044,
+                  "end": 5.000092,
+                  "seconds": 1.000048041343689,
+                  "bytes": 1523056640,
+                  "bits_per_second": 12183867790.62001,
+                  "retransmits": 2,
+                  "snd_cwnd": 936860,
+                  "rtt": 606,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000044,
+                "end": 5.000092,
+                "seconds": 1.000048041343689,
+                "bytes": 1523056640,
+                "bits_per_second": 12183867790.62001,
+                "retransmits": 2,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000092,
+                  "end": 6.000681,
+                  "seconds": 1.0005890130996704,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12376392702.57152,
+                  "retransmits": 6,
+                  "snd_cwnd": 829020,
+                  "rtt": 197,
+                  "rttvar": 54,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000092,
+                "end": 6.000681,
+                "seconds": 1.0005890130996704,
+                "bytes": 1547960320,
+                "bits_per_second": 12376392702.57152,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000681,
+                  "end": 7.000548,
+                  "seconds": 0.9998670220375061,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12385329535.886497,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 218,
+                  "rttvar": 40,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000681,
+                "end": 7.000548,
+                "seconds": 0.9998670220375061,
+                "bytes": 1547960320,
+                "bits_per_second": 12385329535.886497,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000548,
+                  "end": 8.000077,
+                  "seconds": 0.9995290040969849,
+                  "bytes": 1534853120,
+                  "bits_per_second": 12284610961.43297,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 200,
+                  "rttvar": 33,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000548,
+                "end": 8.000077,
+                "seconds": 0.9995290040969849,
+                "bytes": 1534853120,
+                "bits_per_second": 12284610961.43297,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000077,
+                  "end": 9.000416,
+                  "seconds": 1.0003390312194824,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12285145672.081276,
+                  "retransmits": 0,
+                  "snd_cwnd": 934164,
+                  "rtt": 220,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000077,
+                "end": 9.000416,
+                "seconds": 1.0003390312194824,
+                "bytes": 1536163840,
+                "bits_per_second": 12285145672.081276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000416,
+                  "end": 10.00071,
+                  "seconds": 1.0002939701080322,
+                  "bytes": 1544028160,
+                  "bits_per_second": 12348595162.146137,
+                  "retransmits": 50,
+                  "snd_cwnd": 776448,
+                  "rtt": 184,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000416,
+                "end": 10.00071,
+                "seconds": 1.0002939701080322,
+                "bytes": 1544028160,
+                "bits_per_second": 12348595162.146137,
+                "retransmits": 50,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00071,
+                  "seconds": 10.00071,
+                  "bytes": 15346310724,
+                  "bits_per_second": 12276176970.635086,
+                  "retransmits": 123,
+                  "max_snd_cwnd": 936860,
+                  "max_rtt": 606,
+                  "min_rtt": 184,
+                  "mean_rtt": 266,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040277,
+                  "seconds": 10.00071,
+                  "bytes": 15346244356,
+                  "bits_per_second": 12227745793.069256,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00071,
+              "seconds": 10.00071,
+              "bytes": 15346310724,
+              "bits_per_second": 12276176970.635086,
+              "retransmits": 123,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040277,
+              "seconds": 10.040277,
+              "bytes": 15346244356,
+              "bits_per_second": 12227745793.069256,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 95.82562437024121,
+              "host_user": 0.2560031758234491,
+              "host_system": 95.56962119441776,
+              "remote_total": 24.102997438800752,
+              "remote_user": 1.0351409018247604,
+              "remote_system": 23.06785653697599
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39456,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:21 UTC",
+              "timesecs": 1711485261
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1697801956,
+                  "bits_per_second": 13582334690.976553,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1697801956,
+                "bits_per_second": 13582334690.976553,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000057,
+                  "seconds": 1.0000510215759277,
+                  "bytes": 1744419840,
+                  "bits_per_second": 13954646731.932222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000057,
+                "seconds": 1.0000510215759277,
+                "bytes": 1744419840,
+                "bits_per_second": 13954646731.932222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000015,
+                  "seconds": 0.9999579787254333,
+                  "bytes": 1748195168,
+                  "bits_per_second": 13986149059.809772,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000015,
+                "seconds": 0.9999579787254333,
+                "bytes": 1748195168,
+                "bits_per_second": 13986149059.809772,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1734067200,
+                  "bits_per_second": 13872357345.188877,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1734067200,
+                "bits_per_second": 13872357345.188877,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1729473216,
+                  "bits_per_second": 13835744494.268211,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 1729473216,
+                "bits_per_second": 13835744494.268211,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000014,
+                  "seconds": 0.999983012676239,
+                  "bytes": 1727920320,
+                  "bits_per_second": 13823597385.924335,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000014,
+                "seconds": 0.999983012676239,
+                "bytes": 1727920320,
+                "bits_per_second": 13823597385.924335,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000014,
+                  "end": 7.000057,
+                  "seconds": 1.0000430345535278,
+                  "bytes": 1720414656,
+                  "bits_per_second": 13762724975.275362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000014,
+                "end": 7.000057,
+                "seconds": 1.0000430345535278,
+                "bytes": 1720414656,
+                "bits_per_second": 13762724975.275362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000012,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 1731396632,
+                  "bits_per_second": 13851796407.710308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000012,
+                "seconds": 0.9999549984931946,
+                "bytes": 1731396632,
+                "bits_per_second": 13851796407.710308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000012,
+                  "end": 9.000057,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731026112,
+                  "bits_per_second": 13847586559.1197,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000012,
+                "end": 9.000057,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731026112,
+                "bits_per_second": 13847586559.1197,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000057,
+                  "end": 10.000029,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 1741314048,
+                  "bits_per_second": 13930902646.856724,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000057,
+                "end": 10.000029,
+                "seconds": 0.9999719858169556,
+                "bytes": 1741314048,
+                "bits_per_second": 13930902646.856724,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039465,
+                  "seconds": 10.039465,
+                  "bytes": 17308229084,
+                  "bits_per_second": 13792152537.211893,
+                  "retransmits": 2195,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000029,
+                  "seconds": 10.000029,
+                  "bytes": 17306029148,
+                  "bits_per_second": 13844783168.528812,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039465,
+              "seconds": 10.039465,
+              "bytes": 17308229084,
+              "bits_per_second": 13792152537.211893,
+              "retransmits": 2195,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000029,
+              "seconds": 10.000029,
+              "bytes": 17306029148,
+              "bits_per_second": 13844783168.528812,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.47684113065824,
+              "host_user": 1.8968527601361653,
+              "host_system": 42.57999828989936,
+              "remote_total": 12.529305328982618,
+              "remote_user": 0.09332895016906215,
+              "remote_system": 12.435986036196645
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56016,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:38 UTC",
+              "timesecs": 1711485278
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000293,
+                  "seconds": 1.0002930164337158,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25745482710.471886,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000293,
+                "seconds": 1.0002930164337158,
+                "bytes": 3219128320,
+                "bits_per_second": 25745482710.471886,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000293,
+                  "end": 2.000138,
+                  "seconds": 0.999845027923584,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25757018178.58942,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 37,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000293,
+                "end": 2.000138,
+                "seconds": 0.999845027923584,
+                "bytes": 3219128320,
+                "bits_per_second": 25757018178.58942,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000138,
+                  "end": 3.000088,
+                  "seconds": 0.9999499917030334,
+                  "bytes": 3282042880,
+                  "bits_per_second": 26257656140.665928,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000138,
+                "end": 3.000088,
+                "seconds": 0.9999499917030334,
+                "bytes": 3282042880,
+                "bits_per_second": 26257656140.665928,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000088,
+                  "end": 4.000243,
+                  "seconds": 1.000154972076416,
+                  "bytes": 3465543680,
+                  "bits_per_second": 27720053605.734356,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000088,
+                "end": 4.000243,
+                "seconds": 1.000154972076416,
+                "bytes": 3465543680,
+                "bits_per_second": 27720053605.734356,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000243,
+                  "end": 5.000101,
+                  "seconds": 0.999858021736145,
+                  "bytes": 3481272320,
+                  "bits_per_second": 27854133241.47881,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000243,
+                "end": 5.000101,
+                "seconds": 0.999858021736145,
+                "bytes": 3481272320,
+                "bits_per_second": 27854133241.47881,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000101,
+                  "end": 6.000015,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 3489136640,
+                  "bits_per_second": 27915494117.75862,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000101,
+                "end": 6.000015,
+                "seconds": 0.9999139904975891,
+                "bytes": 3489136640,
+                "bits_per_second": 27915494117.75862,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000015,
+                  "end": 7.000294,
+                  "seconds": 1.0002789497375488,
+                  "bytes": 3472097280,
+                  "bits_per_second": 27769032075.790474,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000015,
+                "end": 7.000294,
+                "seconds": 1.0002789497375488,
+                "bytes": 3472097280,
+                "bits_per_second": 27769032075.790474,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000294,
+                  "end": 8.000249,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 3482583040,
+                  "bits_per_second": 27861918148.299164,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000294,
+                "end": 8.000249,
+                "seconds": 0.9999549984931946,
+                "bytes": 3482583040,
+                "bits_per_second": 27861918148.299164,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000249,
+                  "end": 9.000268,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 3388211200,
+                  "bits_per_second": 27105175840.98793,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000249,
+                "end": 9.000268,
+                "seconds": 1.0000189542770386,
+                "bytes": 3388211200,
+                "bits_per_second": 27105175840.98793,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000268,
+                  "end": 10.000366,
+                  "seconds": 1.0000979900360107,
+                  "bytes": 3389521920,
+                  "bits_per_second": 27113518505.345284,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 31,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000268,
+                "end": 10.000366,
+                "seconds": 1.0000979900360107,
+                "bytes": 3389521920,
+                "bits_per_second": 27113518505.345284,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000366,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27109940256.186626,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 663216,
+                  "max_rtt": 37,
+                  "min_rtt": 31,
+                  "mean_rtt": 33,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039647,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27003870235.676613,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000366,
+              "seconds": 10.000366,
+              "bytes": 33888665600,
+              "bits_per_second": 27109940256.186626,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039647,
+              "seconds": 10.039647,
+              "bytes": 33888665600,
+              "bits_per_second": 27003870235.676613,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.6366144037512,
+              "host_user": 0.5079154773387307,
+              "host_system": 98.12868897353042,
+              "remote_total": 69.33475570009895,
+              "remote_user": 1.8358332803622874,
+              "remote_system": 67.4989133777374
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 41272,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:50 UTC",
+              "timesecs": 1711485290
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000015,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 3679605064,
+                  "bits_per_second": 29436398366.39084,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000015,
+                "seconds": 1.0000150203704834,
+                "bytes": 3679605064,
+                "bits_per_second": 29436398366.39084,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000015,
+                  "end": 2.00001,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 3648388804,
+                  "bits_per_second": 29187256566.469006,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000015,
+                "end": 2.00001,
+                "seconds": 0.9999949932098389,
+                "bytes": 3648388804,
+                "bits_per_second": 29187256566.469006,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000028,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 3632922940,
+                  "bits_per_second": 29062860370.99649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000028,
+                "seconds": 1.0000180006027222,
+                "bytes": 3632922940,
+                "bits_per_second": 29062860370.99649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000028,
+                  "end": 4.000024,
+                  "seconds": 0.9999960064888,
+                  "bytes": 3643932672,
+                  "bits_per_second": 29151577793.152412,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000028,
+                "end": 4.000024,
+                "seconds": 0.9999960064888,
+                "bytes": 3643932672,
+                "bits_per_second": 29151577793.152412,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000024,
+                  "end": 5.000031,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 3619028992,
+                  "bits_per_second": 28952028306.307198,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000024,
+                "end": 5.000031,
+                "seconds": 1.0000070333480835,
+                "bytes": 3619028992,
+                "bits_per_second": 28952028306.307198,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000037,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 3631349760,
+                  "bits_per_second": 29050624924.782085,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000037,
+                "seconds": 1.0000059604644775,
+                "bytes": 3631349760,
+                "bits_per_second": 29050624924.782085,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000037,
+                  "end": 7.000025,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 3610509312,
+                  "bits_per_second": 28884420546.770874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000037,
+                "end": 7.000025,
+                "seconds": 0.9999880194664001,
+                "bytes": 3610509312,
+                "bits_per_second": 28884420546.770874,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000025,
+                  "end": 8.000022,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3608674304,
+                  "bits_per_second": 28869480469.756413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000025,
+                "end": 8.000022,
+                "seconds": 0.9999970197677612,
+                "bytes": 3608674304,
+                "bits_per_second": 28869480469.756413,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000022,
+                  "end": 9.000038,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 3623223296,
+                  "bits_per_second": 28985323355.146187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000022,
+                "end": 9.000038,
+                "seconds": 1.0000159740447998,
+                "bytes": 3623223296,
+                "bits_per_second": 28985323355.146187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000038,
+                  "end": 10.000021,
+                  "seconds": 0.999983012676239,
+                  "bytes": 3621519360,
+                  "bits_per_second": 28972647047.73561,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000038,
+                "end": 10.000021,
+                "seconds": 0.999983012676239,
+                "bytes": 3621519360,
+                "bits_per_second": 28972647047.73561,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039809,
+                  "seconds": 10.039809,
+                  "bytes": 36320203080,
+                  "bits_per_second": 28940951430.45052,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000021,
+                  "seconds": 10.000021,
+                  "bytes": 36319154504,
+                  "bits_per_second": 29055262587.148567,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039809,
+              "seconds": 10.039809,
+              "bytes": 36320203080,
+              "bits_per_second": 28940951430.45052,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000021,
+              "seconds": 10.000021,
+              "bytes": 36319154504,
+              "bits_per_second": 29055262587.148567,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.40432984604324,
+              "host_user": 2.1048623181527053,
+              "host_system": 84.29947744708186,
+              "remote_total": 96.37010529501002,
+              "remote_user": 0.5200516733573617,
+              "remote_system": 95.85006329541284
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 35114,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:07 UTC",
+              "timesecs": 1711485307
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2927638472,
+                  "bits_per_second": 23419748144.30112,
+                  "retransmits": 368,
+                  "snd_cwnd": 2701392,
+                  "rtt": 911,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 2927638472,
+                "bits_per_second": 23419748144.30112,
+                "retransmits": 368,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000132,
+                  "seconds": 1.000074028968811,
+                  "bytes": 2915041280,
+                  "bits_per_second": 23318603987.79267,
+                  "retransmits": 202,
+                  "snd_cwnd": 2724308,
+                  "rtt": 935,
+                  "rttvar": 42,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000132,
+                "seconds": 1.000074028968811,
+                "bytes": 2915041280,
+                "bits_per_second": 23318603987.79267,
+                "retransmits": 202,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000132,
+                  "end": 3.000059,
+                  "seconds": 0.9999269843101501,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416411845.464706,
+                  "retransmits": 13,
+                  "snd_cwnd": 2744528,
+                  "rtt": 900,
+                  "rttvar": 30,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000132,
+                "end": 3.000059,
+                "seconds": 0.9999269843101501,
+                "bytes": 2926837760,
+                "bits_per_second": 23416411845.464706,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000057,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23404263750.09612,
+                  "retransmits": 6,
+                  "snd_cwnd": 2345520,
+                  "rtt": 798,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000057,
+                "seconds": 0.9999979734420776,
+                "bytes": 2925527040,
+                "bits_per_second": 23404263750.09612,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000144,
+                  "seconds": 1.000087022781372,
+                  "bytes": 2929459200,
+                  "bits_per_second": 23433634339.962082,
+                  "retransmits": 4,
+                  "snd_cwnd": 2325300,
+                  "rtt": 778,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000144,
+                "seconds": 1.000087022781372,
+                "bytes": 2929459200,
+                "bits_per_second": 23433634339.962082,
+                "retransmits": 4,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000144,
+                  "end": 6.000058,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416716140.103306,
+                  "retransmits": 0,
+                  "snd_cwnd": 3097704,
+                  "rtt": 1023,
+                  "rttvar": 3,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000144,
+                "end": 6.000058,
+                "seconds": 0.9999139904975891,
+                "bytes": 2926837760,
+                "bits_per_second": 23416716140.103306,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000149,
+                  "seconds": 1.0000909566879272,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23423057356.281742,
+                  "retransmits": 0,
+                  "snd_cwnd": 3165104,
+                  "rtt": 1109,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000149,
+                "seconds": 1.0000909566879272,
+                "bytes": 2928148480,
+                "bits_per_second": 23423057356.281742,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000149,
+                  "end": 8.000068,
+                  "seconds": 0.9999189972877502,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416598888.021595,
+                  "retransmits": 711,
+                  "snd_cwnd": 2543676,
+                  "rtt": 841,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000149,
+                "end": 8.000068,
+                "seconds": 0.9999189972877502,
+                "bytes": 2926837760,
+                "bits_per_second": 23416598888.021595,
+                "retransmits": 711,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000068,
+                  "end": 9.000241,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23421136623.249817,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 1059,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000068,
+                "end": 9.000241,
+                "seconds": 1.0001729726791382,
+                "bytes": 2928148480,
+                "bits_per_second": 23421136623.249817,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000241,
+                  "end": 10.000231,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414936547.34786,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 781,
+                  "rttvar": 78,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000241,
+                "end": 10.000231,
+                "seconds": 0.9999899864196777,
+                "bytes": 2926837760,
+                "bits_per_second": 23414936547.34786,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000231,
+                  "seconds": 10.000231,
+                  "bytes": 29261313992,
+                  "bits_per_second": 23408510457.008446,
+                  "retransmits": 1304,
+                  "max_snd_cwnd": 3165104,
+                  "max_rtt": 1109,
+                  "min_rtt": 778,
+                  "mean_rtt": 913,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000231,
+                  "bytes": 29260124328,
+                  "bits_per_second": 23314036650.131382,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000231,
+              "seconds": 10.000231,
+              "bytes": 29261313992,
+              "bits_per_second": 23408510457.008446,
+              "retransmits": 1304,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 29260124328,
+              "bits_per_second": 23314036650.131382,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.97762289166434,
+              "host_user": 0.5691962216451614,
+              "host_system": 34.40843658477508,
+              "remote_total": 62.9251445256492,
+              "remote_user": 2.6124474135751976,
+              "remote_system": 60.31269711207401
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55052,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:19 UTC",
+              "timesecs": 1711485319
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2924870228,
+                  "bits_per_second": 23398635471.838806,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 2924870228,
+                "bits_per_second": 23398635471.838806,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000028,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2928633648,
+                  "bits_per_second": 23428742411.922653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000028,
+                "seconds": 1.0000139474868774,
+                "bytes": 2928633648,
+                "bits_per_second": 23428742411.922653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000028,
+                  "end": 3.000026,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2912575888,
+                  "bits_per_second": 23300654324.125618,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000028,
+                "end": 3.000026,
+                "seconds": 0.9999979734420776,
+                "bytes": 2912575888,
+                "bits_per_second": 23300654324.125618,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000009,
+                  "seconds": 0.999983012676239,
+                  "bytes": 2928793176,
+                  "bits_per_second": 23430743433.62467,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000009,
+                "seconds": 0.999983012676239,
+                "bytes": 2928793176,
+                "bits_per_second": 23430743433.62467,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000009,
+                  "end": 5.000024,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2927518936,
+                  "bits_per_second": 23419799713.93165,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000009,
+                "end": 5.000024,
+                "seconds": 1.0000150203704834,
+                "bytes": 2927518936,
+                "bits_per_second": 23419799713.93165,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000024,
+                  "end": 6.000039,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2928627108,
+                  "bits_per_second": 23428664956.77242,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000024,
+                "end": 6.000039,
+                "seconds": 1.0000150203704834,
+                "bytes": 2928627108,
+                "bits_per_second": 23428664956.77242,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000039,
+                  "end": 7.000044,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2924520712,
+                  "bits_per_second": 23396048556.894276,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000039,
+                "end": 7.000044,
+                "seconds": 1.0000050067901611,
+                "bytes": 2924520712,
+                "bits_per_second": 23396048556.894276,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000044,
+                  "end": 8.00003,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 2928023612,
+                  "bits_per_second": 23424517005.353558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000044,
+                "end": 8.00003,
+                "seconds": 0.9999859929084778,
+                "bytes": 2928023612,
+                "bits_per_second": 23424517005.353558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000029,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927982060,
+                  "bits_per_second": 23423880214.92501,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000029,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927982060,
+                "bits_per_second": 23423880214.92501,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000013,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2927753088,
+                  "bits_per_second": 23422398854.44862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000013,
+                "seconds": 0.9999840259552002,
+                "bytes": 2927753088,
+                "bits_per_second": 23422398854.44862,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039882,
+                  "seconds": 10.039882,
+                  "bytes": 29263263664,
+                  "bits_per_second": 23317615616.597885,
+                  "retransmits": 2270,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000013,
+                  "seconds": 10.000013,
+                  "bytes": 29259298456,
+                  "bits_per_second": 23407408335.169167,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039882,
+              "seconds": 10.039882,
+              "bytes": 29263263664,
+              "bits_per_second": 23317615616.597885,
+              "retransmits": 2270,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000013,
+              "seconds": 10.000013,
+              "bytes": 29259298456,
+              "bits_per_second": 23407408335.169167,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 88.6667781634535,
+              "host_user": 2.169277119907057,
+              "host_system": 86.4975109631894,
+              "remote_total": 22.440235970749637,
+              "remote_user": 0.4127789042736779,
+              "remote_system": 22.027466720316273
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 50458,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:37 UTC",
+              "timesecs": 1711485337
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000278,
+                  "seconds": 1.0002779960632324,
+                  "bytes": 3395979324,
+                  "bits_per_second": 27160284139.932823,
+                  "retransmits": 0,
+                  "snd_cwnd": 884288,
+                  "rtt": 40,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000278,
+                "seconds": 1.0002779960632324,
+                "bytes": 3395979324,
+                "bits_per_second": 27160284139.932823,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000278,
+                  "end": 2.000255,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27473323289.542732,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000278,
+                "end": 2.000255,
+                "seconds": 0.9999769926071167,
+                "bytes": 3434086400,
+                "bits_per_second": 27473323289.542732,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000255,
+                  "end": 3.000046,
+                  "seconds": 0.9997910261154175,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530873233.52556,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000255,
+                "end": 3.000046,
+                "seconds": 0.9997910261154175,
+                "bytes": 3440640000,
+                "bits_per_second": 27530873233.52556,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000267,
+                  "seconds": 1.0002210140228271,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27298885603.47408,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000267,
+                "seconds": 1.0002210140228271,
+                "bytes": 3413114880,
+                "bits_per_second": 27298885603.47408,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000044,
+                  "seconds": 0.9997770190238953,
+                  "bytes": 3420979200,
+                  "bits_per_second": 27373937467.296288,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000044,
+                "seconds": 0.9997770190238953,
+                "bytes": 3420979200,
+                "bits_per_second": 27373937467.296288,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000044,
+                  "end": 6.000099,
+                  "seconds": 1.000054955482483,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27523607426.874187,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000044,
+                "end": 6.000099,
+                "seconds": 1.000054955482483,
+                "bytes": 3440640000,
+                "bits_per_second": 27523607426.874187,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000099,
+                  "end": 7.000285,
+                  "seconds": 1.0001859664916992,
+                  "bytes": 3441950720,
+                  "bits_per_second": 27530486012.101555,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000099,
+                "end": 7.000285,
+                "seconds": 1.0001859664916992,
+                "bytes": 3441950720,
+                "bits_per_second": 27530486012.101555,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000285,
+                  "end": 8.000245,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27526220903.40532,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000285,
+                "end": 8.000245,
+                "seconds": 0.9999600052833557,
+                "bytes": 3440640000,
+                "bits_per_second": 27526220903.40532,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000245,
+                  "end": 9.000034,
+                  "seconds": 0.9997889995574951,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530929038.209633,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 33,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000245,
+                "end": 9.000034,
+                "seconds": 0.9997889995574951,
+                "bytes": 3440640000,
+                "bits_per_second": 27530929038.209633,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000143,
+                  "seconds": 1.0001089572906494,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27469698176.111774,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000143,
+                "seconds": 1.0001089572906494,
+                "bytes": 3434086400,
+                "bits_per_second": 27469698176.111774,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000143,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27441813121.272366,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1074356,
+                  "max_rtt": 40,
+                  "min_rtt": 31,
+                  "mean_rtt": 34,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039944,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27333026498.155766,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000143,
+              "seconds": 10.000143,
+              "bytes": 34302756924,
+              "bits_per_second": 27441813121.272366,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039944,
+              "seconds": 10.039944,
+              "bytes": 34302756924,
+              "bits_per_second": 27333026498.155766,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.72291319227105,
+              "host_user": 0.5304700943978504,
+              "host_system": 84.19243318754582,
+              "remote_total": 37.30641845607046,
+              "remote_user": 1.3600734652179878,
+              "remote_system": 35.946344990852474
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 53048,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:49 UTC",
+              "timesecs": 1711485349
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000028,
+                  "seconds": 1.0000280141830444,
+                  "bytes": 4393816392,
+                  "bits_per_second": 35149546450.171814,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000028,
+                "seconds": 1.0000280141830444,
+                "bytes": 4393816392,
+                "bits_per_second": 35149546450.171814,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000028,
+                  "end": 2.000009,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159421797.086105,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000028,
+                "end": 2.000009,
+                "seconds": 0.9999809861183167,
+                "bytes": 4394844160,
+                "bits_per_second": 35159421797.086105,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000006,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4315414528,
+                  "bits_per_second": 34523419111.80663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000006,
+                "seconds": 0.9999970197677612,
+                "bytes": 4315414528,
+                "bits_per_second": 34523419111.80663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000006,
+                  "end": 4.000048,
+                  "seconds": 1.0000419616699219,
+                  "bytes": 4349886464,
+                  "bits_per_second": 34797631545.271034,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000006,
+                "end": 4.000048,
+                "seconds": 1.0000419616699219,
+                "bytes": 4349886464,
+                "bits_per_second": 34797631545.271034,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000048,
+                  "end": 5.000028,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4430495744,
+                  "bits_per_second": 35444675808.21641,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000048,
+                "end": 5.000028,
+                "seconds": 0.9999799728393555,
+                "bytes": 4430495744,
+                "bits_per_second": 35444675808.21641,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 4407427072,
+                  "bits_per_second": 35259311495.06316,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 4407427072,
+                "bits_per_second": 35259311495.06316,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000031,
+                  "end": 7.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 4397727744,
+                  "bits_per_second": 35182595762.019264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000031,
+                "end": 7.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 4397727744,
+                "bits_per_second": 35182595762.019264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000027,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4317599700,
+                  "bits_per_second": 34540175856.016464,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000027,
+                "seconds": 1.0000180006027222,
+                "bytes": 4317599700,
+                "bits_per_second": 34540175856.016464,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000027,
+                  "end": 9.000013,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159245758.77319,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000027,
+                "end": 9.000013,
+                "seconds": 0.9999859929084778,
+                "bytes": 4394844160,
+                "bits_per_second": 35159245758.77319,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000013,
+                  "end": 10.000067,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4418043904,
+                  "bits_per_second": 35342442676.19047,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000013,
+                "end": 10.000067,
+                "seconds": 1.0000540018081665,
+                "bytes": 4418043904,
+                "bits_per_second": 35342442676.19047,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040332,
+                  "seconds": 10.040332,
+                  "bytes": 43821410588,
+                  "bits_per_second": 34916304032.97421,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 43820099868,
+                  "bits_per_second": 35055845020.238365,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040332,
+              "seconds": 10.040332,
+              "bytes": 43821410588,
+              "bits_per_second": 34916304032.97421,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 43820099868,
+              "bits_per_second": 35055845020.238365,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.7129817857671,
+              "host_user": 1.930649372470762,
+              "host_system": 89.782322494473,
+              "remote_total": 44.03409922696862,
+              "remote_user": 0.28095210440615037,
+              "remote_system": 43.75314712256247
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 47342,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:07 UTC",
+              "timesecs": 1711485367
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000658,
+                  "seconds": 1.0006580352783203,
+                  "bytes": 1519091984,
+                  "bits_per_second": 12144744201.868994,
+                  "retransmits": 186,
+                  "snd_cwnd": 841152,
+                  "rtt": 194,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000658,
+                "seconds": 1.0006580352783203,
+                "bytes": 1519091984,
+                "bits_per_second": 12144744201.868994,
+                "retransmits": 186,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000658,
+                  "end": 2.00053,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 1496842240,
+                  "bits_per_second": 11976270537.380842,
+                  "retransmits": 69,
+                  "snd_cwnd": 831716,
+                  "rtt": 212,
+                  "rttvar": 24,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000658,
+                "end": 2.00053,
+                "seconds": 0.9998720288276672,
+                "bytes": 1496842240,
+                "bits_per_second": 11976270537.380842,
+                "retransmits": 69,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00053,
+                  "end": 3.000069,
+                  "seconds": 0.9995390176773071,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12347431467.637243,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 240,
+                  "rttvar": 28,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.00053,
+                "end": 3.000069,
+                "seconds": 0.9995390176773071,
+                "bytes": 1542717440,
+                "bits_per_second": 12347431467.637243,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000069,
+                  "end": 4.000792,
+                  "seconds": 1.0007230043411255,
+                  "bytes": 1482424320,
+                  "bits_per_second": 11850826361.095003,
+                  "retransmits": 21,
+                  "snd_cwnd": 683436,
+                  "rtt": 355,
+                  "rttvar": 32,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000069,
+                "end": 4.000792,
+                "seconds": 1.0007230043411255,
+                "bytes": 1482424320,
+                "bits_per_second": 11850826361.095003,
+                "retransmits": 21,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000792,
+                  "end": 5.000133,
+                  "seconds": 0.9993410110473633,
+                  "bytes": 1537474560,
+                  "bits_per_second": 12307907254.911064,
+                  "retransmits": 0,
+                  "snd_cwnd": 789928,
+                  "rtt": 201,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000792,
+                "end": 5.000133,
+                "seconds": 0.9993410110473633,
+                "bytes": 1537474560,
+                "bits_per_second": 12307907254.911064,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000133,
+                  "end": 6.000434,
+                  "seconds": 1.0003010034561157,
+                  "bytes": 1528299520,
+                  "bits_per_second": 12222717079.915821,
+                  "retransmits": 22,
+                  "snd_cwnd": 798016,
+                  "rtt": 187,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000133,
+                "end": 6.000434,
+                "seconds": 1.0003010034561157,
+                "bytes": 1528299520,
+                "bits_per_second": 12222717079.915821,
+                "retransmits": 22,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000434,
+                  "end": 7.000335,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 1551892480,
+                  "bits_per_second": 12416369101.700983,
+                  "retransmits": 0,
+                  "snd_cwnd": 823628,
+                  "rtt": 270,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000434,
+                "end": 7.000335,
+                "seconds": 0.9999009966850281,
+                "bytes": 1551892480,
+                "bits_per_second": 12416369101.700983,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000335,
+                  "end": 8.00007,
+                  "seconds": 0.9997349977493286,
+                  "bytes": 1550581760,
+                  "bits_per_second": 12407942212.612543,
+                  "retransmits": 0,
+                  "snd_cwnd": 924728,
+                  "rtt": 210,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000335,
+                "end": 8.00007,
+                "seconds": 0.9997349977493286,
+                "bytes": 1550581760,
+                "bits_per_second": 12407942212.612543,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00007,
+                  "end": 9.000638,
+                  "seconds": 1.0005680322647095,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12355692607.945854,
+                  "retransmits": 35,
+                  "snd_cwnd": 802060,
+                  "rtt": 187,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00007,
+                "end": 9.000638,
+                "seconds": 1.0005680322647095,
+                "bytes": 1545338880,
+                "bits_per_second": 12355692607.945854,
+                "retransmits": 35,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000638,
+                  "end": 10.000796,
+                  "seconds": 1.0001579523086548,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12339790421.61459,
+                  "retransmits": 0,
+                  "snd_cwnd": 851936,
+                  "rtt": 272,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000638,
+                "end": 10.000796,
+                "seconds": 1.0001579523086548,
+                "bytes": 1542717440,
+                "bits_per_second": 12339790421.61459,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000796,
+                  "seconds": 10.000796,
+                  "bytes": 15297380624,
+                  "bits_per_second": 12236930439.537014,
+                  "retransmits": 333,
+                  "max_snd_cwnd": 924728,
+                  "max_rtt": 355,
+                  "min_rtt": 187,
+                  "mean_rtt": 232,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040404,
+                  "seconds": 10.000796,
+                  "bytes": 15297378960,
+                  "bits_per_second": 12188656121.805456,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000796,
+              "seconds": 10.000796,
+              "bytes": 15297380624,
+              "bits_per_second": 12236930439.537014,
+              "retransmits": 333,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040404,
+              "seconds": 10.040404,
+              "bytes": 15297378960,
+              "bits_per_second": 12188656121.805456,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 94.61572077164762,
+              "host_user": 0.29949784294138804,
+              "host_system": 94.31623284257061,
+              "remote_total": 24.200736107154952,
+              "remote_user": 0.7375246434410879,
+              "remote_system": 23.463211463713865
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 48142,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:19 UTC",
+              "timesecs": 1711485379
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000003,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1743350008,
+                  "bits_per_second": 13946758499.420694,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000003,
+                "seconds": 1.0000029802322388,
+                "bytes": 1743350008,
+                "bits_per_second": 13946758499.420694,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000003,
+                  "end": 2.000012,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 1755937152,
+                  "bits_per_second": 14047371622.71066,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000003,
+                "end": 2.000012,
+                "seconds": 1.0000089406967163,
+                "bytes": 1755937152,
+                "bits_per_second": 14047371622.71066,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000012,
+                  "end": 3.00001,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1733808384,
+                  "bits_per_second": 13870495181.361897,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000012,
+                "end": 3.00001,
+                "seconds": 0.9999979734420776,
+                "bytes": 1733808384,
+                "bits_per_second": 13870495181.361897,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00001,
+                  "end": 4.000018,
+                  "seconds": 1.0000079870224,
+                  "bytes": 1738644752,
+                  "bits_per_second": 13909046924.130655,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.00001,
+                "end": 4.000018,
+                "seconds": 1.0000079870224,
+                "bytes": 1738644752,
+                "bits_per_second": 13909046924.130655,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000023,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900420131.51325,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000023,
+                "seconds": 1.0000050067901611,
+                "bytes": 1737561216,
+                "bits_per_second": 13900420131.51325,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000023,
+                  "end": 6.000056,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1736454280,
+                  "bits_per_second": 13891175539.864704,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000023,
+                "end": 6.000056,
+                "seconds": 1.0000330209732056,
+                "bytes": 1736454280,
+                "bits_per_second": 13891175539.864704,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000026,
+                  "seconds": 0.999970018863678,
+                  "bytes": 1727790912,
+                  "bits_per_second": 13822741717.503777,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000026,
+                "seconds": 0.999970018863678,
+                "bytes": 1727790912,
+                "bits_per_second": 13822741717.503777,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000019,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1724361600,
+                  "bits_per_second": 13794989002.714045,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000019,
+                "seconds": 0.9999930262565613,
+                "bytes": 1724361600,
+                "bits_per_second": 13794989002.714045,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000019,
+                  "end": 9.000026,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1740731712,
+                  "bits_per_second": 13925755751.312475,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000019,
+                "end": 9.000026,
+                "seconds": 1.0000070333480835,
+                "bytes": 1740731712,
+                "bits_per_second": 13925755751.312475,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000039,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1729926144,
+                  "bits_per_second": 13839229327.648127,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000039,
+                "seconds": 1.000012993812561,
+                "bytes": 1729926144,
+                "bits_per_second": 13839229327.648127,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039511,
+                  "seconds": 10.039511,
+                  "bytes": 17371187600,
+                  "bits_per_second": 13842257934.674309,
+                  "retransmits": 2068,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000039,
+                  "seconds": 10.000039,
+                  "bytes": 17368566160,
+                  "bits_per_second": 13894798738.284922,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039511,
+              "seconds": 10.039511,
+              "bytes": 17371187600,
+              "bits_per_second": 13842257934.674309,
+              "retransmits": 2068,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000039,
+              "seconds": 10.000039,
+              "bytes": 17368566160,
+              "bits_per_second": 13894798738.284922,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.48791626719862,
+              "host_user": 1.6040884366461445,
+              "host_system": 42.883837750090144,
+              "remote_total": 12.877414932148609,
+              "remote_user": 0.20340289771075803,
+              "remote_system": 12.674021700497715
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39362,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:36 UTC",
+              "timesecs": 1711485396
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000203,
+                  "seconds": 1.000203013420105,
+                  "bytes": 3477340160,
+                  "bits_per_second": 27813074852.55055,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000203,
+                "seconds": 1.000203013420105,
+                "bytes": 3477340160,
+                "bits_per_second": 27813074852.55055,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000203,
+                  "end": 2.000079,
+                  "seconds": 0.9998760223388672,
+                  "bytes": 3461611520,
+                  "bits_per_second": 27696325885.70528,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000203,
+                "end": 2.000079,
+                "seconds": 0.9998760223388672,
+                "bytes": 3461611520,
+                "bits_per_second": 27696325885.70528,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000079,
+                  "end": 3.000169,
+                  "seconds": 1.0000900030136108,
+                  "bytes": 3432745096,
+                  "bits_per_second": 27459489331.207977,
+                  "retransmits": 0,
+                  "snd_cwnd": 599860,
+                  "rtt": 31,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000079,
+                "end": 3.000169,
+                "seconds": 1.0000900030136108,
+                "bytes": 3432745096,
+                "bits_per_second": 27459489331.207977,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000169,
+                  "end": 4.000043,
+                  "seconds": 0.9998739957809448,
+                  "bytes": 3490447360,
+                  "bits_per_second": 27927097812.1503,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 31,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000169,
+                "end": 4.000043,
+                "seconds": 0.9998739957809448,
+                "bytes": 3490447360,
+                "bits_per_second": 27927097812.1503,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000043,
+                  "end": 5.000105,
+                  "seconds": 1.0000619888305664,
+                  "bytes": 3575644160,
+                  "bits_per_second": 28603380189.91178,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000043,
+                "end": 5.000105,
+                "seconds": 1.0000619888305664,
+                "bytes": 3575644160,
+                "bits_per_second": 28603380189.91178,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000105,
+                  "end": 6.000004,
+                  "seconds": 0.9998990297317505,
+                  "bytes": 3565158400,
+                  "bits_per_second": 28524147290.80354,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000105,
+                "end": 6.000004,
+                "seconds": 0.9998990297317505,
+                "bytes": 3565158400,
+                "bits_per_second": 28524147290.80354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000302,
+                  "seconds": 1.000298023223877,
+                  "bytes": 3586129920,
+                  "bits_per_second": 28680491907.339397,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000302,
+                "seconds": 1.000298023223877,
+                "bytes": 3586129920,
+                "bits_per_second": 28680491907.339397,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000302,
+                  "end": 8.000114,
+                  "seconds": 0.9998120069503784,
+                  "bytes": 3579576320,
+                  "bits_per_second": 28641995055.99782,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000302,
+                "end": 8.000114,
+                "seconds": 0.9998120069503784,
+                "bytes": 3579576320,
+                "bits_per_second": 28641995055.99782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000114,
+                  "end": 9.000032,
+                  "seconds": 0.9999179840087891,
+                  "bytes": 3584819200,
+                  "bits_per_second": 28680905892.925636,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000114,
+                "end": 9.000032,
+                "seconds": 0.9999179840087891,
+                "bytes": 3584819200,
+                "bits_per_second": 28680905892.925636,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000166,
+                  "seconds": 1.000133991241455,
+                  "bytes": 3587440640,
+                  "bits_per_second": 28695680150.192276,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000166,
+                "seconds": 1.000133991241455,
+                "bytes": 3587440640,
+                "bits_per_second": 28695680150.192276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000166,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28272260901.26904,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 769708,
+                  "max_rtt": 33,
+                  "min_rtt": 31,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040211,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28159498063.138317,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000166,
+              "seconds": 10.000166,
+              "bytes": 35340912776,
+              "bits_per_second": 28272260901.26904,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040211,
+              "seconds": 10.040211,
+              "bytes": 35340912776,
+              "bits_per_second": 28159498063.138317,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.19888011381254,
+              "host_user": 0.5898692408770353,
+              "host_system": 97.6090108729355,
+              "remote_total": 71.89727658532618,
+              "remote_user": 1.9320023444980647,
+              "remote_system": 69.96528325535468
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37670,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:48 UTC",
+              "timesecs": 1711485408
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000002,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 3779153100,
+                  "bits_per_second": 30233163530.742928,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000002,
+                "seconds": 1.0000020265579224,
+                "bytes": 3779153100,
+                "bits_per_second": 30233163530.742928,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000002,
+                  "end": 2.000029,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30331340786.265507,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000002,
+                "end": 2.000029,
+                "seconds": 1.0000269412994385,
+                "bytes": 3791519744,
+                "bits_per_second": 30331340786.265507,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000029,
+                  "end": 3.000014,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30332613559.093388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000029,
+                "end": 3.000014,
+                "seconds": 0.9999849796295166,
+                "bytes": 3791519744,
+                "bits_per_second": 30332613559.093388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000014,
+                  "end": 4.000004,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 3793747968,
+                  "bits_per_second": 30350287659.043278,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000014,
+                "end": 4.000004,
+                "seconds": 0.9999899864196777,
+                "bytes": 3793747968,
+                "bits_per_second": 30350287659.043278,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000004,
+                  "end": 5.000013,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 3797024768,
+                  "bits_per_second": 30375926562.05313,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000004,
+                "end": 5.000013,
+                "seconds": 1.0000089406967163,
+                "bytes": 3797024768,
+                "bits_per_second": 30375926562.05313,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000018,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 3796106948,
+                  "bits_per_second": 30368703534.273937,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000018,
+                "seconds": 1.0000050067901611,
+                "bytes": 3796106948,
+                "bits_per_second": 30368703534.273937,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 3778281788,
+                  "bits_per_second": 30226526351.846264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 3778281788,
+                "bits_per_second": 30226526351.846264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000013,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3812884480,
+                  "bits_per_second": 30502952208.001095,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000013,
+                "seconds": 1.0000040531158447,
+                "bytes": 3812884480,
+                "bits_per_second": 30502952208.001095,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000013,
+                  "end": 9.000017,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3806855168,
+                  "bits_per_second": 30454717907.5003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000013,
+                "end": 9.000017,
+                "seconds": 1.0000040531158447,
+                "bytes": 3806855168,
+                "bits_per_second": 30454717907.5003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000017,
+                  "end": 10.000014,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3791650816,
+                  "bits_per_second": 30333296928.269413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000017,
+                "end": 10.000014,
+                "seconds": 0.9999970197677612,
+                "bytes": 3791650816,
+                "bits_per_second": 30333296928.269413,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040168,
+                  "seconds": 10.040168,
+                  "bytes": 37939793100,
+                  "bits_per_second": 30230404989.239223,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000014,
+                  "seconds": 10.000014,
+                  "bytes": 37938744524,
+                  "bits_per_second": 30350953127.86562,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040168,
+              "seconds": 10.040168,
+              "bytes": 37939793100,
+              "bits_per_second": 30230404989.239223,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000014,
+              "seconds": 10.000014,
+              "bytes": 37938744524,
+              "bits_per_second": 30350953127.86562,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 89.35457193175537,
+              "host_user": 2.1531064410889655,
+              "host_system": 87.20146549066642,
+              "remote_total": 96.25175156651449,
+              "remote_user": 0.5483803525296743,
+              "remote_system": 95.70338087979988
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39876,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:05 UTC",
+              "timesecs": 1711485425
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000173,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2929832972,
+                  "bits_per_second": 23434610228.684185,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1011,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000173,
+                "seconds": 1.0001729726791382,
+                "bytes": 2929832972,
+                "bits_per_second": 23434610228.684185,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000173,
+                  "end": 2.000056,
+                  "seconds": 0.9998829960823059,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23417442012.457832,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1030,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000173,
+                "end": 2.000056,
+                "seconds": 0.9998829960823059,
+                "bytes": 2926837760,
+                "bits_per_second": 23417442012.457832,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000045,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393988522.219513,
+                  "retransmits": 1071,
+                  "snd_cwnd": 2109620,
+                  "rtt": 718,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000045,
+                "seconds": 0.9999889731407166,
+                "bytes": 2924216320,
+                "bits_per_second": 23393988522.219513,
+                "retransmits": 1071,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000045,
+                  "end": 4.000057,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414420167.144268,
+                  "retransmits": 0,
+                  "snd_cwnd": 2934596,
+                  "rtt": 882,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000045,
+                "end": 4.000057,
+                "seconds": 1.0000120401382446,
+                "bytes": 2926837760,
+                "bits_per_second": 23414420167.144268,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000134,
+                  "seconds": 1.0000770092010498,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23402414118.786076,
+                  "retransmits": 680,
+                  "snd_cwnd": 2067832,
+                  "rtt": 699,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000134,
+                "seconds": 1.0000770092010498,
+                "bytes": 2925527040,
+                "bits_per_second": 23402414118.786076,
+                "retransmits": 680,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000134,
+                  "end": 6.000072,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23405667209.938972,
+                  "retransmits": 576,
+                  "snd_cwnd": 2143320,
+                  "rtt": 731,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000134,
+                "end": 6.000072,
+                "seconds": 0.9999380111694336,
+                "bytes": 2925527040,
+                "bits_per_second": 23405667209.938972,
+                "retransmits": 576,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000072,
+                  "end": 7.000057,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23415053782.782707,
+                  "retransmits": 0,
+                  "snd_cwnd": 2985820,
+                  "rtt": 1004,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000072,
+                "end": 7.000057,
+                "seconds": 0.9999849796295166,
+                "bytes": 2926837760,
+                "bits_per_second": 23415053782.782707,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000151,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422984764.712734,
+                  "retransmits": 0,
+                  "snd_cwnd": 3150276,
+                  "rtt": 1131,
+                  "rttvar": 47,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000151,
+                "seconds": 1.0000940561294556,
+                "bytes": 2928148480,
+                "bits_per_second": 23422984764.712734,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000151,
+                  "end": 9.00006,
+                  "seconds": 0.999908983707428,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416833393.35924,
+                  "retransmits": 536,
+                  "snd_cwnd": 2446620,
+                  "rtt": 816,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000151,
+                "end": 9.00006,
+                "seconds": 0.999908983707428,
+                "bytes": 2926837760,
+                "bits_per_second": 23416833393.35924,
+                "retransmits": 536,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00006,
+                  "end": 10.000062,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425140367.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 3163756,
+                  "rtt": 1040,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.00006,
+                "end": 10.000062,
+                "seconds": 1.0000020265579224,
+                "bytes": 2928148480,
+                "bits_per_second": 23425140367.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 29268751372,
+                  "bits_per_second": 23414855925.493263,
+                  "retransmits": 2863,
+                  "max_snd_cwnd": 3301252,
+                  "max_rtt": 1131,
+                  "min_rtt": 699,
+                  "mean_rtt": 906,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040299,
+                  "seconds": 10.000062,
+                  "bytes": 29268042576,
+                  "bits_per_second": 23320454959.35928,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 29268751372,
+              "bits_per_second": 23414855925.493263,
+              "retransmits": 2863,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040299,
+              "seconds": 10.040299,
+              "bytes": 29268042576,
+              "bits_per_second": 23320454959.35928,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 36.61979232353807,
+              "host_user": 0.5177138138716962,
+              "host_system": 36.10208842470637,
+              "remote_total": 63.645622998347704,
+              "remote_user": 2.779808989119691,
+              "remote_system": 60.86582297594884
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 49506,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:17 UTC",
+              "timesecs": 1711485437
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00003,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 2928081096,
+                  "bits_per_second": 23423945095.33297,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00003,
+                "seconds": 1.0000300407409668,
+                "bytes": 2928081096,
+                "bits_per_second": 23423945095.33297,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00003,
+                  "end": 2.00001,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2924874236,
+                  "bits_per_second": 23399462512.79474,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00003,
+                "end": 2.00001,
+                "seconds": 0.9999799728393555,
+                "bytes": 2924874236,
+                "bits_per_second": 23399462512.79474,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 2928934064,
+                  "bits_per_second": 23431098222.587284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 2928934064,
+                "bits_per_second": 23431098222.587284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2927109320,
+                  "bits_per_second": 23417343542.901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 2927109320,
+                "bits_per_second": 23417343542.901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000006,
+                  "end": 5.000015,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 2928650940,
+                  "bits_per_second": 23428998048.434082,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000006,
+                "end": 5.000015,
+                "seconds": 1.0000089406967163,
+                "bytes": 2928650940,
+                "bits_per_second": 23428998048.434082,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000015,
+                  "end": 6.00002,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2928599620,
+                  "bits_per_second": 23428679657.517204,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000015,
+                "end": 6.00002,
+                "seconds": 1.0000050067901611,
+                "bytes": 2928599620,
+                "bits_per_second": 23428679657.517204,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000018,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2903162060,
+                  "bits_per_second": 23225343547.503967,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000018,
+                "seconds": 0.9999979734420776,
+                "bytes": 2903162060,
+                "bits_per_second": 23225343547.503967,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000018,
+                  "end": 8.000028,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 2520932544,
+                  "bits_per_second": 20167258405.538074,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000018,
+                "end": 8.000028,
+                "seconds": 1.0000100135803223,
+                "bytes": 2520932544,
+                "bits_per_second": 20167258405.538074,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000028,
+                  "end": 9.000012,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2699663148,
+                  "bits_per_second": 21597650185.83164,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000028,
+                "end": 9.000012,
+                "seconds": 0.9999840259552002,
+                "bytes": 2699663148,
+                "bits_per_second": 21597650185.83164,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000012,
+                  "end": 10.000011,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927449024,
+                  "bits_per_second": 23419615922.60409,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000012,
+                "end": 10.000011,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927449024,
+                "bits_per_second": 23419615922.60409,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039579,
+                  "seconds": 10.039579,
+                  "bytes": 28621053072,
+                  "bits_per_second": 22806576309.225716,
+                  "retransmits": 2146,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000011,
+                  "seconds": 10.000011,
+                  "bytes": 28617456052,
+                  "bits_per_second": 22893939658.266373,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039579,
+              "seconds": 10.039579,
+              "bytes": 28621053072,
+              "bits_per_second": 22806576309.225716,
+              "retransmits": 2146,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000011,
+              "seconds": 10.000011,
+              "bytes": 28617456052,
+              "bits_per_second": 22893939658.266373,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.71637462053445,
+              "host_user": 2.3097157068484533,
+              "host_system": 84.40665891368599,
+              "remote_total": 20.40828750936386,
+              "remote_user": 0.3775983988088474,
+              "remote_system": 20.030689110555013
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 38034,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:34 UTC",
+              "timesecs": 1711485454
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1174382536,
+                  "bits_per_second": 9394514890.15193,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2566,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1174382536,
+                "bits_per_second": 9394514890.15193,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000058,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2504,
+                  "rttvar": 111,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000058,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374766195.07232,
+                  "retransmits": 13,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2578,
+                  "rttvar": 100,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1171783680,
+                "bits_per_second": 9374766195.07232,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.000059,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373763239.835724,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2548,
+                  "rttvar": 49,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.000059,
+                "seconds": 1.0000540018081665,
+                "bytes": 1171783680,
+                "bits_per_second": 9373763239.835724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000059,
+                  "end": 5.000059,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2544,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000059,
+                "end": 5.000059,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000092,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373959902.721222,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2626,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000092,
+                "seconds": 1.0000330209732056,
+                "bytes": 1171783680,
+                "bits_per_second": 9373959902.721222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000092,
+                  "end": 7.000102,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374175570.939966,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2637,
+                  "rttvar": 87,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000092,
+                "end": 7.000102,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171783680,
+                "bits_per_second": 9374175570.939966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000102,
+                  "end": 8.000204,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373312957.602478,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2584,
+                  "rttvar": 65,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000102,
+                "end": 8.000204,
+                "seconds": 1.0001020431518555,
+                "bytes": 1171783680,
+                "bits_per_second": 9373312957.602478,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000204,
+                  "end": 9.000059,
+                  "seconds": 0.9998549818992615,
+                  "bytes": 1170472960,
+                  "bits_per_second": 9365141795.07627,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2646,
+                  "rttvar": 50,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000204,
+                "end": 9.000059,
+                "seconds": 0.9998549818992615,
+                "bytes": 1170472960,
+                "bits_per_second": 9365141795.07627,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000059,
+                  "end": 10.000063,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374231445.153997,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2624,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000059,
+                "end": 10.000063,
+                "seconds": 1.0000040531158447,
+                "bytes": 1171783680,
+                "bits_per_second": 9374231445.153997,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9375240884.782425,
+                  "retransmits": 13,
+                  "max_snd_cwnd": 3298556,
+                  "max_rtt": 2646,
+                  "min_rtt": 2504,
+                  "mean_rtt": 2585,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042436,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9335683044.23349,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 11719124936,
+              "bits_per_second": 9375240884.782425,
+              "retransmits": 13,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042436,
+              "seconds": 10.042436,
+              "bytes": 11719124936,
+              "bits_per_second": 9335683044.23349,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 8.581878883067088,
+              "host_user": 0.24757613109832505,
+              "host_system": 8.334302751968762,
+              "remote_total": 17.882794832888134,
+              "remote_user": 0.6213889785332932,
+              "remote_system": 17.261397456752558
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 59786,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:44 UTC",
+              "timesecs": 1711485464
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00001,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171526660,
+                  "bits_per_second": 9372119431.529282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00001,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171526660,
+                "bits_per_second": 9372119431.529282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00001,
+                  "end": 2.00001,
+                  "seconds": 1,
+                  "bytes": 1171728636,
+                  "bits_per_second": 9373829088,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00001,
+                "end": 2.00001,
+                "seconds": 1,
+                "bytes": 1171728636,
+                "bits_per_second": 9373829088,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171634728,
+                  "bits_per_second": 9372928100.426619,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171634728,
+                "bits_per_second": 9372928100.426619,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000003,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1171698712,
+                  "bits_per_second": 9373805362.822794,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000003,
+                "seconds": 0.9999769926071167,
+                "bytes": 1171698712,
+                "bits_per_second": 9373805362.822794,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000003,
+                  "end": 5.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171728612,
+                  "bits_per_second": 9373679160.429152,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000003,
+                "end": 5.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171728612,
+                "bits_per_second": 9373679160.429152,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000019,
+                  "end": 6.000033,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1171430044,
+                  "bits_per_second": 9371309645.78169,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000019,
+                "end": 6.000033,
+                "seconds": 1.0000139474868774,
+                "bytes": 1171430044,
+                "bits_per_second": 9371309645.78169,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000033,
+                  "end": 7.000019,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171711552,
+                  "bits_per_second": 9373823716.006702,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000033,
+                "end": 7.000019,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171711552,
+                "bits_per_second": 9373823716.006702,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.000005,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171704164,
+                  "bits_per_second": 9373764611.178816,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.000005,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171704164,
+                "bits_per_second": 9373764611.178816,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000005,
+                  "end": 9.000005,
+                  "seconds": 1,
+                  "bytes": 1171264340,
+                  "bits_per_second": 9370114720,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000005,
+                "end": 9.000005,
+                "seconds": 1,
+                "bytes": 1171264340,
+                "bits_per_second": 9370114720,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000005,
+                  "end": 10.000025,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 1171724928,
+                  "bits_per_second": 9373611697.172722,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000005,
+                "end": 10.000025,
+                "seconds": 1.0000200271606445,
+                "bytes": 1171724928,
+                "bits_per_second": 9373611697.172722,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040362,
+                  "seconds": 10.040362,
+                  "bytes": 11719168912,
+                  "bits_per_second": 9337646520.713099,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000025,
+                  "seconds": 10.000025,
+                  "bytes": 11716152376,
+                  "bits_per_second": 9372898468.553827,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040362,
+              "seconds": 10.040362,
+              "bytes": 11719168912,
+              "bits_per_second": 9337646520.713099,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000025,
+              "seconds": 10.000025,
+              "bytes": 11716152376,
+              "bits_per_second": 9372898468.553827,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.12079215423493,
+              "host_user": 1.449299942928998,
+              "host_system": 32.671502129797744,
+              "remote_total": 9.21759648553234,
+              "remote_user": 0.13056616222089867,
+              "remote_system": 9.087020816528113
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 42748,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:01 UTC",
+              "timesecs": 1711485481
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000059,
+                  "seconds": 1.0000590085983276,
+                  "bytes": 1180082728,
+                  "bits_per_second": 9440104776.649063,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2528,
+                  "rttvar": 68,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000059,
+                "seconds": 1.0000590085983276,
+                "bytes": 1180082728,
+                "bits_per_second": 9440104776.649063,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000059,
+                  "end": 2.000103,
+                  "seconds": 1.0000439882278442,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9415798295.719233,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2635,
+                  "rttvar": 38,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000059,
+                "end": 2.000103,
+                "seconds": 1.0000439882278442,
+                "bytes": 1177026560,
+                "bits_per_second": 9415798295.719233,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000103,
+                  "end": 3.000059,
+                  "seconds": 0.9999560117721558,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9406140479.450544,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2580,
+                  "rttvar": 45,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000103,
+                "end": 3.000059,
+                "seconds": 0.9999560117721558,
+                "bytes": 1175715840,
+                "bits_per_second": 9406140479.450544,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2614,
+                  "rttvar": 61,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000059,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416203500.008564,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2540,
+                  "rttvar": 36,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000059,
+                "seconds": 1.0000009536743164,
+                "bytes": 1177026560,
+                "bits_per_second": 9416203500.008564,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2532,
+                  "rttvar": 66,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416193397.538671,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2621,
+                  "rttvar": 26,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 1177026560,
+                "bits_per_second": 9416193397.538671,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.00006,
+                  "end": 8.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9405745781.28863,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2647,
+                  "rttvar": 79,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.00006,
+                "end": 8.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 1175715840,
+                "bits_per_second": 9405745781.28863,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416212480,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2616,
+                  "rttvar": 57,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1177026560,
+                "bits_per_second": 9416212480,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000062,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416174315.154686,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2608,
+                  "rttvar": 75,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000062,
+                "seconds": 1.0000040531158447,
+                "bytes": 1177026560,
+                "bits_per_second": 9416174315.154686,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 11770700328,
+                  "bits_per_second": 9416501880.088345,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 3302888,
+                  "max_rtt": 2647,
+                  "min_rtt": 2528,
+                  "mean_rtt": 2592,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042832,
+                  "seconds": 10.000062,
+                  "bytes": 11770469264,
+                  "bits_per_second": 9376215206.228682,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 11770700328,
+              "bits_per_second": 9416501880.088345,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042832,
+              "seconds": 10.042832,
+              "bytes": 11770469264,
+              "bits_per_second": 9376215206.228682,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 9.991931328513951,
+              "host_user": 0.30260245650629003,
+              "host_system": 9.689348708938175,
+              "remote_total": 19.41962833866342,
+              "remote_user": 0.6099473016485951,
+              "remote_system": 18.809681037014826
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 58986,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:11 UTC",
+              "timesecs": 1711485491
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1176615352,
+                  "bits_per_second": 9412866710.942337,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1176615352,
+                "bits_per_second": 9412866710.942337,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000016,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1176524120,
+                  "bits_per_second": 9412098711.193554,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000016,
+                "seconds": 1.0000100135803223,
+                "bytes": 1176524120,
+                "bits_per_second": 9412098711.193554,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000009,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1176810760,
+                  "bits_per_second": 9414551734.668388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000009,
+                "seconds": 0.9999930262565613,
+                "bytes": 1176810760,
+                "bits_per_second": 9414551734.668388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000007,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1176810048,
+                  "bits_per_second": 9414499463.028471,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000007,
+                "seconds": 0.9999979734420776,
+                "bytes": 1176810048,
+                "bits_per_second": 9414499463.028471,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000007,
+                  "end": 5.000007,
+                  "seconds": 1,
+                  "bytes": 1176803976,
+                  "bits_per_second": 9414431808,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000007,
+                "end": 5.000007,
+                "seconds": 1,
+                "bytes": 1176803976,
+                "bits_per_second": 9414431808,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000007,
+                  "end": 6.000009,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1176724064,
+                  "bits_per_second": 9413773434.442867,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000007,
+                "end": 6.000009,
+                "seconds": 1.0000020265579224,
+                "bytes": 1176724064,
+                "bits_per_second": 9413773434.442867,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000009,
+                  "end": 7.000003,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1176792016,
+                  "bits_per_second": 9414392803.29542,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000009,
+                "end": 7.000003,
+                "seconds": 0.9999939799308777,
+                "bytes": 1176792016,
+                "bits_per_second": 9414392803.29542,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000003,
+                  "end": 8.000015,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 1176820328,
+                  "bits_per_second": 9414449272.72926,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000003,
+                "end": 8.000015,
+                "seconds": 1.0000120401382446,
+                "bytes": 1176820328,
+                "bits_per_second": 9414449272.72926,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000011,
+                  "seconds": 0.9999960064888,
+                  "bytes": 1176491696,
+                  "bits_per_second": 9411971154.81222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000011,
+                "seconds": 0.9999960064888,
+                "bytes": 1176491696,
+                "bits_per_second": 9411971154.81222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000011,
+                  "end": 10.000015,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1176819760,
+                  "bits_per_second": 9414519921.860134,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000011,
+                "end": 10.000015,
+                "seconds": 1.0000040531158447,
+                "bytes": 1176819760,
+                "bits_per_second": 9414519921.860134,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040305,
+                  "seconds": 10.040305,
+                  "bytes": 11770238744,
+                  "bits_per_second": 9378391388.707813,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000015,
+                  "seconds": 10.000015,
+                  "bytes": 11767212120,
+                  "bits_per_second": 9413755575.366638,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040305,
+              "seconds": 10.040305,
+              "bytes": 11770238744,
+              "bits_per_second": 9378391388.707813,
+              "retransmits": 0,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000015,
+              "seconds": 10.000015,
+              "bytes": 11767212120,
+              "bits_per_second": 9413755575.366638,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 48.724054060084946,
+              "host_user": 3.9110899538590087,
+              "host_system": 44.81297402368786,
+              "remote_total": 7.595950273368541,
+              "remote_user": 0.15972436790366432,
+              "remote_system": 7.436225905464877
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    }
+  ]
+}

--- a/tests/input3.json
+++ b/tests/input3.json
@@ -1,1 +1,15204 @@
-{"tft-tests": [{"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "invalid_test_type", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 56762, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:32 UTC", "timesecs": 1711484912}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "snd_cwnd": 477192, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "snd_cwnd": 477192, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "snd_cwnd": 477192, "rtt": 27, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "snd_cwnd": 502804, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "snd_cwnd": 528416, "rtt": 29, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "snd_cwnd": 528416, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "snd_cwnd": 528416, "rtt": 30, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "snd_cwnd": 591772, "rtt": 26, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "snd_cwnd": 621428, "rtt": 27, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "snd_cwnd": 621428, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "max_snd_cwnd": 621428, "max_rtt": 30, "min_rtt": 25, "mean_rtt": 26, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040752, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "sender": true}, "sum_received": {"start": 0, "end": 10.040752, "seconds": 10.040752, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}, "cpu_utilization_percent": {"host_total": 51.95896032207571, "host_user": 0.46109579260875955, "host_system": 51.4978546106554, "remote_total": 46.34560190202221, "remote_user": 1.2743335369337774, "remote_system": 45.07127657478376}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 54270, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:43 UTC", "timesecs": 1711484923}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}], "sum": {"start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}], "sum": {"start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}], "sum": {"start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}], "sum": {"start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}], "sum": {"start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}], "sum": {"start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}], "sum": {"start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}], "sum": {"start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "sender": false}, "sum_received": {"start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}, "cpu_utilization_percent": {"host_total": 59.961165048543684, "host_user": 1.7074681645153693, "host_system": 58.25370680355615, "remote_total": 54.92808068462117, "remote_user": 0.35009864909523675, "remote_system": 54.57798203552594}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 43488, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:03 UTC", "timesecs": 1711484943}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "snd_cwnd": 858676, "rtt": 477, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "snd_cwnd": 864068, "rtt": 582, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "snd_cwnd": 897768, "rtt": 469, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "snd_cwnd": 843848, "rtt": 459, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "snd_cwnd": 931468, "rtt": 278, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "snd_cwnd": 773752, "rtt": 389, "rttvar": 21, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "snd_cwnd": 706352, "rtt": 351, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "snd_cwnd": 957080, "rtt": 494, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "snd_cwnd": 668608, "rtt": 406, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "snd_cwnd": 835760, "rtt": 417, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "max_snd_cwnd": 957080, "max_rtt": 582, "min_rtt": 278, "mean_rtt": 432, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040323, "seconds": 10.000067, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "sender": true}, "sum_received": {"start": 0, "end": 10.040323, "seconds": 10.040323, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}, "cpu_utilization_percent": {"host_total": 13.428581942246796, "host_user": 0.18264039451277397, "host_system": 13.245951466295686, "remote_total": 23.0189867907264, "remote_user": 0.650631880001117, "remote_system": 22.368346697024506}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 52702, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:14 UTC", "timesecs": 1711484954}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}], "sum": {"start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}], "sum": {"start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}], "sum": {"start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}], "sum": {"start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}], "sum": {"start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}], "sum": {"start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "sender": false}, "sum_received": {"start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}, "cpu_utilization_percent": {"host_total": 27.136162389258295, "host_user": 1.0734065668100488, "host_system": 26.062755822448246, "remote_total": 12.134681085322041, "remote_user": 0.20150770671204546, "remote_system": 11.933173378609997}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 37248, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:34 UTC", "timesecs": 1711484974}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "snd_cwnd": 477192, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "max_snd_cwnd": 1412704, "max_rtt": 24, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040463, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040463, "seconds": 10.040463, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}, "cpu_utilization_percent": {"host_total": 51.42879332323217, "host_user": 0.48554830964161494, "host_system": 50.94323509492755, "remote_total": 45.16438235241609, "remote_user": 1.4607549345618025, "remote_system": 43.703627417854285}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 42348, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:45 UTC", "timesecs": 1711484985}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}], "sum": {"start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}], "sum": {"start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}], "sum": {"start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}], "sum": {"start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}], "sum": {"start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}, "cpu_utilization_percent": {"host_total": 58.9131700562321, "host_user": 1.8313076617106898, "host_system": 57.08186239452141, "remote_total": 54.91579537328721, "remote_user": 0.4710685503353111, "remote_system": 54.44472682295189}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 45258, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:05 UTC", "timesecs": 1711485005}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "snd_cwnd": 958428, "rtt": 667, "rttvar": 176, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "snd_cwnd": 913944, "rtt": 617, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "snd_cwnd": 698264, "rtt": 354, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "snd_cwnd": 789928, "rtt": 504, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "snd_cwnd": 698264, "rtt": 352, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "snd_cwnd": 947644, "rtt": 487, "rttvar": 19, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "snd_cwnd": 706352, "rtt": 362, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "snd_cwnd": 684784, "rtt": 352, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "snd_cwnd": 877548, "rtt": 463, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "snd_cwnd": 858676, "rtt": 461, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "max_snd_cwnd": 958428, "max_rtt": 667, "min_rtt": 352, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039933, "seconds": 10.000063, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "sender": true}, "sum_received": {"start": 0, "end": 10.039933, "seconds": 10.039933, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}, "cpu_utilization_percent": {"host_total": 12.965573157783645, "host_user": 0.2766736708792456, "host_system": 12.688899486904399, "remote_total": 23.378925135581515, "remote_user": 0.7967034489409502, "remote_system": 22.582213415818792}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 46944, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:16 UTC", "timesecs": 1711485016}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}], "sum": {"start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}], "sum": {"start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}], "sum": {"start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}], "sum": {"start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}], "sum": {"start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}], "sum": {"start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}], "sum": {"start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}], "sum": {"start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}, "cpu_utilization_percent": {"host_total": 26.49645360241422, "host_user": 1.0953846141637273, "host_system": 25.40107890796627, "remote_total": 12.308727742765743, "remote_user": 0.1856302180705536, "remote_system": 12.12309752469519}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 39718, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:35 UTC", "timesecs": 1711485035}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "snd_cwnd": 551332, "rtt": 31, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "snd_cwnd": 551332, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "snd_cwnd": 707700, "rtt": 27, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "snd_cwnd": 808800, "rtt": 30, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "snd_cwnd": 808800, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "max_snd_cwnd": 808800, "max_rtt": 31, "min_rtt": 26, "mean_rtt": 28, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}, "cpu_utilization_percent": {"host_total": 50.79991850744037, "host_user": 0.5093780915545499, "host_system": 50.29054041588581, "remote_total": 69.18971718930246, "remote_user": 1.6048329699753412, "remote_system": 67.58487595116893}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 45210, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:46 UTC", "timesecs": 1711485046}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}], "sum": {"start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}], "sum": {"start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}], "sum": {"start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}], "sum": {"start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}], "sum": {"start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}], "sum": {"start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}, "cpu_utilization_percent": {"host_total": 53.87293306289964, "host_user": 1.9549507299646565, "host_system": 51.91798233293498, "remote_total": 84.71007116240497, "remote_user": 0.4765840963192183, "remote_system": 84.23349673055752}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 42424, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:05 UTC", "timesecs": 1711485065}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 397, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 398, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "snd_cwnd": 760272, "rtt": 242, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "snd_cwnd": 1517848, "rtt": 400, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 393, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 373, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "snd_cwnd": 1442360, "rtt": 379, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "snd_cwnd": 1544808, "rtt": 397, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "snd_cwnd": 1569072, "rtt": 419, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "snd_cwnd": 1606816, "rtt": 410, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "max_snd_cwnd": 1763184, "max_rtt": 419, "min_rtt": 242, "mean_rtt": 380, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039772, "seconds": 10.000116, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "sender": true}, "sum_received": {"start": 0, "end": 10.039772, "seconds": 10.039772, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}, "cpu_utilization_percent": {"host_total": 19.865083177612643, "host_user": 0.41521108861582645, "host_system": 19.449872088996816, "remote_total": 59.10663386005702, "remote_user": 2.4033524078476156, "remote_system": 56.70327318135753}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 38322, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:16 UTC", "timesecs": 1711485076}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}], "sum": {"start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}], "sum": {"start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}], "sum": {"start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}], "sum": {"start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "sender": false}, "sum_received": {"start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}, "cpu_utilization_percent": {"host_total": 37.45748338542608, "host_user": 1.3319334804012157, "host_system": 36.125549905024855, "remote_total": 15.928314062618693, "remote_user": 0.36963858784471143, "remote_system": 15.558675474773981}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 47958, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:36 UTC", "timesecs": 1711485096}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "snd_cwnd": 579640, "rtt": 26, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "snd_cwnd": 579640, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "snd_cwnd": 899116, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 26, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 24, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "max_snd_cwnd": 1043352, "max_rtt": 26, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040386, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040386, "seconds": 10.040386, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}, "cpu_utilization_percent": {"host_total": 51.71680226694355, "host_user": 0.47637317598252343, "host_system": 51.24043901002937, "remote_total": 45.230156070887375, "remote_user": 1.3387075643093247, "remote_system": 43.891456788045936}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 60988, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:48 UTC", "timesecs": 1711485108}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}], "sum": {"start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}], "sum": {"start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}], "sum": {"start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}], "sum": {"start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}], "sum": {"start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}], "sum": {"start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72172176163449, "host_user": 1.7632532126911542, "host_system": 56.958468548943344, "remote_total": 54.5440108210963, "remote_user": 0.40678669250280086, "remote_system": 54.137214462757875}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 46580, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:07 UTC", "timesecs": 1711485127}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "snd_cwnd": 812844, "rtt": 417, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "snd_cwnd": 912596, "rtt": 445, "rttvar": 23, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "snd_cwnd": 669956, "rtt": 482, "rttvar": 128, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "snd_cwnd": 843848, "rtt": 461, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "snd_cwnd": 838456, "rtt": 544, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "snd_cwnd": 928772, "rtt": 486, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "snd_cwnd": 831716, "rtt": 416, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "snd_cwnd": 824976, "rtt": 580, "rttvar": 185, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "snd_cwnd": 634908, "rtt": 423, "rttvar": 97, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "snd_cwnd": 676696, "rtt": 360, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "max_snd_cwnd": 928772, "max_rtt": 580, "min_rtt": 360, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039945, "seconds": 10.000063, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "sender": true}, "sum_received": {"start": 0, "end": 10.039945, "seconds": 10.039945, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}, "cpu_utilization_percent": {"host_total": 13.61059396129923, "host_user": 0.19270043453809127, "host_system": 13.417903445457585, "remote_total": 23.486672814565882, "remote_user": 0.5555645903789477, "remote_system": 22.931108224186932}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 50678, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:19 UTC", "timesecs": 1711485139}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}], "sum": {"start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}], "sum": {"start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}], "sum": {"start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}], "sum": {"start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "sender": false}, "sum_received": {"start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}, "cpu_utilization_percent": {"host_total": 26.747516641197084, "host_user": 1.0158505257156165, "host_system": 25.731666115481467, "remote_total": 11.755923477356498, "remote_user": 0.13796182174123386, "remote_system": 11.617971314101807}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 41706, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:38 UTC", "timesecs": 1711485158}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "snd_cwnd": 525720, "rtt": 24, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 37, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "max_snd_cwnd": 1202416, "max_rtt": 37, "min_rtt": 21, "mean_rtt": 24, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040372, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040372, "seconds": 10.040372, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}, "cpu_utilization_percent": {"host_total": 51.579098862767125, "host_user": 0.4361726860977011, "host_system": 51.14293609532062, "remote_total": 44.789642459824776, "remote_user": 1.3832780535675204, "remote_system": 43.40635613187544}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 57026, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:50 UTC", "timesecs": 1711485170}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}], "sum": {"start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}], "sum": {"start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}], "sum": {"start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}], "sum": {"start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}], "sum": {"start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}], "sum": {"start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}], "sum": {"start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}], "sum": {"start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72825614611755, "host_user": 1.7371177997142697, "host_system": 56.991148265535564, "remote_total": 54.64429253795493, "remote_user": 0.4133314501365237, "remote_system": 54.23096108781841}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 43702, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:09 UTC", "timesecs": 1711485189}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "snd_cwnd": 816888, "rtt": 591, "rttvar": 85, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "snd_cwnd": 958428, "rtt": 636, "rttvar": 81, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "snd_cwnd": 688828, "rtt": 360, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "snd_cwnd": 804756, "rtt": 415, "rttvar": 1, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "snd_cwnd": 953036, "rtt": 494, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "snd_cwnd": 850588, "rtt": 461, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "snd_cwnd": 943600, "rtt": 507, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "snd_cwnd": 846544, "rtt": 461, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "snd_cwnd": 830368, "rtt": 478, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "snd_cwnd": 501456, "rtt": 244, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "max_snd_cwnd": 958428, "max_rtt": 636, "min_rtt": 244, "mean_rtt": 464, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039929, "seconds": 10.000215, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "sender": true}, "sum_received": {"start": 0, "end": 10.039929, "seconds": 10.039929, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}, "cpu_utilization_percent": {"host_total": 13.005006946322178, "host_user": 0.19271754050004394, "host_system": 12.812299324888505, "remote_total": 23.26438245505795, "remote_user": 0.8376646905752849, "remote_system": 22.426726025964516}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 57004, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:21 UTC", "timesecs": 1711485201}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}], "sum": {"start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}], "sum": {"start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}], "sum": {"start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}], "sum": {"start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}], "sum": {"start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}], "sum": {"start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "sender": false}, "sum_received": {"start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}, "cpu_utilization_percent": {"host_total": 26.064632328384384, "host_user": 1.162207899423042, "host_system": 24.902424428961346, "remote_total": 11.69062967191739, "remote_user": 0.12009331046577057, "remote_system": 11.570546012927187}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56708, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:39 UTC", "timesecs": 1711485219}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "snd_cwnd": 798016, "rtt": 32, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "snd_cwnd": 798016, "rtt": 30, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "max_snd_cwnd": 798016, "max_rtt": 35, "min_rtt": 30, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040107, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040107, "seconds": 10.040107, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}, "cpu_utilization_percent": {"host_total": 84.44527815243438, "host_user": 0.4874417118707169, "host_system": 83.95785625929561, "remote_total": 37.5809576369255, "remote_user": 1.2945095444412822, "remote_system": 36.286448092484214}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37086, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:51 UTC", "timesecs": 1711485231}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}], "sum": {"start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}], "sum": {"start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}], "sum": {"start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}], "sum": {"start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}], "sum": {"start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}], "sum": {"start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}, "cpu_utilization_percent": {"host_total": 91.26294493237891, "host_user": 1.8116036545309533, "host_system": 89.45135119667133, "remote_total": 44.14246868282316, "remote_user": 0.32552835005268926, "remote_system": 43.816940332770464}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55424, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:09 UTC", "timesecs": 1711485249}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "snd_cwnd": 641648, "rtt": 391, "rttvar": 37, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "snd_cwnd": 787232, "rtt": 223, "rttvar": 31, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "snd_cwnd": 655128, "rtt": 228, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "snd_cwnd": 849240, "rtt": 193, "rttvar": 25, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "snd_cwnd": 936860, "rtt": 606, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "snd_cwnd": 829020, "rtt": 197, "rttvar": 54, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "snd_cwnd": 917988, "rtt": 218, "rttvar": 40, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "snd_cwnd": 917988, "rtt": 200, "rttvar": 33, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "snd_cwnd": 934164, "rtt": 220, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "snd_cwnd": 776448, "rtt": 184, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "max_snd_cwnd": 936860, "max_rtt": 606, "min_rtt": 184, "mean_rtt": 266, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040277, "seconds": 10.00071, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "sender": true}, "sum_received": {"start": 0, "end": 10.040277, "seconds": 10.040277, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}, "cpu_utilization_percent": {"host_total": 95.82562437024121, "host_user": 0.2560031758234491, "host_system": 95.56962119441776, "remote_total": 24.102997438800752, "remote_user": 1.0351409018247604, "remote_system": 23.06785653697599}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39456, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:21 UTC", "timesecs": 1711485261}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}], "sum": {"start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}], "sum": {"start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}], "sum": {"start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}], "sum": {"start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}], "sum": {"start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "sender": false}, "sum_received": {"start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}, "cpu_utilization_percent": {"host_total": 44.47684113065824, "host_user": 1.8968527601361653, "host_system": 42.57999828989936, "remote_total": 12.529305328982618, "remote_user": 0.09332895016906215, "remote_system": 12.435986036196645}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56016, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:38 UTC", "timesecs": 1711485278}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "snd_cwnd": 663216, "rtt": 37, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "snd_cwnd": 663216, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "snd_cwnd": 663216, "rtt": 31, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "max_snd_cwnd": 663216, "max_rtt": 37, "min_rtt": 31, "mean_rtt": 33, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039647, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039647, "seconds": 10.039647, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}, "cpu_utilization_percent": {"host_total": 98.6366144037512, "host_user": 0.5079154773387307, "host_system": 98.12868897353042, "remote_total": 69.33475570009895, "remote_user": 1.8358332803622874, "remote_system": 67.4989133777374}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 41272, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:50 UTC", "timesecs": 1711485290}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}], "sum": {"start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}], "sum": {"start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}], "sum": {"start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}], "sum": {"start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}], "sum": {"start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}], "sum": {"start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}], "sum": {"start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}, "cpu_utilization_percent": {"host_total": 86.40432984604324, "host_user": 2.1048623181527053, "host_system": 84.29947744708186, "remote_total": 96.37010529501002, "remote_user": 0.5200516733573617, "remote_system": 95.85006329541284}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 35114, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:07 UTC", "timesecs": 1711485307}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "snd_cwnd": 2701392, "rtt": 911, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "snd_cwnd": 2724308, "rtt": 935, "rttvar": 42, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "snd_cwnd": 2744528, "rtt": 900, "rttvar": 30, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "snd_cwnd": 2345520, "rtt": 798, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "snd_cwnd": 2325300, "rtt": 778, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "snd_cwnd": 3097704, "rtt": 1023, "rttvar": 3, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "snd_cwnd": 3165104, "rtt": 1109, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "snd_cwnd": 2543676, "rtt": 841, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 1059, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 781, "rttvar": 78, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "max_snd_cwnd": 3165104, "max_rtt": 1109, "min_rtt": 778, "mean_rtt": 913, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000231, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}, "cpu_utilization_percent": {"host_total": 34.97762289166434, "host_user": 0.5691962216451614, "host_system": 34.40843658477508, "remote_total": 62.9251445256492, "remote_user": 2.6124474135751976, "remote_system": 60.31269711207401}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55052, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:19 UTC", "timesecs": 1711485319}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}], "sum": {"start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}], "sum": {"start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}], "sum": {"start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}], "sum": {"start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}], "sum": {"start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "sender": false}, "sum_received": {"start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}, "cpu_utilization_percent": {"host_total": 88.6667781634535, "host_user": 2.169277119907057, "host_system": 86.4975109631894, "remote_total": 22.440235970749637, "remote_user": 0.4127789042736779, "remote_system": 22.027466720316273}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 50458, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:37 UTC", "timesecs": 1711485337}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "snd_cwnd": 884288, "rtt": 40, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "snd_cwnd": 974604, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "snd_cwnd": 974604, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 33, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "max_snd_cwnd": 1074356, "max_rtt": 40, "min_rtt": 31, "mean_rtt": 34, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039944, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039944, "seconds": 10.039944, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}, "cpu_utilization_percent": {"host_total": 84.72291319227105, "host_user": 0.5304700943978504, "host_system": 84.19243318754582, "remote_total": 37.30641845607046, "remote_user": 1.3600734652179878, "remote_system": 35.946344990852474}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 53048, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:49 UTC", "timesecs": 1711485349}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}], "sum": {"start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}], "sum": {"start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}], "sum": {"start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}], "sum": {"start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}], "sum": {"start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}], "sum": {"start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}, "cpu_utilization_percent": {"host_total": 91.7129817857671, "host_user": 1.930649372470762, "host_system": 89.782322494473, "remote_total": 44.03409922696862, "remote_user": 0.28095210440615037, "remote_system": 43.75314712256247}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 47342, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:07 UTC", "timesecs": 1711485367}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "snd_cwnd": 841152, "rtt": 194, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "snd_cwnd": 831716, "rtt": 212, "rttvar": 24, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "snd_cwnd": 849240, "rtt": 240, "rttvar": 28, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "snd_cwnd": 683436, "rtt": 355, "rttvar": 32, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "snd_cwnd": 789928, "rtt": 201, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "snd_cwnd": 798016, "rtt": 187, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "snd_cwnd": 823628, "rtt": 270, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "snd_cwnd": 924728, "rtt": 210, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "snd_cwnd": 802060, "rtt": 187, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "snd_cwnd": 851936, "rtt": 272, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "max_snd_cwnd": 924728, "max_rtt": 355, "min_rtt": 187, "mean_rtt": 232, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040404, "seconds": 10.000796, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "sender": true}, "sum_received": {"start": 0, "end": 10.040404, "seconds": 10.040404, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}, "cpu_utilization_percent": {"host_total": 94.61572077164762, "host_user": 0.29949784294138804, "host_system": 94.31623284257061, "remote_total": 24.200736107154952, "remote_user": 0.7375246434410879, "remote_system": 23.463211463713865}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 48142, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:19 UTC", "timesecs": 1711485379}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}], "sum": {"start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}], "sum": {"start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}], "sum": {"start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}], "sum": {"start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}], "sum": {"start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}], "sum": {"start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "sender": false}, "sum_received": {"start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}, "cpu_utilization_percent": {"host_total": 44.48791626719862, "host_user": 1.6040884366461445, "host_system": 42.883837750090144, "remote_total": 12.877414932148609, "remote_user": 0.20340289771075803, "remote_system": 12.674021700497715}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39362, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:36 UTC", "timesecs": 1711485396}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "snd_cwnd": 412488, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "snd_cwnd": 412488, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "snd_cwnd": 599860, "rtt": 31, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "snd_cwnd": 769708, "rtt": 31, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "snd_cwnd": 769708, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "max_snd_cwnd": 769708, "max_rtt": 33, "min_rtt": 31, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040211, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040211, "seconds": 10.040211, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}, "cpu_utilization_percent": {"host_total": 98.19888011381254, "host_user": 0.5898692408770353, "host_system": 97.6090108729355, "remote_total": 71.89727658532618, "remote_user": 1.9320023444980647, "remote_system": 69.96528325535468}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37670, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:48 UTC", "timesecs": 1711485408}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}], "sum": {"start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}], "sum": {"start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}], "sum": {"start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}], "sum": {"start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}], "sum": {"start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}], "sum": {"start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}, "cpu_utilization_percent": {"host_total": 89.35457193175537, "host_user": 2.1531064410889655, "host_system": 87.20146549066642, "remote_total": 96.25175156651449, "remote_user": 0.5483803525296743, "remote_system": 95.70338087979988}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39876, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:05 UTC", "timesecs": 1711485425}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1011, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1030, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "snd_cwnd": 2109620, "rtt": 718, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "snd_cwnd": 2934596, "rtt": 882, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "snd_cwnd": 2067832, "rtt": 699, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "snd_cwnd": 2143320, "rtt": 731, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "snd_cwnd": 2985820, "rtt": 1004, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "snd_cwnd": 3150276, "rtt": 1131, "rttvar": 47, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "snd_cwnd": 2446620, "rtt": 816, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "snd_cwnd": 3163756, "rtt": 1040, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "max_snd_cwnd": 3301252, "max_rtt": 1131, "min_rtt": 699, "mean_rtt": 906, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040299, "seconds": 10.000062, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "sender": true}, "sum_received": {"start": 0, "end": 10.040299, "seconds": 10.040299, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}, "cpu_utilization_percent": {"host_total": 36.61979232353807, "host_user": 0.5177138138716962, "host_system": 36.10208842470637, "remote_total": 63.645622998347704, "remote_user": 2.779808989119691, "remote_system": 60.86582297594884}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 49506, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:17 UTC", "timesecs": 1711485437}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}], "sum": {"start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}], "sum": {"start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}], "sum": {"start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}], "sum": {"start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}], "sum": {"start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}], "sum": {"start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}], "sum": {"start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "sender": false}, "sum_received": {"start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}, "cpu_utilization_percent": {"host_total": 86.71637462053445, "host_user": 2.3097157068484533, "host_system": 84.40665891368599, "remote_total": 20.40828750936386, "remote_user": 0.3775983988088474, "remote_system": 20.030689110555013}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 38034, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:34 UTC", "timesecs": 1711485454}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2566, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2504, "rttvar": 111, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "snd_cwnd": 3298556, "rtt": 2578, "rttvar": 100, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2548, "rttvar": 49, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2544, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2626, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2637, "rttvar": 87, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2584, "rttvar": 65, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2646, "rttvar": 50, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2624, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "max_snd_cwnd": 3298556, "max_rtt": 2646, "min_rtt": 2504, "mean_rtt": 2585, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042436, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "sender": true}, "sum_received": {"start": 0, "end": 10.042436, "seconds": 10.042436, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}, "cpu_utilization_percent": {"host_total": 8.581878883067088, "host_user": 0.24757613109832505, "host_system": 8.334302751968762, "remote_total": 17.882794832888134, "remote_user": 0.6213889785332932, "remote_system": 17.261397456752558}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 59786, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:44 UTC", "timesecs": 1711485464}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}], "sum": {"start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}], "sum": {"start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}], "sum": {"start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}], "sum": {"start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}], "sum": {"start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}], "sum": {"start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}, "cpu_utilization_percent": {"host_total": 34.12079215423493, "host_user": 1.449299942928998, "host_system": 32.671502129797744, "remote_total": 9.21759648553234, "remote_user": 0.13056616222089867, "remote_system": 9.087020816528113}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 42748, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:01 UTC", "timesecs": 1711485481}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2528, "rttvar": 68, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2635, "rttvar": 38, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2580, "rttvar": 45, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2614, "rttvar": 61, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2540, "rttvar": 36, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2532, "rttvar": 66, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2621, "rttvar": 26, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2647, "rttvar": 79, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2616, "rttvar": 57, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2608, "rttvar": 75, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "max_snd_cwnd": 3302888, "max_rtt": 2647, "min_rtt": 2528, "mean_rtt": 2592, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042832, "seconds": 10.000062, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.042832, "seconds": 10.042832, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}, "cpu_utilization_percent": {"host_total": 9.991931328513951, "host_user": 0.30260245650629003, "host_system": 9.689348708938175, "remote_total": 19.41962833866342, "remote_user": 0.6099473016485951, "remote_system": 18.809681037014826}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 58986, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:11 UTC", "timesecs": 1711485491}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}], "sum": {"start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}], "sum": {"start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}], "sum": {"start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}], "sum": {"start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}], "sum": {"start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "sender": false}, "sum_received": {"start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}, "cpu_utilization_percent": {"host_total": 48.724054060084946, "host_user": 3.9110899538590087, "host_system": 44.81297402368786, "remote_total": 7.595950273368541, "remote_user": 0.15972436790366432, "remote_system": 7.436225905464877}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}]}
+{
+  "tft-tests": [
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "invalid_test_type",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 56762,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:32 UTC",
+              "timesecs": 1711484912
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000191,
+                  "seconds": 1.0001909732818604,
+                  "bytes": 4895539200,
+                  "bits_per_second": 39156835690.5809,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000191,
+                "seconds": 1.0001909732818604,
+                "bytes": 4895539200,
+                "bits_per_second": 39156835690.5809,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000191,
+                  "end": 2.000081,
+                  "seconds": 0.9998900294303894,
+                  "bytes": 4911267840,
+                  "bits_per_second": 39294463954.583626,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000191,
+                "end": 2.000081,
+                "seconds": 0.9998900294303894,
+                "bytes": 4911267840,
+                "bits_per_second": 39294463954.583626,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000081,
+                  "end": 3.000218,
+                  "seconds": 1.0001369714736938,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38781514278.83715,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 27,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000081,
+                "end": 3.000218,
+                "seconds": 1.0001369714736938,
+                "bytes": 4848353280,
+                "bits_per_second": 38781514278.83715,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000218,
+                  "end": 4.000267,
+                  "seconds": 1.0000489950180054,
+                  "bytes": 4840488960,
+                  "bits_per_second": 38722014494.20265,
+                  "retransmits": 0,
+                  "snd_cwnd": 502804,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000218,
+                "end": 4.000267,
+                "seconds": 1.0000489950180054,
+                "bytes": 4840488960,
+                "bits_per_second": 38722014494.20265,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000247,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4881121280,
+                  "bits_per_second": 39049752295.66235,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 29,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000247,
+                "seconds": 0.9999799728393555,
+                "bytes": 4881121280,
+                "bits_per_second": 39049752295.66235,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000247,
+                  "end": 6.00002,
+                  "seconds": 0.9997730255126953,
+                  "bytes": 4856217600,
+                  "bits_per_second": 38858560701.89271,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000247,
+                "end": 6.00002,
+                "seconds": 0.9997730255126953,
+                "bytes": 4856217600,
+                "bits_per_second": 38858560701.89271,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000117,
+                  "seconds": 1.0000970363616943,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38825001843.07837,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 30,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000117,
+                "seconds": 1.0000970363616943,
+                "bytes": 4853596160,
+                "bits_per_second": 38825001843.07837,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000117,
+                  "end": 8.000116,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4864081920,
+                  "bits_per_second": 38912694789.414955,
+                  "retransmits": 0,
+                  "snd_cwnd": 591772,
+                  "rtt": 26,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000117,
+                "end": 8.000116,
+                "seconds": 0.9999989867210388,
+                "bytes": 4864081920,
+                "bits_per_second": 38912694789.414955,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000116,
+                  "end": 9.000019,
+                  "seconds": 0.9999030232429504,
+                  "bytes": 4836556800,
+                  "bits_per_second": 38696207032.668144,
+                  "retransmits": 99,
+                  "snd_cwnd": 621428,
+                  "rtt": 27,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000116,
+                "end": 9.000019,
+                "seconds": 0.9999030232429504,
+                "bytes": 4836556800,
+                "bits_per_second": 38696207032.668144,
+                "retransmits": 99,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000019,
+                  "end": 10.000269,
+                  "seconds": 1.000249981880188,
+                  "bytes": 4773642240,
+                  "bits_per_second": 38179593713.378716,
+                  "retransmits": 0,
+                  "snd_cwnd": 621428,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000019,
+                "end": 10.000269,
+                "seconds": 1.000249981880188,
+                "bytes": 4773642240,
+                "bits_per_second": 38179593713.378716,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000269,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38847647222.28973,
+                  "retransmits": 99,
+                  "max_snd_cwnd": 621428,
+                  "max_rtt": 30,
+                  "min_rtt": 25,
+                  "mean_rtt": 26,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040752,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38691018585.06216,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000269,
+              "seconds": 10.000269,
+              "bytes": 48560865280,
+              "bits_per_second": 38847647222.28973,
+              "retransmits": 99,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040752,
+              "seconds": 10.040752,
+              "bytes": 48560865280,
+              "bits_per_second": 38691018585.06216,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.95896032207571,
+              "host_user": 0.46109579260875955,
+              "host_system": 51.4978546106554,
+              "remote_total": 46.34560190202221,
+              "remote_user": 1.2743335369337774,
+              "remote_system": 45.07127657478376
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 54270,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:43 UTC",
+              "timesecs": 1711484923
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000023,
+                  "seconds": 1.0000230073928833,
+                  "bytes": 5267935560,
+                  "bits_per_second": 42142514890.60282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000023,
+                "seconds": 1.0000230073928833,
+                "bytes": 5267935560,
+                "bits_per_second": 42142514890.60282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000023,
+                  "end": 2.000011,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5283380932,
+                  "bits_per_second": 42267553843.84901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000023,
+                "end": 2.000011,
+                "seconds": 0.9999880194664001,
+                "bytes": 5283380932,
+                "bits_per_second": 42267553843.84901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000011,
+                  "end": 3.000025,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5144593776,
+                  "bits_per_second": 41156176182.772766,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000011,
+                "end": 3.000025,
+                "seconds": 1.0000139474868774,
+                "bytes": 5144593776,
+                "bits_per_second": 41156176182.772766,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000025,
+                  "end": 4.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5313921024,
+                  "bits_per_second": 42511454343.92459,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000025,
+                "end": 4.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5313921024,
+                "bits_per_second": 42511454343.92459,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.000026,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 5324144640,
+                  "bits_per_second": 42593030182.8783,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.000026,
+                "seconds": 1.0000029802322388,
+                "bytes": 5324144640,
+                "bits_per_second": 42593030182.8783,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000026,
+                  "end": 6.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 5340397568,
+                  "bits_per_second": 42724036185.13606,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000026,
+                "end": 6.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 5340397568,
+                "bits_per_second": 42724036185.13606,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000006,
+                  "end": 7.000013,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 5317722112,
+                  "bits_per_second": 42541477686.97944,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000006,
+                "end": 7.000013,
+                "seconds": 1.0000070333480835,
+                "bytes": 5317722112,
+                "bits_per_second": 42541477686.97944,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000013,
+                  "end": 8.000023,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 5339086848,
+                  "bits_per_second": 42712267081.28284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000013,
+                "end": 8.000023,
+                "seconds": 1.0000100135803223,
+                "bytes": 5339086848,
+                "bits_per_second": 42712267081.28284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000023,
+                  "end": 9.000043,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5329256448,
+                  "bits_per_second": 42633197762.099625,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000023,
+                "end": 9.000043,
+                "seconds": 1.0000200271606445,
+                "bytes": 5329256448,
+                "bits_per_second": 42633197762.099625,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000043,
+                  "end": 10.000027,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5294784512,
+                  "bits_per_second": 42358952739.80874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000043,
+                "end": 10.000027,
+                "seconds": 0.9999840259552002,
+                "bytes": 5294784512,
+                "bits_per_second": 42358952739.80874,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040745,
+                  "seconds": 10.040745,
+                  "bytes": 52956665212,
+                  "bits_per_second": 42193415099.77596,
+                  "retransmits": 220,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000027,
+                  "seconds": 10.000027,
+                  "bytes": 52955223420,
+                  "bits_per_second": 42364064353.02625,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040745,
+              "seconds": 10.040745,
+              "bytes": 52956665212,
+              "bits_per_second": 42193415099.77596,
+              "retransmits": 220,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000027,
+              "seconds": 10.000027,
+              "bytes": 52955223420,
+              "bits_per_second": 42364064353.02625,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 59.961165048543684,
+              "host_user": 1.7074681645153693,
+              "host_system": 58.25370680355615,
+              "remote_total": 54.92808068462117,
+              "remote_user": 0.35009864909523675,
+              "remote_system": 54.57798203552594
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 43488,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:03 UTC",
+              "timesecs": 1711484943
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1552629896,
+                  "bits_per_second": 12420331432.172485,
+                  "retransmits": 1162,
+                  "snd_cwnd": 858676,
+                  "rtt": 477,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1552629896,
+                "bits_per_second": 12420331432.172485,
+                "retransmits": 1162,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000057,
+                  "seconds": 1,
+                  "bytes": 1785895104,
+                  "bits_per_second": 14287160832,
+                  "retransmits": 250,
+                  "snd_cwnd": 864068,
+                  "rtt": 582,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000057,
+                "seconds": 1,
+                "bytes": 1785895104,
+                "bits_per_second": 14287160832,
+                "retransmits": 250,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1781226624,
+                  "bits_per_second": 14249799402.332296,
+                  "retransmits": 41,
+                  "snd_cwnd": 897768,
+                  "rtt": 469,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1781226624,
+                "bits_per_second": 14249799402.332296,
+                "retransmits": 41,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000058,
+                  "end": 4.000033,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 1770754368,
+                  "bits_per_second": 14166388740.29625,
+                  "retransmits": 43,
+                  "snd_cwnd": 843848,
+                  "rtt": 459,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000058,
+                "end": 4.000033,
+                "seconds": 0.9999750256538391,
+                "bytes": 1770754368,
+                "bits_per_second": 14166388740.29625,
+                "retransmits": 43,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000033,
+                  "end": 5.00012,
+                  "seconds": 1.000087022781372,
+                  "bytes": 1756157248,
+                  "bits_per_second": 14048035484.879292,
+                  "retransmits": 508,
+                  "snd_cwnd": 931468,
+                  "rtt": 278,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000033,
+                "end": 5.00012,
+                "seconds": 1.000087022781372,
+                "bytes": 1756157248,
+                "bits_per_second": 14048035484.879292,
+                "retransmits": 508,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00012,
+                  "end": 6.000058,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 1776470548,
+                  "bits_per_second": 14212645409.268175,
+                  "retransmits": 774,
+                  "snd_cwnd": 773752,
+                  "rtt": 389,
+                  "rttvar": 21,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.00012,
+                "end": 6.000058,
+                "seconds": 0.9999380111694336,
+                "bytes": 1776470548,
+                "bits_per_second": 14212645409.268175,
+                "retransmits": 774,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000214,
+                  "seconds": 1.000156044960022,
+                  "bytes": 1780520960,
+                  "bits_per_second": 14241945296.215616,
+                  "retransmits": 107,
+                  "snd_cwnd": 706352,
+                  "rtt": 351,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000214,
+                "seconds": 1.000156044960022,
+                "bytes": 1780520960,
+                "bits_per_second": 14241945296.215616,
+                "retransmits": 107,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000214,
+                  "end": 8.000165,
+                  "seconds": 0.9999510049819946,
+                  "bytes": 1782724608,
+                  "bits_per_second": 14262495655.23143,
+                  "retransmits": 103,
+                  "snd_cwnd": 957080,
+                  "rtt": 494,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000214,
+                "end": 8.000165,
+                "seconds": 0.9999510049819946,
+                "bytes": 1782724608,
+                "bits_per_second": 14262495655.23143,
+                "retransmits": 103,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000165,
+                  "end": 9.000061,
+                  "seconds": 0.9998959898948669,
+                  "bytes": 1708298368,
+                  "bits_per_second": 13667808534.202581,
+                  "retransmits": 636,
+                  "snd_cwnd": 668608,
+                  "rtt": 406,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000165,
+                "end": 9.000061,
+                "seconds": 0.9998959898948669,
+                "bytes": 1708298368,
+                "bits_per_second": 13667808534.202581,
+                "retransmits": 636,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000061,
+                  "end": 10.000067,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1711744320,
+                  "bits_per_second": 13693872938.156792,
+                  "retransmits": 37,
+                  "snd_cwnd": 835760,
+                  "rtt": 417,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000061,
+                "end": 10.000067,
+                "seconds": 1.0000059604644775,
+                "bytes": 1711744320,
+                "bits_per_second": 13693872938.156792,
+                "retransmits": 37,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 17406422044,
+                  "bits_per_second": 13925044337.40294,
+                  "retransmits": 3661,
+                  "max_snd_cwnd": 957080,
+                  "max_rtt": 582,
+                  "min_rtt": 278,
+                  "mean_rtt": 432,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040323,
+                  "seconds": 10.000067,
+                  "bytes": 17404804444,
+                  "bits_per_second": 13867923925.554983,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 17406422044,
+              "bits_per_second": 13925044337.40294,
+              "retransmits": 3661,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040323,
+              "seconds": 10.040323,
+              "bytes": 17404804444,
+              "bits_per_second": 13867923925.554983,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.428581942246796,
+              "host_user": 0.18264039451277397,
+              "host_system": 13.245951466295686,
+              "remote_total": 23.0189867907264,
+              "remote_user": 0.650631880001117,
+              "remote_system": 22.368346697024506
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 52702,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:14 UTC",
+              "timesecs": 1711484954
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 1769360536,
+                  "bits_per_second": 14154529944.193699,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 1769360536,
+                "bits_per_second": 14154529944.193699,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000056,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 1654294820,
+                  "bits_per_second": 13233948381.508026,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000056,
+                "seconds": 1.0000309944152832,
+                "bytes": 1654294820,
+                "bits_per_second": 13233948381.508026,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000002,
+                  "seconds": 0.9999459981918335,
+                  "bytes": 1693522048,
+                  "bits_per_second": 13548908049.533356,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000002,
+                "seconds": 0.9999459981918335,
+                "bytes": 1693522048,
+                "bits_per_second": 13548908049.533356,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000002,
+                  "end": 4.000058,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1778357520,
+                  "bits_per_second": 14226063096.928802,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000002,
+                "end": 4.000058,
+                "seconds": 1.0000560283660889,
+                "bytes": 1778357520,
+                "bits_per_second": 14226063096.928802,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000058,
+                  "seconds": 1,
+                  "bytes": 1699132892,
+                  "bits_per_second": 13593063136,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000058,
+                "seconds": 1,
+                "bytes": 1699132892,
+                "bits_per_second": 13593063136,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1776734848,
+                  "bits_per_second": 14214631996.442686,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1776734848,
+                "bits_per_second": 14214631996.442686,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000005,
+                  "end": 7.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1770689664,
+                  "bits_per_second": 14165319741.388792,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000005,
+                "end": 7.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 1770689664,
+                "bits_per_second": 14165319741.388792,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.00003,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1596714580,
+                  "bits_per_second": 12773576548.933342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.00003,
+                "seconds": 1.0000109672546387,
+                "bytes": 1596714580,
+                "bits_per_second": 12773576548.933342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000056,
+                  "seconds": 1.000025987625122,
+                  "bytes": 1650146112,
+                  "bits_per_second": 13200825837.886824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000056,
+                "seconds": 1.000025987625122,
+                "bytes": 1650146112,
+                "bits_per_second": 13200825837.886824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000056,
+                  "end": 10.00005,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1544969596,
+                  "bits_per_second": 12359831175.038013,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000056,
+                "end": 10.00005,
+                "seconds": 0.9999939799308777,
+                "bytes": 1544969596,
+                "bits_per_second": 12359831175.038013,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039981,
+                  "seconds": 10.039981,
+                  "bytes": 16936819512,
+                  "bits_per_second": 13495499254.032454,
+                  "retransmits": 2334,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00005,
+                  "seconds": 10.00005,
+                  "bytes": 16933922616,
+                  "bits_per_second": 13547070357.448214,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039981,
+              "seconds": 10.039981,
+              "bytes": 16936819512,
+              "bits_per_second": 13495499254.032454,
+              "retransmits": 2334,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00005,
+              "seconds": 10.00005,
+              "bytes": 16933922616,
+              "bits_per_second": 13547070357.448214,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 27.136162389258295,
+              "host_user": 1.0734065668100488,
+              "host_system": 26.062755822448246,
+              "remote_total": 12.134681085322041,
+              "remote_user": 0.20150770671204546,
+              "remote_system": 11.933173378609997
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 37248,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:34 UTC",
+              "timesecs": 1711484974
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000223,
+                  "seconds": 1.0002230405807495,
+                  "bytes": 4827381760,
+                  "bits_per_second": 38610442384.50756,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000223,
+                "seconds": 1.0002230405807495,
+                "bytes": 4827381760,
+                "bits_per_second": 38610442384.50756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000223,
+                  "end": 2.000162,
+                  "seconds": 0.9999390244483948,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38799677831.7579,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000223,
+                "end": 2.000162,
+                "seconds": 0.9999390244483948,
+                "bytes": 4849664000,
+                "bits_per_second": 38799677831.7579,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000162,
+                  "end": 3.000191,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 4826247500,
+                  "bits_per_second": 38608861584.00477,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000162,
+                "end": 3.000191,
+                "seconds": 1.0000289678573608,
+                "bytes": 4826247500,
+                "bits_per_second": 38608861584.00477,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000191,
+                  "end": 4.00012,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4861460480,
+                  "bits_per_second": 38894444922.881874,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000191,
+                "end": 4.00012,
+                "seconds": 0.9999290108680725,
+                "bytes": 4861460480,
+                "bits_per_second": 38894444922.881874,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00012,
+                  "end": 5.000266,
+                  "seconds": 1.0001460313796997,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38487604562.00447,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.00012,
+                "end": 5.000266,
+                "seconds": 1.0001460313796997,
+                "bytes": 4811653120,
+                "bits_per_second": 38487604562.00447,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000266,
+                  "end": 6.000154,
+                  "seconds": 0.999888002872467,
+                  "bytes": 4818206720,
+                  "bits_per_second": 38549971246.046036,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000266,
+                "end": 6.000154,
+                "seconds": 0.999888002872467,
+                "bytes": 4818206720,
+                "bits_per_second": 38549971246.046036,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000154,
+                  "end": 7.000089,
+                  "seconds": 0.99993497133255,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38831294427.33196,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000154,
+                "end": 7.000089,
+                "seconds": 0.99993497133255,
+                "bytes": 4853596160,
+                "bits_per_second": 38831294427.33196,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000089,
+                  "end": 8.000143,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4870635520,
+                  "bits_per_second": 38962980088.62366,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000089,
+                "end": 8.000143,
+                "seconds": 1.0000540018081665,
+                "bytes": 4870635520,
+                "bits_per_second": 38962980088.62366,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000143,
+                  "end": 9.000159,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38796692259.89976,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000143,
+                "end": 9.000159,
+                "seconds": 1.0000159740447998,
+                "bytes": 4849664000,
+                "bits_per_second": 38796692259.89976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000159,
+                  "end": 10.000248,
+                  "seconds": 1.0000890493392944,
+                  "bytes": 4823449600,
+                  "bits_per_second": 38584160905.964096,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000159,
+                "end": 10.000248,
+                "seconds": 1.0000890493392944,
+                "bytes": 4823449600,
+                "bits_per_second": 38584160905.964096,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000248,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38712607015.34602,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1412704,
+                  "max_rtt": 24,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040463,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38557551666.69106,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000248,
+              "seconds": 10.000248,
+              "bytes": 48391958860,
+              "bits_per_second": 38712607015.34602,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040463,
+              "seconds": 10.040463,
+              "bytes": 48391958860,
+              "bits_per_second": 38557551666.69106,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.42879332323217,
+              "host_user": 0.48554830964161494,
+              "host_system": 50.94323509492755,
+              "remote_total": 45.16438235241609,
+              "remote_user": 1.4607549345618025,
+              "remote_system": 43.703627417854285
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 42348,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:45 UTC",
+              "timesecs": 1711484985
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5317084948,
+                  "bits_per_second": 42536086312.49434,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 5317084948,
+                "bits_per_second": 42536086312.49434,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000016,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 5316804608,
+                  "bits_per_second": 42534350665.67468,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000016,
+                "seconds": 1.0000020265579224,
+                "bytes": 5316804608,
+                "bits_per_second": 42534350665.67468,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000013,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5298323456,
+                  "bits_per_second": 42386713970.25147,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000013,
+                "seconds": 0.9999970197677612,
+                "bytes": 5298323456,
+                "bits_per_second": 42386713970.25147,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000013,
+                  "end": 4.000027,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5347213312,
+                  "bits_per_second": 42777109862.82153,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000013,
+                "end": 4.000027,
+                "seconds": 1.0000139474868774,
+                "bytes": 5347213312,
+                "bits_per_second": 42777109862.82153,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000027,
+                  "end": 5.000006,
+                  "seconds": 0.9999790191650391,
+                  "bytes": 5329387520,
+                  "bits_per_second": 42635994698.76817,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000027,
+                "end": 5.000006,
+                "seconds": 0.9999790191650391,
+                "bytes": 5329387520,
+                "bits_per_second": 42635994698.76817,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000006,
+                  "end": 6.000018,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 5332271104,
+                  "bits_per_second": 42657655227.93386,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000006,
+                "end": 6.000018,
+                "seconds": 1.0000120401382446,
+                "bytes": 5332271104,
+                "bits_per_second": 42657655227.93386,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000031,
+                  "seconds": 1.000012993812561,
+                  "bytes": 5274468352,
+                  "bits_per_second": 42195198539.4992,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000031,
+                "seconds": 1.000012993812561,
+                "bytes": 5274468352,
+                "bits_per_second": 42195198539.4992,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000031,
+                  "end": 8.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5300420608,
+                  "bits_per_second": 42404297508.9502,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000031,
+                "end": 8.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 5300420608,
+                "bits_per_second": 42404297508.9502,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000009,
+                  "end": 9.000029,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5310644224,
+                  "bits_per_second": 42484302952.03991,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000009,
+                "end": 9.000029,
+                "seconds": 1.0000200271606445,
+                "bytes": 5310644224,
+                "bits_per_second": 42484302952.03991,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000028,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5294129152,
+                  "bits_per_second": 42353076131.48099,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000028,
+                "seconds": 0.9999989867210388,
+                "bytes": 5294129152,
+                "bits_per_second": 42353076131.48099,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040317,
+                  "seconds": 10.040317,
+                  "bytes": 53121271572,
+                  "bits_per_second": 42326370031.54382,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 53120747284,
+                  "bits_per_second": 42496478837.05926,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040317,
+              "seconds": 10.040317,
+              "bytes": 53121271572,
+              "bits_per_second": 42326370031.54382,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 53120747284,
+              "bits_per_second": 42496478837.05926,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.9131700562321,
+              "host_user": 1.8313076617106898,
+              "host_system": 57.08186239452141,
+              "remote_total": 54.91579537328721,
+              "remote_user": 0.4710685503353111,
+              "remote_system": 54.44472682295189
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 45258,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:05 UTC",
+              "timesecs": 1711485005
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1756790944,
+                  "bits_per_second": 14053511676.447533,
+                  "retransmits": 563,
+                  "snd_cwnd": 958428,
+                  "rtt": 667,
+                  "rttvar": 176,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1756790944,
+                "bits_per_second": 14053511676.447533,
+                "retransmits": 563,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1762679616,
+                  "bits_per_second": 14101451216.70384,
+                  "retransmits": 117,
+                  "snd_cwnd": 913944,
+                  "rtt": 617,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1762679616,
+                "bits_per_second": 14101451216.70384,
+                "retransmits": 117,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000057,
+                  "seconds": 1,
+                  "bytes": 1743596572,
+                  "bits_per_second": 13948772576,
+                  "retransmits": 76,
+                  "snd_cwnd": 698264,
+                  "rtt": 354,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000057,
+                "seconds": 1,
+                "bytes": 1743596572,
+                "bits_per_second": 13948772576,
+                "retransmits": 76,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1585909824,
+                  "bits_per_second": 12687278592,
+                  "retransmits": 93,
+                  "snd_cwnd": 789928,
+                  "rtt": 504,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1585909824,
+                "bits_per_second": 12687278592,
+                "retransmits": 93,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1719381848,
+                  "bits_per_second": 13755041666.170042,
+                  "retransmits": 79,
+                  "snd_cwnd": 698264,
+                  "rtt": 352,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1719381848,
+                "bits_per_second": 13755041666.170042,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.00008,
+                  "seconds": 1.000022053718567,
+                  "bytes": 1698620928,
+                  "bits_per_second": 13588667743.34589,
+                  "retransmits": 427,
+                  "snd_cwnd": 947644,
+                  "rtt": 487,
+                  "rttvar": 19,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.00008,
+                "seconds": 1.000022053718567,
+                "bytes": 1698620928,
+                "bits_per_second": 13588667743.34589,
+                "retransmits": 427,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00008,
+                  "end": 7.000196,
+                  "seconds": 1.000115990638733,
+                  "bytes": 1755761024,
+                  "bits_per_second": 14044459166.210653,
+                  "retransmits": 62,
+                  "snd_cwnd": 706352,
+                  "rtt": 362,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00008,
+                "end": 7.000196,
+                "seconds": 1.000115990638733,
+                "bytes": 1755761024,
+                "bits_per_second": 14044459166.210653,
+                "retransmits": 62,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000196,
+                  "end": 8.000057,
+                  "seconds": 0.9998610019683838,
+                  "bytes": 1783120320,
+                  "bits_per_second": 14266945637.36077,
+                  "retransmits": 88,
+                  "snd_cwnd": 684784,
+                  "rtt": 352,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000196,
+                "end": 8.000057,
+                "seconds": 0.9998610019683838,
+                "bytes": 1783120320,
+                "bits_per_second": 14266945637.36077,
+                "retransmits": 88,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000057,
+                  "end": 9.000034,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1733497792,
+                  "bits_per_second": 13868301409.459152,
+                  "retransmits": 177,
+                  "snd_cwnd": 877548,
+                  "rtt": 463,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000057,
+                "end": 9.000034,
+                "seconds": 0.9999769926071167,
+                "bytes": 1733497792,
+                "bits_per_second": 13868301409.459152,
+                "retransmits": 177,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000063,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 1775311360,
+                  "bits_per_second": 14202079476.187506,
+                  "retransmits": 53,
+                  "snd_cwnd": 858676,
+                  "rtt": 461,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000063,
+                "seconds": 1.0000289678573608,
+                "bytes": 1775311360,
+                "bits_per_second": 14202079476.187506,
+                "retransmits": 53,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17314670228,
+                  "bits_per_second": 13851648917.011822,
+                  "retransmits": 1735,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 667,
+                  "min_rtt": 352,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039933,
+                  "seconds": 10.000063,
+                  "bytes": 17312453588,
+                  "bits_per_second": 13794875792.896229,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17314670228,
+              "bits_per_second": 13851648917.011822,
+              "retransmits": 1735,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039933,
+              "seconds": 10.039933,
+              "bytes": 17312453588,
+              "bits_per_second": 13794875792.896229,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 12.965573157783645,
+              "host_user": 0.2766736708792456,
+              "host_system": 12.688899486904399,
+              "remote_total": 23.378925135581515,
+              "remote_user": 0.7967034489409502,
+              "remote_system": 22.582213415818792
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 46944,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:16 UTC",
+              "timesecs": 1711485016
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000056,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1588301472,
+                  "bits_per_second": 12705699896.394789,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000056,
+                "seconds": 1.0000560283660889,
+                "bytes": 1588301472,
+                "bits_per_second": 12705699896.394789,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000056,
+                  "end": 2.000025,
+                  "seconds": 0.9999690055847168,
+                  "bytes": 1717632384,
+                  "bits_per_second": 13741484981.292118,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000056,
+                "end": 2.000025,
+                "seconds": 0.9999690055847168,
+                "bytes": 1717632384,
+                "bits_per_second": 13741484981.292118,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000025,
+                  "end": 3.000046,
+                  "seconds": 1.000020980834961,
+                  "bytes": 1637153304,
+                  "bits_per_second": 13096951647.019003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000025,
+                "end": 3.000046,
+                "seconds": 1.000020980834961,
+                "bytes": 1637153304,
+                "bits_per_second": 13096951647.019003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000057,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1548560832,
+                  "bits_per_second": 12388350789.802336,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000057,
+                "seconds": 1.0000109672546387,
+                "bytes": 1548560832,
+                "bits_per_second": 12388350789.802336,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000057,
+                  "seconds": 1,
+                  "bytes": 1661339904,
+                  "bits_per_second": 13290719232,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000057,
+                "seconds": 1,
+                "bytes": 1661339904,
+                "bits_per_second": 13290719232,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000057,
+                  "seconds": 1,
+                  "bytes": 1734958228,
+                  "bits_per_second": 13879665824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000057,
+                "seconds": 1,
+                "bytes": 1734958228,
+                "bits_per_second": 13879665824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000024,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 1733693804,
+                  "bits_per_second": 13870008433.176832,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000024,
+                "seconds": 0.9999669790267944,
+                "bytes": 1733693804,
+                "bits_per_second": 13870008433.176832,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000056,
+                  "seconds": 1.0000319480895996,
+                  "bytes": 1624242608,
+                  "bits_per_second": 12993525745.675262,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000056,
+                "seconds": 1.0000319480895996,
+                "bytes": 1624242608,
+                "bits_per_second": 12993525745.675262,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000056,
+                  "end": 9.000015,
+                  "seconds": 0.9999589920043945,
+                  "bytes": 1732061376,
+                  "bits_per_second": 13857059258.225166,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000056,
+                "end": 9.000015,
+                "seconds": 0.9999589920043945,
+                "bytes": 1732061376,
+                "bits_per_second": 13857059258.225166,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000015,
+                  "end": 10.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1706050368,
+                  "bits_per_second": 13648225601.514744,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000015,
+                "end": 10.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1706050368,
+                "bits_per_second": 13648225601.514744,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03969,
+                  "seconds": 10.03969,
+                  "bytes": 16687168488,
+                  "bits_per_second": 13296959159.49596,
+                  "retransmits": 2081,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 16683994280,
+                  "bits_per_second": 13347158051.957455,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03969,
+              "seconds": 10.03969,
+              "bytes": 16687168488,
+              "bits_per_second": 13296959159.49596,
+              "retransmits": 2081,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 16683994280,
+              "bits_per_second": 13347158051.957455,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.49645360241422,
+              "host_user": 1.0953846141637273,
+              "host_system": 25.40107890796627,
+              "remote_total": 12.308727742765743,
+              "remote_user": 0.1856302180705536,
+              "remote_system": 12.12309752469519
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 39718,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:35 UTC",
+              "timesecs": 1711485035
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000101,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 4825423936,
+                  "bits_per_second": 38599494086.72777,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 31,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000101,
+                "seconds": 1.0001009702682495,
+                "bytes": 4825423936,
+                "bits_per_second": 38599494086.72777,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000101,
+                  "end": 2.000064,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38452705227.057976,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000101,
+                "end": 2.000064,
+                "seconds": 0.9999629855155945,
+                "bytes": 4806410240,
+                "bits_per_second": 38452705227.057976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000064,
+                  "end": 3.000036,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 4803788800,
+                  "bits_per_second": 38431387023.910736,
+                  "retransmits": 0,
+                  "snd_cwnd": 707700,
+                  "rtt": 27,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000064,
+                "end": 3.000036,
+                "seconds": 0.9999719858169556,
+                "bytes": 4803788800,
+                "bits_per_second": 38431387023.910736,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000036,
+                  "end": 4.000268,
+                  "seconds": 1.0002319812774658,
+                  "bytes": 4790681600,
+                  "bits_per_second": 38316564074.51789,
+                  "retransmits": 78,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000036,
+                "end": 4.000268,
+                "seconds": 1.0002319812774658,
+                "bytes": 4790681600,
+                "bits_per_second": 38316564074.51789,
+                "retransmits": 78,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000268,
+                  "end": 5.000265,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4696309760,
+                  "bits_per_second": 37570590049.083694,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 30,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000268,
+                "end": 5.000265,
+                "seconds": 0.9999970197677612,
+                "bytes": 4696309760,
+                "bits_per_second": 37570590049.083694,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000265,
+                  "end": 6.000018,
+                  "seconds": 0.9997529983520508,
+                  "bytes": 4778885120,
+                  "bits_per_second": 38240526433.04741,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000265,
+                "end": 6.000018,
+                "seconds": 0.9997529983520508,
+                "bytes": 4778885120,
+                "bits_per_second": 38240526433.04741,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000112,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38112152918.41128,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000112,
+                "seconds": 1.0000940561294556,
+                "bytes": 4764467200,
+                "bits_per_second": 38112152918.41128,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000112,
+                  "end": 8.000259,
+                  "seconds": 1.0001469850540161,
+                  "bytes": 4839178240,
+                  "bits_per_second": 38707736461.265396,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000112,
+                "end": 8.000259,
+                "seconds": 1.0001469850540161,
+                "bytes": 4839178240,
+                "bits_per_second": 38707736461.265396,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000259,
+                  "end": 9.000227,
+                  "seconds": 0.9999679923057556,
+                  "bytes": 4712038400,
+                  "bits_per_second": 37697513810.49582,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000259,
+                "end": 9.000227,
+                "seconds": 0.9999679923057556,
+                "bytes": 4712038400,
+                "bits_per_second": 37697513810.49582,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000227,
+                  "end": 10.000156,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4784128000,
+                  "bits_per_second": 38275741161.63895,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000227,
+                "end": 10.000156,
+                "seconds": 0.9999290108680725,
+                "bytes": 4784128000,
+                "bits_per_second": 38275741161.63895,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000156,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38240452485.74122,
+                  "retransmits": 78,
+                  "max_snd_cwnd": 808800,
+                  "max_rtt": 31,
+                  "min_rtt": 26,
+                  "mean_rtt": 28,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38087381686.64706,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000156,
+              "seconds": 10.000156,
+              "bytes": 47801311296,
+              "bits_per_second": 38240452485.74122,
+              "retransmits": 78,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 47801311296,
+              "bits_per_second": 38087381686.64706,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 50.79991850744037,
+              "host_user": 0.5093780915545499,
+              "host_system": 50.29054041588581,
+              "remote_total": 69.18971718930246,
+              "remote_user": 1.6048329699753412,
+              "remote_system": 67.58487595116893
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 45210,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:46 UTC",
+              "timesecs": 1711485046
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000004,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 4517548360,
+                  "bits_per_second": 36140240399.41901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000004,
+                "seconds": 1.0000040531158447,
+                "bytes": 4517548360,
+                "bits_per_second": 36140240399.41901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000004,
+                  "end": 2.000005,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4473749504,
+                  "bits_per_second": 35789961900.03255,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000004,
+                "end": 2.000005,
+                "seconds": 1.0000009536743164,
+                "bytes": 4473749504,
+                "bits_per_second": 35789961900.03255,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4472438784,
+                  "bits_per_second": 35779011244.710175,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 4472438784,
+                "bits_per_second": 35779011244.710175,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000014,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 4757520384,
+                  "bits_per_second": 38060353632.204094,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000014,
+                "seconds": 0.9999949932098389,
+                "bytes": 4757520384,
+                "bits_per_second": 38060353632.204094,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000014,
+                  "end": 5.000022,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4763942596,
+                  "bits_per_second": 38111236372.7014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000014,
+                "end": 5.000022,
+                "seconds": 1.0000079870224,
+                "bytes": 4763942596,
+                "bits_per_second": 38111236372.7014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000022,
+                  "end": 6.000016,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4744937788,
+                  "bits_per_second": 37959730824.20342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000022,
+                "end": 6.000016,
+                "seconds": 0.9999939799308777,
+                "bytes": 4744937788,
+                "bits_per_second": 37959730824.20342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000016,
+                  "end": 7.000004,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 4736604700,
+                  "bits_per_second": 37893291581.853004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000016,
+                "end": 7.000004,
+                "seconds": 0.9999880194664001,
+                "bytes": 4736604700,
+                "bits_per_second": 37893291581.853004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000004,
+                  "end": 8.000015,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 4758175744,
+                  "bits_per_second": 38064988483.57848,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000004,
+                "end": 8.000015,
+                "seconds": 1.0000109672546387,
+                "bytes": 4758175744,
+                "bits_per_second": 38064988483.57848,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000031,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4740612096,
+                  "bits_per_second": 37924290963.67715,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000031,
+                "seconds": 1.0000159740447998,
+                "bytes": 4740612096,
+                "bits_per_second": 37924290963.67715,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000031,
+                  "end": 10.000012,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4774428672,
+                  "bits_per_second": 38196155633.18397,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000031,
+                "end": 10.000012,
+                "seconds": 0.9999809861183167,
+                "bytes": 4774428672,
+                "bits_per_second": 38196155633.18397,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040275,
+                  "seconds": 10.040275,
+                  "bytes": 46740351844,
+                  "bits_per_second": 37242288159.63706,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000012,
+                  "seconds": 10.000012,
+                  "bytes": 46739958628,
+                  "bits_per_second": 37391922032.09356,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040275,
+              "seconds": 10.040275,
+              "bytes": 46740351844,
+              "bits_per_second": 37242288159.63706,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000012,
+              "seconds": 10.000012,
+              "bytes": 46739958628,
+              "bits_per_second": 37391922032.09356,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 53.87293306289964,
+              "host_user": 1.9549507299646565,
+              "host_system": 51.91798233293498,
+              "remote_total": 84.71007116240497,
+              "remote_user": 0.4765840963192183,
+              "remote_system": 84.23349673055752
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 42424,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:05 UTC",
+              "timesecs": 1711485065
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00002,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 2929396644,
+                  "bits_per_second": 23434703821.421913,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 397,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00002,
+                "seconds": 1.0000200271606445,
+                "bytes": 2929396644,
+                "bits_per_second": 23434703821.421913,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00002,
+                  "end": 2.000058,
+                  "seconds": 1.0000380277633667,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23424297066.37413,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 398,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.00002,
+                "end": 2.000058,
+                "seconds": 1.0000380277633667,
+                "bytes": 2928148480,
+                "bits_per_second": 23424297066.37413,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393683151.346077,
+                  "retransmits": 655,
+                  "snd_cwnd": 760272,
+                  "rtt": 242,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 2924216320,
+                "bits_per_second": 23393683151.346077,
+                "retransmits": 655,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00006,
+                  "end": 4.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425235312.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 1517848,
+                  "rtt": 400,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00006,
+                "end": 4.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 2928148480,
+                "bits_per_second": 23425235312.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425211576.27405,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 393,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 2928148480,
+                "bits_per_second": 23425211576.27405,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000027,
+                  "seconds": 0.999970018863678,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425890174.806797,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 373,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000027,
+                "seconds": 0.999970018863678,
+                "bytes": 2928148480,
+                "bits_per_second": 23425890174.806797,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000027,
+                  "end": 7.000129,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422797703.897022,
+                  "retransmits": 152,
+                  "snd_cwnd": 1442360,
+                  "rtt": 379,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000027,
+                "end": 7.000129,
+                "seconds": 1.0001020431518555,
+                "bytes": 2928148480,
+                "bits_per_second": 23422797703.897022,
+                "retransmits": 152,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000129,
+                  "end": 8.000058,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416364387.380756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1544808,
+                  "rtt": 397,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000129,
+                "end": 8.000058,
+                "seconds": 0.9999290108680725,
+                "bytes": 2926837760,
+                "bits_per_second": 23416364387.380756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425187840,
+                  "retransmits": 0,
+                  "snd_cwnd": 1569072,
+                  "rtt": 419,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 2928148480,
+                "bits_per_second": 23425187840,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000116,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2921594880,
+                  "bits_per_second": 23371402215.02037,
+                  "retransmits": 0,
+                  "snd_cwnd": 1606816,
+                  "rtt": 410,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000116,
+                "seconds": 1.0000580549240112,
+                "bytes": 2921594880,
+                "bits_per_second": 23371402215.02037,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000116,
+                  "seconds": 10.000116,
+                  "bytes": 29270936484,
+                  "bits_per_second": 23416477556.06035,
+                  "retransmits": 807,
+                  "max_snd_cwnd": 1763184,
+                  "max_rtt": 419,
+                  "min_rtt": 242,
+                  "mean_rtt": 380,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039772,
+                  "seconds": 10.000116,
+                  "bytes": 29268240456,
+                  "bits_per_second": 23321836755.65541,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000116,
+              "seconds": 10.000116,
+              "bytes": 29270936484,
+              "bits_per_second": 23416477556.06035,
+              "retransmits": 807,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039772,
+              "seconds": 10.039772,
+              "bytes": 29268240456,
+              "bits_per_second": 23321836755.65541,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 19.865083177612643,
+              "host_user": 0.41521108861582645,
+              "host_system": 19.449872088996816,
+              "remote_total": 59.10663386005702,
+              "remote_user": 2.4033524078476156,
+              "remote_system": 56.70327318135753
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 38322,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:16 UTC",
+              "timesecs": 1711485076
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000018,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 2577850256,
+                  "bits_per_second": 20622430831.81543,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000018,
+                "seconds": 1.0000180006027222,
+                "bytes": 2577850256,
+                "bits_per_second": 20622430831.81543,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000018,
+                  "end": 2.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 2421676608,
+                  "bits_per_second": 19373587232.123535,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000018,
+                "end": 2.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 2421676608,
+                "bits_per_second": 19373587232.123535,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000009,
+                  "seconds": 1,
+                  "bytes": 2353155072,
+                  "bits_per_second": 18825240576,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000009,
+                "seconds": 1,
+                "bytes": 2353155072,
+                "bits_per_second": 18825240576,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000015,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 2349402240,
+                  "bits_per_second": 18795105892.438976,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000015,
+                "seconds": 1.0000059604644775,
+                "bytes": 2349402240,
+                "bits_per_second": 18795105892.438976,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000015,
+                  "end": 5.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 2327467584,
+                  "bits_per_second": 18619498733.723473,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000015,
+                "end": 5.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 2327467584,
+                "bits_per_second": 18619498733.723473,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000022,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 2343643584,
+                  "bits_per_second": 18749261543.850487,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000022,
+                "seconds": 0.9999939799308777,
+                "bytes": 2343643584,
+                "bits_per_second": 18749261543.850487,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000022,
+                  "end": 7.000011,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2349466944,
+                  "bits_per_second": 18795942812.21649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000022,
+                "end": 7.000011,
+                "seconds": 0.9999889731407166,
+                "bytes": 2349466944,
+                "bits_per_second": 18795942812.21649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000011,
+                  "end": 8.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 2404465344,
+                  "bits_per_second": 19235358159.692505,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000011,
+                "end": 8.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 2404465344,
+                "bits_per_second": 19235358159.692505,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.00003,
+                  "seconds": 1,
+                  "bytes": 2575413312,
+                  "bits_per_second": 20603306496,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.00003,
+                "seconds": 1,
+                "bytes": 2575413312,
+                "bits_per_second": 20603306496,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.000034,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 2567907648,
+                  "bits_per_second": 20543177920.12007,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.000034,
+                "seconds": 1.0000040531158447,
+                "bytes": 2567907648,
+                "bits_per_second": 20543177920.12007,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039536,
+                  "seconds": 10.039536,
+                  "bytes": 24273090960,
+                  "bits_per_second": 19342002227.991413,
+                  "retransmits": 2404,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000034,
+                  "seconds": 10.000034,
+                  "bytes": 24270448592,
+                  "bits_per_second": 19416292858.204285,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039536,
+              "seconds": 10.039536,
+              "bytes": 24273090960,
+              "bits_per_second": 19342002227.991413,
+              "retransmits": 2404,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000034,
+              "seconds": 10.000034,
+              "bytes": 24270448592,
+              "bits_per_second": 19416292858.204285,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 37.45748338542608,
+              "host_user": 1.3319334804012157,
+              "host_system": 36.125549905024855,
+              "remote_total": 15.928314062618693,
+              "remote_user": 0.36963858784471143,
+              "remote_system": 15.558675474773981
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 47958,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:36 UTC",
+              "timesecs": 1711485096
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000048,
+                  "seconds": 1.000048041343689,
+                  "bytes": 4818672896,
+                  "bits_per_second": 38547531292.800804,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 26,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000048,
+                "seconds": 1.000048041343689,
+                "bytes": 4818672896,
+                "bits_per_second": 38547531292.800804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000048,
+                  "end": 2.000066,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38461075357.46222,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000048,
+                "end": 2.000066,
+                "seconds": 1.0000180006027222,
+                "bytes": 4807720960,
+                "bits_per_second": 38461075357.46222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000066,
+                  "end": 3.000236,
+                  "seconds": 1.0001699924468994,
+                  "bytes": 4804968024,
+                  "bits_per_second": 38433210836.44771,
+                  "retransmits": 0,
+                  "snd_cwnd": 899116,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000066,
+                "end": 3.000236,
+                "seconds": 1.0001699924468994,
+                "bytes": 4804968024,
+                "bits_per_second": 38433210836.44771,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000236,
+                  "end": 4.000147,
+                  "seconds": 0.9999110102653503,
+                  "bytes": 4799728368,
+                  "bits_per_second": 38401244260.536964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000236,
+                "end": 4.000147,
+                "seconds": 0.9999110102653503,
+                "bytes": 4799728368,
+                "bits_per_second": 38401244260.536964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000147,
+                  "end": 5.000114,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 4824760320,
+                  "bits_per_second": 38599357148.33815,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 26,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000147,
+                "end": 5.000114,
+                "seconds": 0.9999669790267944,
+                "bytes": 4824760320,
+                "bits_per_second": 38599357148.33815,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000114,
+                  "end": 6.000145,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 4833935360,
+                  "bits_per_second": 38670284317.14876,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 24,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000114,
+                "end": 6.000145,
+                "seconds": 1.0000309944152832,
+                "bytes": 4833935360,
+                "bits_per_second": 38670284317.14876,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000145,
+                  "end": 7.000159,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38408803173.721756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000145,
+                "end": 7.000159,
+                "seconds": 1.0000139474868774,
+                "bytes": 4801167360,
+                "bits_per_second": 38408803173.721756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000159,
+                  "end": 8.00016,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4820828160,
+                  "bits_per_second": 38566588500.03507,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000159,
+                "end": 8.00016,
+                "seconds": 1.0000009536743164,
+                "bytes": 4820828160,
+                "bits_per_second": 38566588500.03507,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00016,
+                  "end": 9.000032,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38372306389.033714,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00016,
+                "end": 9.000032,
+                "seconds": 0.9998720288276672,
+                "bytes": 4795924480,
+                "bits_per_second": 38372306389.033714,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000128,
+                  "seconds": 1.0000959634780884,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38783104478.40319,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000128,
+                "seconds": 1.0000959634780884,
+                "bytes": 4848353280,
+                "bits_per_second": 38783104478.40319,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000128,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38524354254.66554,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1043352,
+                  "max_rtt": 26,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040386,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38369886741.80455,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000128,
+              "seconds": 10.000128,
+              "bytes": 48156059208,
+              "bits_per_second": 38524354254.66554,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040386,
+              "seconds": 10.040386,
+              "bytes": 48156059208,
+              "bits_per_second": 38369886741.80455,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.71680226694355,
+              "host_user": 0.47637317598252343,
+              "host_system": 51.24043901002937,
+              "remote_total": 45.230156070887375,
+              "remote_user": 1.3387075643093247,
+              "remote_system": 43.891456788045936
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 60988,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:48 UTC",
+              "timesecs": 1711485108
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000022,
+                  "seconds": 1.000022053718567,
+                  "bytes": 5308961096,
+                  "bits_per_second": 42470752129.9852,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000022,
+                "seconds": 1.000022053718567,
+                "bytes": 5308961096,
+                "bits_per_second": 42470752129.9852,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000022,
+                  "end": 2.000005,
+                  "seconds": 0.999983012676239,
+                  "bytes": 5317292584,
+                  "bits_per_second": 42539063296.84071,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000022,
+                "end": 2.000005,
+                "seconds": 0.999983012676239,
+                "bytes": 5317292584,
+                "bits_per_second": 42539063296.84071,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000026,
+                  "seconds": 1.000020980834961,
+                  "bytes": 5243928576,
+                  "bits_per_second": 41950548450.46644,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000026,
+                "seconds": 1.000020980834961,
+                "bytes": 5243928576,
+                "bits_per_second": 41950548450.46644,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000023,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5279918676,
+                  "bits_per_second": 42239475291.446014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000023,
+                "seconds": 0.9999970197677612,
+                "bytes": 5279918676,
+                "bits_per_second": 42239475291.446014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.00002,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5323227136,
+                  "bits_per_second": 42585944004.00324,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.00002,
+                "seconds": 0.9999970197677612,
+                "bytes": 5323227136,
+                "bits_per_second": 42585944004.00324,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00002,
+                  "end": 6.000004,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5266341888,
+                  "bits_per_second": 42131408113.00068,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.00002,
+                "end": 6.000004,
+                "seconds": 0.9999840259552002,
+                "bytes": 5266341888,
+                "bits_per_second": 42131408113.00068,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000028,
+                  "seconds": 1.0000239610671997,
+                  "bytes": 5331222528,
+                  "bits_per_second": 42648758314.236046,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000028,
+                "seconds": 1.0000239610671997,
+                "bytes": 5331222528,
+                "bits_per_second": 42648758314.236046,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000028,
+                  "end": 8.000016,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5229510656,
+                  "bits_per_second": 41836586472.62994,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000028,
+                "end": 8.000016,
+                "seconds": 0.9999880194664001,
+                "bytes": 5229510656,
+                "bits_per_second": 41836586472.62994,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000016,
+                  "end": 9.000006,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 5216403456,
+                  "bits_per_second": 41731645531.18451,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000016,
+                "end": 9.000006,
+                "seconds": 0.9999899864196777,
+                "bytes": 5216403456,
+                "bits_per_second": 41731645531.18451,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000006,
+                  "end": 10.000033,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 5329518592,
+                  "bits_per_second": 42635000093.695915,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000006,
+                "end": 10.000033,
+                "seconds": 1.0000269412994385,
+                "bytes": 5329518592,
+                "bits_per_second": 42635000093.695915,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040391,
+                  "seconds": 10.040391,
+                  "bytes": 52847242692,
+                  "bits_per_second": 42107716874.37273,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000033,
+                  "seconds": 10.000033,
+                  "bytes": 52846325188,
+                  "bits_per_second": 42276920636.5619,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040391,
+              "seconds": 10.040391,
+              "bytes": 52847242692,
+              "bits_per_second": 42107716874.37273,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000033,
+              "seconds": 10.000033,
+              "bytes": 52846325188,
+              "bits_per_second": 42276920636.5619,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72172176163449,
+              "host_user": 1.7632532126911542,
+              "host_system": 56.958468548943344,
+              "remote_total": 54.5440108210963,
+              "remote_user": 0.40678669250280086,
+              "remote_system": 54.137214462757875
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 46580,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:07 UTC",
+              "timesecs": 1711485127
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1749200440,
+                  "bits_per_second": 13992791169.571945,
+                  "retransmits": 621,
+                  "snd_cwnd": 812844,
+                  "rtt": 417,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1749200440,
+                "bits_per_second": 13992791169.571945,
+                "retransmits": 621,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000151,
+                  "seconds": 1.0000929832458496,
+                  "bytes": 1770835776,
+                  "bits_per_second": 14165369066.005585,
+                  "retransmits": 57,
+                  "snd_cwnd": 912596,
+                  "rtt": 445,
+                  "rttvar": 23,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000151,
+                "seconds": 1.0000929832458496,
+                "bytes": 1770835776,
+                "bits_per_second": 14165369066.005585,
+                "retransmits": 57,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000151,
+                  "end": 3.000227,
+                  "seconds": 1.0000760555267334,
+                  "bytes": 1781066812,
+                  "bits_per_second": 14247450898.617298,
+                  "retransmits": 87,
+                  "snd_cwnd": 669956,
+                  "rtt": 482,
+                  "rttvar": 128,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000151,
+                "end": 3.000227,
+                "seconds": 1.0000760555267334,
+                "bytes": 1781066812,
+                "bits_per_second": 14247450898.617298,
+                "retransmits": 87,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000227,
+                  "end": 4.000645,
+                  "seconds": 1.000417947769165,
+                  "bytes": 1706121192,
+                  "bits_per_second": 13643267362.841578,
+                  "retransmits": 532,
+                  "snd_cwnd": 843848,
+                  "rtt": 461,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000227,
+                "end": 4.000645,
+                "seconds": 1.000417947769165,
+                "bytes": 1706121192,
+                "bits_per_second": 13643267362.841578,
+                "retransmits": 532,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000645,
+                  "end": 5.000058,
+                  "seconds": 0.999413013458252,
+                  "bytes": 1646996516,
+                  "bits_per_second": 13183710788.803326,
+                  "retransmits": 142,
+                  "snd_cwnd": 838456,
+                  "rtt": 544,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000645,
+                "end": 5.000058,
+                "seconds": 0.999413013458252,
+                "bytes": 1646996516,
+                "bits_per_second": 13183710788.803326,
+                "retransmits": 142,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1782799112,
+                  "bits_per_second": 14262407347.797302,
+                  "retransmits": 132,
+                  "snd_cwnd": 928772,
+                  "rtt": 486,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1782799112,
+                "bits_per_second": 14262407347.797302,
+                "retransmits": 132,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000161,
+                  "seconds": 1.0001039505004883,
+                  "bytes": 1788102904,
+                  "bits_per_second": 14303336393.023293,
+                  "retransmits": 77,
+                  "snd_cwnd": 831716,
+                  "rtt": 416,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000161,
+                "seconds": 1.0001039505004883,
+                "bytes": 1788102904,
+                "bits_per_second": 14303336393.023293,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000161,
+                  "end": 8.000058,
+                  "seconds": 0.9998970031738281,
+                  "bytes": 1783196620,
+                  "bits_per_second": 14267042420.088129,
+                  "retransmits": 96,
+                  "snd_cwnd": 824976,
+                  "rtt": 580,
+                  "rttvar": 185,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000161,
+                "end": 8.000058,
+                "seconds": 0.9998970031738281,
+                "bytes": 1783196620,
+                "bits_per_second": 14267042420.088129,
+                "retransmits": 96,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000076,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 1775786432,
+                  "bits_per_second": 14206035738.794409,
+                  "retransmits": 301,
+                  "snd_cwnd": 634908,
+                  "rtt": 423,
+                  "rttvar": 97,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000076,
+                "seconds": 1.0000180006027222,
+                "bytes": 1775786432,
+                "bits_per_second": 14206035738.794409,
+                "retransmits": 301,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000076,
+                  "end": 10.000063,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1681309440,
+                  "bits_per_second": 13450650295.22876,
+                  "retransmits": 249,
+                  "snd_cwnd": 676696,
+                  "rtt": 360,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000076,
+                "end": 10.000063,
+                "seconds": 0.999987006187439,
+                "bytes": 1681309440,
+                "bits_per_second": 13450650295.22876,
+                "retransmits": 249,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17465415244,
+                  "bits_per_second": 13972244170.061728,
+                  "retransmits": 2294,
+                  "max_snd_cwnd": 928772,
+                  "max_rtt": 580,
+                  "min_rtt": 360,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039945,
+                  "seconds": 10.000063,
+                  "bytes": 17463546188,
+                  "bits_per_second": 13915252474.391047,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17465415244,
+              "bits_per_second": 13972244170.061728,
+              "retransmits": 2294,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039945,
+              "seconds": 10.039945,
+              "bytes": 17463546188,
+              "bits_per_second": 13915252474.391047,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.61059396129923,
+              "host_user": 0.19270043453809127,
+              "host_system": 13.417903445457585,
+              "remote_total": 23.486672814565882,
+              "remote_user": 0.5555645903789477,
+              "remote_system": 22.931108224186932
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 50678,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:19 UTC",
+              "timesecs": 1711485139
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000045,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731201352,
+                  "bits_per_second": 13848988416.117579,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000045,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731201352,
+                "bits_per_second": 13848988416.117579,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000045,
+                  "end": 2.000008,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 1582543756,
+                  "bits_per_second": 12660818681.675653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000045,
+                "end": 2.000008,
+                "seconds": 0.9999629855155945,
+                "bytes": 1582543756,
+                "bits_per_second": 12660818681.675653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000008,
+                  "end": 3.000015,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1576707072,
+                  "bits_per_second": 12613567860.386663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000008,
+                "end": 3.000015,
+                "seconds": 1.0000070333480835,
+                "bytes": 1576707072,
+                "bits_per_second": 12613567860.386663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1528626392,
+                  "bits_per_second": 12228852236.5862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1528626392,
+                "bits_per_second": 12228852236.5862,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000013,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 1714944660,
+                  "bits_per_second": 13719763355.92855,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000013,
+                "seconds": 0.9999849796295166,
+                "bytes": 1714944660,
+                "bits_per_second": 13719763355.92855,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000043,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 1705468032,
+                  "bits_per_second": 13643334400.125362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000043,
+                "seconds": 1.0000300407409668,
+                "bytes": 1705468032,
+                "bits_per_second": 13643334400.125362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000043,
+                  "end": 7.000024,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1737755328,
+                  "bits_per_second": 13902306960.81968,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000043,
+                "end": 7.000024,
+                "seconds": 0.9999809861183167,
+                "bytes": 1737755328,
+                "bits_per_second": 13902306960.81968,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000011,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1737625920,
+                  "bits_per_second": 13901187989.43111,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000011,
+                "seconds": 0.999987006187439,
+                "bytes": 1737625920,
+                "bits_per_second": 13901187989.43111,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000011,
+                  "end": 9.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 1625946816,
+                  "bits_per_second": 13007327983.50187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000011,
+                "end": 9.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 1625946816,
+                "bits_per_second": 13007327983.50187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.00004,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1604133292,
+                  "bits_per_second": 12832937832.346245,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.00004,
+                "seconds": 1.0000100135803223,
+                "bytes": 1604133292,
+                "bits_per_second": 12832937832.346245,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039719,
+                  "seconds": 10.039719,
+                  "bytes": 16547546348,
+                  "bits_per_second": 13185664935.841331,
+                  "retransmits": 2136,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00004,
+                  "seconds": 10.00004,
+                  "bytes": 16544952620,
+                  "bits_per_second": 13235909152.36339,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039719,
+              "seconds": 10.039719,
+              "bytes": 16547546348,
+              "bits_per_second": 13185664935.841331,
+              "retransmits": 2136,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00004,
+              "seconds": 10.00004,
+              "bytes": 16544952620,
+              "bits_per_second": 13235909152.36339,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.747516641197084,
+              "host_user": 1.0158505257156165,
+              "host_system": 25.731666115481467,
+              "remote_total": 11.755923477356498,
+              "remote_user": 0.13796182174123386,
+              "remote_system": 11.617971314101807
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 41706,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:38 UTC",
+              "timesecs": 1711485158
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000041,
+                  "seconds": 1.0000410079956055,
+                  "bytes": 4768399360,
+                  "bits_per_second": 38145630604.14782,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 24,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000041,
+                "seconds": 1.0000410079956055,
+                "bytes": 4768399360,
+                "bits_per_second": 38145630604.14782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000041,
+                  "end": 2.000213,
+                  "seconds": 1.0001720190048218,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38444668706.348434,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000041,
+                "end": 2.000213,
+                "seconds": 1.0001720190048218,
+                "bytes": 4806410240,
+                "bits_per_second": 38444668706.348434,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000213,
+                  "end": 3.00012,
+                  "seconds": 0.9999070167541504,
+                  "bytes": 4761203140,
+                  "bits_per_second": 38093167146.32596,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000213,
+                "end": 3.00012,
+                "seconds": 0.9999070167541504,
+                "bytes": 4761203140,
+                "bits_per_second": 38093167146.32596,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00012,
+                  "end": 4.000102,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 4814274560,
+                  "bits_per_second": 38514889771.22966,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00012,
+                "end": 4.000102,
+                "seconds": 0.9999819993972778,
+                "bytes": 4814274560,
+                "bits_per_second": 38514889771.22966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000102,
+                  "end": 5.000003,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38497036294.209724,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000102,
+                "end": 5.000003,
+                "seconds": 0.9999009966850281,
+                "bytes": 4811653120,
+                "bits_per_second": 38497036294.209724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000003,
+                  "end": 6.000056,
+                  "seconds": 1.00005304813385,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38365360629.214134,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000003,
+                "end": 6.000056,
+                "seconds": 1.00005304813385,
+                "bytes": 4795924480,
+                "bits_per_second": 38365360629.214134,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000108,
+                  "seconds": 1.0000519752502441,
+                  "bytes": 4746117120,
+                  "bits_per_second": 37966963617.564964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000108,
+                "seconds": 1.0000519752502441,
+                "bytes": 4746117120,
+                "bits_per_second": 37966963617.564964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000108,
+                  "end": 8.000094,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38409876890.660965,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 37,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000108,
+                "end": 8.000094,
+                "seconds": 0.9999859929084778,
+                "bytes": 4801167360,
+                "bits_per_second": 38409876890.660965,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000094,
+                  "end": 9.000078,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38462382079.81445,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000094,
+                "end": 9.000078,
+                "seconds": 0.9999840259552002,
+                "bytes": 4807720960,
+                "bits_per_second": 38462382079.81445,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000078,
+                  "end": 10.00019,
+                  "seconds": 1.0001120567321777,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38111466953.55469,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000078,
+                "end": 10.00019,
+                "seconds": 1.0001120567321777,
+                "bytes": 4764467200,
+                "bits_per_second": 38111466953.55469,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00019,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38301142310.296104,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1202416,
+                  "max_rtt": 37,
+                  "min_rtt": 21,
+                  "mean_rtt": 24,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040372,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38147859493.65223,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00019,
+              "seconds": 10.00019,
+              "bytes": 47877337540,
+              "bits_per_second": 38301142310.296104,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040372,
+              "seconds": 10.040372,
+              "bytes": 47877337540,
+              "bits_per_second": 38147859493.65223,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.579098862767125,
+              "host_user": 0.4361726860977011,
+              "host_system": 51.14293609532062,
+              "remote_total": 44.789642459824776,
+              "remote_user": 1.3832780535675204,
+              "remote_system": 43.40635613187544
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 57026,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:50 UTC",
+              "timesecs": 1711485170
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5283402056,
+                  "bits_per_second": 42266158359.07089,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 5283402056,
+                "bits_per_second": 42266158359.07089,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5276569800,
+                  "bits_per_second": 42212643946.36801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5276569800,
+                "bits_per_second": 42212643946.36801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000023,
+                  "end": 3.000005,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42418808492.11961,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000023,
+                "end": 3.000005,
+                "seconds": 0.9999819993972778,
+                "bytes": 5302255616,
+                "bits_per_second": 42418808492.11961,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.00003,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5176033280,
+                  "bits_per_second": 41407229653.44986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.00003,
+                "seconds": 1.0000250339508057,
+                "bytes": 5176033280,
+                "bits_per_second": 41407229653.44986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00003,
+                  "end": 5.000008,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5233967104,
+                  "bits_per_second": 41872657784.00552,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.00003,
+                "end": 5.000008,
+                "seconds": 0.9999780058860779,
+                "bytes": 5233967104,
+                "bits_per_second": 41872657784.00552,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000008,
+                  "end": 6.000007,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5299765248,
+                  "bits_per_second": 42398164945.16853,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000008,
+                "end": 6.000007,
+                "seconds": 0.9999989867210388,
+                "bytes": 5299765248,
+                "bits_per_second": 42398164945.16853,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000007,
+                  "end": 7.000021,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42417453311.12657,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000007,
+                "end": 7.000021,
+                "seconds": 1.0000139474868774,
+                "bytes": 5302255616,
+                "bits_per_second": 42417453311.12657,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000021,
+                  "end": 8.000026,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 5336727552,
+                  "bits_per_second": 42693606658.070244,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000021,
+                "end": 8.000026,
+                "seconds": 1.0000050067901611,
+                "bytes": 5336727552,
+                "bits_per_second": 42693606658.070244,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000026,
+                  "end": 9.000032,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 5314183168,
+                  "bits_per_second": 42513211945.510376,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000026,
+                "end": 9.000032,
+                "seconds": 1.0000059604644775,
+                "bytes": 5314183168,
+                "bits_per_second": 42513211945.510376,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000018,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 5215485952,
+                  "bits_per_second": 41724472054.49879,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000018,
+                "seconds": 0.9999859929084778,
+                "bytes": 5215485952,
+                "bits_per_second": 41724472054.49879,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040334,
+                  "seconds": 10.040334,
+                  "bytes": 52741693968,
+                  "bits_per_second": 42023856152.99252,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000018,
+                  "seconds": 10.000018,
+                  "bytes": 52740645392,
+                  "bits_per_second": 42192440367.20734,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040334,
+              "seconds": 10.040334,
+              "bytes": 52741693968,
+              "bits_per_second": 42023856152.99252,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000018,
+              "seconds": 10.000018,
+              "bytes": 52740645392,
+              "bits_per_second": 42192440367.20734,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72825614611755,
+              "host_user": 1.7371177997142697,
+              "host_system": 56.991148265535564,
+              "remote_total": 54.64429253795493,
+              "remote_user": 0.4133314501365237,
+              "remote_system": 54.23096108781841
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 43702,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:09 UTC",
+              "timesecs": 1711485189
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1470700168,
+                  "bits_per_second": 11764930954.229,
+                  "retransmits": 1151,
+                  "snd_cwnd": 816888,
+                  "rtt": 591,
+                  "rttvar": 85,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1470700168,
+                "bits_per_second": 11764930954.229,
+                "retransmits": 1151,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1666939764,
+                  "bits_per_second": 13335505394.27101,
+                  "retransmits": 59,
+                  "snd_cwnd": 958428,
+                  "rtt": 636,
+                  "rttvar": 81,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1666939764,
+                "bits_per_second": 13335505394.27101,
+                "retransmits": 59,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1704166784,
+                  "bits_per_second": 13633348086.384787,
+                  "retransmits": 118,
+                  "snd_cwnd": 688828,
+                  "rtt": 360,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1704166784,
+                "bits_per_second": 13633348086.384787,
+                "retransmits": 118,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1593611456,
+                  "bits_per_second": 12748891648,
+                  "retransmits": 128,
+                  "snd_cwnd": 804756,
+                  "rtt": 415,
+                  "rttvar": 1,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1593611456,
+                "bits_per_second": 12748891648,
+                "retransmits": 128,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1778151040,
+                  "bits_per_second": 14225194753.797117,
+                  "retransmits": 49,
+                  "snd_cwnd": 953036,
+                  "rtt": 494,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1778151040,
+                "bits_per_second": 14225194753.797117,
+                "retransmits": 49,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000056,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1775902848,
+                  "bits_per_second": 14207251575.818235,
+                  "retransmits": 79,
+                  "snd_cwnd": 850588,
+                  "rtt": 461,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000056,
+                "seconds": 0.9999979734420776,
+                "bytes": 1775902848,
+                "bits_per_second": 14207251575.818235,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000058,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1780742784,
+                  "bits_per_second": 14245913401.831335,
+                  "retransmits": 108,
+                  "snd_cwnd": 943600,
+                  "rtt": 507,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000058,
+                "seconds": 1.0000020265579224,
+                "bytes": 1780742784,
+                "bits_per_second": 14245913401.831335,
+                "retransmits": 108,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000058,
+                  "end": 8.000058,
+                  "seconds": 1,
+                  "bytes": 1778931136,
+                  "bits_per_second": 14231449088,
+                  "retransmits": 110,
+                  "snd_cwnd": 846544,
+                  "rtt": 461,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000058,
+                "end": 8.000058,
+                "seconds": 1,
+                "bytes": 1778931136,
+                "bits_per_second": 14231449088,
+                "retransmits": 110,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1771323712,
+                  "bits_per_second": 14170589696,
+                  "retransmits": 77,
+                  "snd_cwnd": 830368,
+                  "rtt": 478,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1771323712,
+                "bits_per_second": 14170589696,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000215,
+                  "seconds": 1.0001569986343384,
+                  "bytes": 1773207680,
+                  "bits_per_second": 14183434660.128132,
+                  "retransmits": 120,
+                  "snd_cwnd": 501456,
+                  "rtt": 244,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000215,
+                "seconds": 1.0001569986343384,
+                "bytes": 1773207680,
+                "bits_per_second": 14183434660.128132,
+                "retransmits": 120,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000215,
+                  "seconds": 10.000215,
+                  "bytes": 17093677372,
+                  "bits_per_second": 13674647892.670307,
+                  "retransmits": 1999,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 636,
+                  "min_rtt": 244,
+                  "mean_rtt": 464,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039929,
+                  "seconds": 10.000215,
+                  "bytes": 17090819196,
+                  "bits_per_second": 13618278930.85698,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000215,
+              "seconds": 10.000215,
+              "bytes": 17093677372,
+              "bits_per_second": 13674647892.670307,
+              "retransmits": 1999,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039929,
+              "seconds": 10.039929,
+              "bytes": 17090819196,
+              "bits_per_second": 13618278930.85698,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.005006946322178,
+              "host_user": 0.19271754050004394,
+              "host_system": 12.812299324888505,
+              "remote_total": 23.26438245505795,
+              "remote_user": 0.8376646905752849,
+              "remote_system": 22.426726025964516
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 57004,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:21 UTC",
+              "timesecs": 1711485201
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1720841732,
+                  "bits_per_second": 13765949444.112558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1720841732,
+                "bits_per_second": 13765949444.112558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000017,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 1732854844,
+                  "bits_per_second": 13863393214.483341,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000017,
+                "seconds": 0.9999600052833557,
+                "bytes": 1732854844,
+                "bits_per_second": 13863393214.483341,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000017,
+                  "end": 3.000057,
+                  "seconds": 1.000040054321289,
+                  "bytes": 1691401320,
+                  "bits_per_second": 13530668598.25271,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000017,
+                "end": 3.000057,
+                "seconds": 1.000040054321289,
+                "bytes": 1691401320,
+                "bits_per_second": 13530668598.25271,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000067,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1568036736,
+                  "bits_per_second": 12544168275.963392,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000067,
+                "seconds": 1.0000100135803223,
+                "bytes": 1568036736,
+                "bits_per_second": 12544168275.963392,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000067,
+                  "end": 5.000031,
+                  "seconds": 0.9999639987945557,
+                  "bytes": 1557489984,
+                  "bits_per_second": 12460368460.284851,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000067,
+                "end": 5.000031,
+                "seconds": 0.9999639987945557,
+                "bytes": 1557489984,
+                "bits_per_second": 12460368460.284851,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000045,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900295853.805986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000045,
+                "seconds": 1.0000139474868774,
+                "bytes": 1737561216,
+                "bits_per_second": 13900295853.805986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000045,
+                  "end": 7.000026,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1735555392,
+                  "bits_per_second": 13884707138.178734,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000045,
+                "end": 7.000026,
+                "seconds": 0.9999809861183167,
+                "bytes": 1735555392,
+                "bits_per_second": 13884707138.178734,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000033,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1590631612,
+                  "bits_per_second": 12724963396.90308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000033,
+                "seconds": 1.0000070333480835,
+                "bytes": 1590631612,
+                "bits_per_second": 12724963396.90308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000033,
+                  "end": 9.000026,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1589841984,
+                  "bits_per_second": 12718824569.819391,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000033,
+                "end": 9.000026,
+                "seconds": 0.9999930262565613,
+                "bytes": 1589841984,
+                "bits_per_second": 12718824569.819391,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000026,
+                  "seconds": 1,
+                  "bytes": 1480498380,
+                  "bits_per_second": 11843987040,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000026,
+                "seconds": 1,
+                "bytes": 1480498380,
+                "bits_per_second": 11843987040,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03968,
+                  "seconds": 10.03968,
+                  "bytes": 16408142512,
+                  "bits_per_second": 13074633862.43386,
+                  "retransmits": 1734,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000026,
+                  "seconds": 10.000026,
+                  "bytes": 16404713200,
+                  "bits_per_second": 13123736438.285261,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03968,
+              "seconds": 10.03968,
+              "bytes": 16408142512,
+              "bits_per_second": 13074633862.43386,
+              "retransmits": 1734,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000026,
+              "seconds": 10.000026,
+              "bytes": 16404713200,
+              "bits_per_second": 13123736438.285261,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.064632328384384,
+              "host_user": 1.162207899423042,
+              "host_system": 24.902424428961346,
+              "remote_total": 11.69062967191739,
+              "remote_user": 0.12009331046577057,
+              "remote_system": 11.570546012927187
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56708,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:39 UTC",
+              "timesecs": 1711485219
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000229,
+                  "seconds": 1.000229001045227,
+                  "bytes": 3386293120,
+                  "bits_per_second": 27084142663.02109,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000229,
+                "seconds": 1.000229001045227,
+                "bytes": 3386293120,
+                "bits_per_second": 27084142663.02109,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000229,
+                  "end": 2.000133,
+                  "seconds": 0.9999039769172668,
+                  "bytes": 3393454080,
+                  "bits_per_second": 27150239689.71195,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000229,
+                "end": 2.000133,
+                "seconds": 0.9999039769172668,
+                "bytes": 3393454080,
+                "bits_per_second": 27150239689.71195,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000133,
+                  "end": 3.000277,
+                  "seconds": 1.0001440048217773,
+                  "bytes": 3402629120,
+                  "bits_per_second": 27217113564.41186,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000133,
+                "end": 3.000277,
+                "seconds": 1.0001440048217773,
+                "bytes": 3402629120,
+                "bits_per_second": 27217113564.41186,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000277,
+                  "end": 4.000095,
+                  "seconds": 0.9998180270195007,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27309888701.844177,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000277,
+                "end": 4.000095,
+                "seconds": 0.9998180270195007,
+                "bytes": 3413114880,
+                "bits_per_second": 27309888701.844177,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000095,
+                  "end": 5.000135,
+                  "seconds": 1.000040054321289,
+                  "bytes": 3415736320,
+                  "bits_per_second": 27324796083.8385,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000095,
+                "end": 5.000135,
+                "seconds": 1.000040054321289,
+                "bytes": 3415736320,
+                "bits_per_second": 27324796083.8385,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000135,
+                  "end": 6.000236,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27302162333.34541,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000135,
+                "end": 6.000236,
+                "seconds": 1.0001009702682495,
+                "bytes": 3413114880,
+                "bits_per_second": 27302162333.34541,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000236,
+                  "end": 7.000377,
+                  "seconds": 1.0001410245895386,
+                  "bytes": 3403939840,
+                  "bits_per_second": 27227678947.752304,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000236,
+                "end": 7.000377,
+                "seconds": 1.0001410245895386,
+                "bytes": 3403939840,
+                "bits_per_second": 27227678947.752304,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000377,
+                  "end": 8.000122,
+                  "seconds": 0.9997450113296509,
+                  "bytes": 3405250560,
+                  "bits_per_second": 27248952654.205704,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000377,
+                "end": 8.000122,
+                "seconds": 0.9997450113296509,
+                "bytes": 3405250560,
+                "bits_per_second": 27248952654.205704,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000122,
+                  "end": 9.000175,
+                  "seconds": 1.00005304813385,
+                  "bytes": 3457679360,
+                  "bits_per_second": 27659967570.33804,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 32,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000122,
+                "end": 9.000175,
+                "seconds": 1.00005304813385,
+                "bytes": 3457679360,
+                "bits_per_second": 27659967570.33804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000175,
+                  "end": 10.000275,
+                  "seconds": 1.000100016593933,
+                  "bytes": 3503554560,
+                  "bits_per_second": 28025633451.599354,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 30,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000175,
+                "end": 10.000275,
+                "seconds": 1.000100016593933,
+                "bytes": 3503554560,
+                "bits_per_second": 28025633451.599354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000275,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27355061111.819424,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 798016,
+                  "max_rtt": 35,
+                  "min_rtt": 30,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040107,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27246535695.28691,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000275,
+              "seconds": 10.000275,
+              "bytes": 34194766720,
+              "bits_per_second": 27355061111.819424,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040107,
+              "seconds": 10.040107,
+              "bytes": 34194766720,
+              "bits_per_second": 27246535695.28691,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.44527815243438,
+              "host_user": 0.4874417118707169,
+              "host_system": 83.95785625929561,
+              "remote_total": 37.5809576369255,
+              "remote_user": 1.2945095444412822,
+              "remote_system": 36.286448092484214
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37086,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:51 UTC",
+              "timesecs": 1711485231
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000019,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 4331032904,
+                  "bits_per_second": 34647606511.66746,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000019,
+                "seconds": 1.0000189542770386,
+                "bytes": 4331032904,
+                "bits_per_second": 34647606511.66746,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000019,
+                  "end": 2.000003,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4384751616,
+                  "bits_per_second": 35078573274.701004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000019,
+                "end": 2.000003,
+                "seconds": 0.9999840259552002,
+                "bytes": 4384751616,
+                "bits_per_second": 35078573274.701004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000003,
+                  "end": 3.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4398120960,
+                  "bits_per_second": 35184405642.72801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000003,
+                "end": 3.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 4398120960,
+                "bits_per_second": 35184405642.72801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000018,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4399955968,
+                  "bits_per_second": 35199683411.09864,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000018,
+                "seconds": 0.9999989867210388,
+                "bytes": 4399955968,
+                "bits_per_second": 35199683411.09864,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000002,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4368367616,
+                  "bits_per_second": 34947499180.91756,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000002,
+                "seconds": 0.9999840259552002,
+                "bytes": 4368367616,
+                "bits_per_second": 34947499180.91756,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000002,
+                  "end": 6.000018,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4274782208,
+                  "bits_per_second": 34197711388.226234,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000002,
+                "end": 6.000018,
+                "seconds": 1.0000159740447998,
+                "bytes": 4274782208,
+                "bits_per_second": 34197711388.226234,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000016,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 4378853376,
+                  "bits_per_second": 35030898000.14387,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000016,
+                "seconds": 0.9999979734420776,
+                "bytes": 4378853376,
+                "bits_per_second": 35030898000.14387,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000016,
+                  "end": 8.000018,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 4318953472,
+                  "bits_per_second": 34551557755.2669,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000016,
+                "end": 8.000018,
+                "seconds": 1.0000020265579224,
+                "bytes": 4318953472,
+                "bits_per_second": 34551557755.2669,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000018,
+                  "end": 9.000035,
+                  "seconds": 1.0000170469284058,
+                  "bytes": 4416208896,
+                  "bits_per_second": 35329068915.89155,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000018,
+                "end": 9.000035,
+                "seconds": 1.0000170469284058,
+                "bytes": 4416208896,
+                "bits_per_second": 35329068915.89155,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000035,
+                  "end": 10.00001,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 4437573632,
+                  "bits_per_second": 35501475682.14291,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000035,
+                "end": 10.00001,
+                "seconds": 0.9999750256538391,
+                "bytes": 4437573632,
+                "bits_per_second": 35501475682.14291,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040164,
+                  "seconds": 10.040164,
+                  "bytes": 43710042440,
+                  "bits_per_second": 34828150169.65858,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00001,
+                  "seconds": 10.00001,
+                  "bytes": 43708600648,
+                  "bits_per_second": 34966845551.55445,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040164,
+              "seconds": 10.040164,
+              "bytes": 43710042440,
+              "bits_per_second": 34828150169.65858,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00001,
+              "seconds": 10.00001,
+              "bytes": 43708600648,
+              "bits_per_second": 34966845551.55445,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.26294493237891,
+              "host_user": 1.8116036545309533,
+              "host_system": 89.45135119667133,
+              "remote_total": 44.14246868282316,
+              "remote_user": 0.32552835005268926,
+              "remote_system": 43.816940332770464
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55424,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:09 UTC",
+              "timesecs": 1711485249
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000296,
+                  "seconds": 1.0002959966659546,
+                  "bytes": 1501175364,
+                  "bits_per_second": 12005849220.658731,
+                  "retransmits": 40,
+                  "snd_cwnd": 641648,
+                  "rtt": 391,
+                  "rttvar": 37,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000296,
+                "seconds": 1.0002959966659546,
+                "bytes": 1501175364,
+                "bits_per_second": 12005849220.658731,
+                "retransmits": 40,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000296,
+                  "end": 2.000231,
+                  "seconds": 0.99993497133255,
+                  "bytes": 1529610240,
+                  "bits_per_second": 12237677719.874805,
+                  "retransmits": 12,
+                  "snd_cwnd": 787232,
+                  "rtt": 223,
+                  "rttvar": 31,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000296,
+                "end": 2.000231,
+                "seconds": 0.99993497133255,
+                "bytes": 1529610240,
+                "bits_per_second": 12237677719.874805,
+                "retransmits": 12,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000231,
+                  "end": 3.000429,
+                  "seconds": 1.0001980066299438,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12286877836.727018,
+                  "retransmits": 13,
+                  "snd_cwnd": 655128,
+                  "rtt": 228,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000231,
+                "end": 3.000429,
+                "seconds": 1.0001980066299438,
+                "bytes": 1536163840,
+                "bits_per_second": 12286877836.727018,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000429,
+                  "end": 4.000044,
+                  "seconds": 0.9996150135993958,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12367472348.664085,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 193,
+                  "rttvar": 25,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000429,
+                "end": 4.000044,
+                "seconds": 0.9996150135993958,
+                "bytes": 1545338880,
+                "bits_per_second": 12367472348.664085,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000044,
+                  "end": 5.000092,
+                  "seconds": 1.000048041343689,
+                  "bytes": 1523056640,
+                  "bits_per_second": 12183867790.62001,
+                  "retransmits": 2,
+                  "snd_cwnd": 936860,
+                  "rtt": 606,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000044,
+                "end": 5.000092,
+                "seconds": 1.000048041343689,
+                "bytes": 1523056640,
+                "bits_per_second": 12183867790.62001,
+                "retransmits": 2,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000092,
+                  "end": 6.000681,
+                  "seconds": 1.0005890130996704,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12376392702.57152,
+                  "retransmits": 6,
+                  "snd_cwnd": 829020,
+                  "rtt": 197,
+                  "rttvar": 54,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000092,
+                "end": 6.000681,
+                "seconds": 1.0005890130996704,
+                "bytes": 1547960320,
+                "bits_per_second": 12376392702.57152,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000681,
+                  "end": 7.000548,
+                  "seconds": 0.9998670220375061,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12385329535.886497,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 218,
+                  "rttvar": 40,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000681,
+                "end": 7.000548,
+                "seconds": 0.9998670220375061,
+                "bytes": 1547960320,
+                "bits_per_second": 12385329535.886497,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000548,
+                  "end": 8.000077,
+                  "seconds": 0.9995290040969849,
+                  "bytes": 1534853120,
+                  "bits_per_second": 12284610961.43297,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 200,
+                  "rttvar": 33,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000548,
+                "end": 8.000077,
+                "seconds": 0.9995290040969849,
+                "bytes": 1534853120,
+                "bits_per_second": 12284610961.43297,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000077,
+                  "end": 9.000416,
+                  "seconds": 1.0003390312194824,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12285145672.081276,
+                  "retransmits": 0,
+                  "snd_cwnd": 934164,
+                  "rtt": 220,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000077,
+                "end": 9.000416,
+                "seconds": 1.0003390312194824,
+                "bytes": 1536163840,
+                "bits_per_second": 12285145672.081276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000416,
+                  "end": 10.00071,
+                  "seconds": 1.0002939701080322,
+                  "bytes": 1544028160,
+                  "bits_per_second": 12348595162.146137,
+                  "retransmits": 50,
+                  "snd_cwnd": 776448,
+                  "rtt": 184,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000416,
+                "end": 10.00071,
+                "seconds": 1.0002939701080322,
+                "bytes": 1544028160,
+                "bits_per_second": 12348595162.146137,
+                "retransmits": 50,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00071,
+                  "seconds": 10.00071,
+                  "bytes": 15346310724,
+                  "bits_per_second": 12276176970.635086,
+                  "retransmits": 123,
+                  "max_snd_cwnd": 936860,
+                  "max_rtt": 606,
+                  "min_rtt": 184,
+                  "mean_rtt": 266,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040277,
+                  "seconds": 10.00071,
+                  "bytes": 15346244356,
+                  "bits_per_second": 12227745793.069256,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00071,
+              "seconds": 10.00071,
+              "bytes": 15346310724,
+              "bits_per_second": 12276176970.635086,
+              "retransmits": 123,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040277,
+              "seconds": 10.040277,
+              "bytes": 15346244356,
+              "bits_per_second": 12227745793.069256,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 95.82562437024121,
+              "host_user": 0.2560031758234491,
+              "host_system": 95.56962119441776,
+              "remote_total": 24.102997438800752,
+              "remote_user": 1.0351409018247604,
+              "remote_system": 23.06785653697599
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39456,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:21 UTC",
+              "timesecs": 1711485261
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1697801956,
+                  "bits_per_second": 13582334690.976553,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1697801956,
+                "bits_per_second": 13582334690.976553,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000057,
+                  "seconds": 1.0000510215759277,
+                  "bytes": 1744419840,
+                  "bits_per_second": 13954646731.932222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000057,
+                "seconds": 1.0000510215759277,
+                "bytes": 1744419840,
+                "bits_per_second": 13954646731.932222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000015,
+                  "seconds": 0.9999579787254333,
+                  "bytes": 1748195168,
+                  "bits_per_second": 13986149059.809772,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000015,
+                "seconds": 0.9999579787254333,
+                "bytes": 1748195168,
+                "bits_per_second": 13986149059.809772,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1734067200,
+                  "bits_per_second": 13872357345.188877,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1734067200,
+                "bits_per_second": 13872357345.188877,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1729473216,
+                  "bits_per_second": 13835744494.268211,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 1729473216,
+                "bits_per_second": 13835744494.268211,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000014,
+                  "seconds": 0.999983012676239,
+                  "bytes": 1727920320,
+                  "bits_per_second": 13823597385.924335,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000014,
+                "seconds": 0.999983012676239,
+                "bytes": 1727920320,
+                "bits_per_second": 13823597385.924335,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000014,
+                  "end": 7.000057,
+                  "seconds": 1.0000430345535278,
+                  "bytes": 1720414656,
+                  "bits_per_second": 13762724975.275362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000014,
+                "end": 7.000057,
+                "seconds": 1.0000430345535278,
+                "bytes": 1720414656,
+                "bits_per_second": 13762724975.275362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000012,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 1731396632,
+                  "bits_per_second": 13851796407.710308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000012,
+                "seconds": 0.9999549984931946,
+                "bytes": 1731396632,
+                "bits_per_second": 13851796407.710308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000012,
+                  "end": 9.000057,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731026112,
+                  "bits_per_second": 13847586559.1197,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000012,
+                "end": 9.000057,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731026112,
+                "bits_per_second": 13847586559.1197,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000057,
+                  "end": 10.000029,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 1741314048,
+                  "bits_per_second": 13930902646.856724,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000057,
+                "end": 10.000029,
+                "seconds": 0.9999719858169556,
+                "bytes": 1741314048,
+                "bits_per_second": 13930902646.856724,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039465,
+                  "seconds": 10.039465,
+                  "bytes": 17308229084,
+                  "bits_per_second": 13792152537.211893,
+                  "retransmits": 2195,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000029,
+                  "seconds": 10.000029,
+                  "bytes": 17306029148,
+                  "bits_per_second": 13844783168.528812,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039465,
+              "seconds": 10.039465,
+              "bytes": 17308229084,
+              "bits_per_second": 13792152537.211893,
+              "retransmits": 2195,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000029,
+              "seconds": 10.000029,
+              "bytes": 17306029148,
+              "bits_per_second": 13844783168.528812,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.47684113065824,
+              "host_user": 1.8968527601361653,
+              "host_system": 42.57999828989936,
+              "remote_total": 12.529305328982618,
+              "remote_user": 0.09332895016906215,
+              "remote_system": 12.435986036196645
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56016,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:38 UTC",
+              "timesecs": 1711485278
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000293,
+                  "seconds": 1.0002930164337158,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25745482710.471886,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000293,
+                "seconds": 1.0002930164337158,
+                "bytes": 3219128320,
+                "bits_per_second": 25745482710.471886,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000293,
+                  "end": 2.000138,
+                  "seconds": 0.999845027923584,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25757018178.58942,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 37,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000293,
+                "end": 2.000138,
+                "seconds": 0.999845027923584,
+                "bytes": 3219128320,
+                "bits_per_second": 25757018178.58942,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000138,
+                  "end": 3.000088,
+                  "seconds": 0.9999499917030334,
+                  "bytes": 3282042880,
+                  "bits_per_second": 26257656140.665928,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000138,
+                "end": 3.000088,
+                "seconds": 0.9999499917030334,
+                "bytes": 3282042880,
+                "bits_per_second": 26257656140.665928,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000088,
+                  "end": 4.000243,
+                  "seconds": 1.000154972076416,
+                  "bytes": 3465543680,
+                  "bits_per_second": 27720053605.734356,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000088,
+                "end": 4.000243,
+                "seconds": 1.000154972076416,
+                "bytes": 3465543680,
+                "bits_per_second": 27720053605.734356,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000243,
+                  "end": 5.000101,
+                  "seconds": 0.999858021736145,
+                  "bytes": 3481272320,
+                  "bits_per_second": 27854133241.47881,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000243,
+                "end": 5.000101,
+                "seconds": 0.999858021736145,
+                "bytes": 3481272320,
+                "bits_per_second": 27854133241.47881,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000101,
+                  "end": 6.000015,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 3489136640,
+                  "bits_per_second": 27915494117.75862,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000101,
+                "end": 6.000015,
+                "seconds": 0.9999139904975891,
+                "bytes": 3489136640,
+                "bits_per_second": 27915494117.75862,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000015,
+                  "end": 7.000294,
+                  "seconds": 1.0002789497375488,
+                  "bytes": 3472097280,
+                  "bits_per_second": 27769032075.790474,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000015,
+                "end": 7.000294,
+                "seconds": 1.0002789497375488,
+                "bytes": 3472097280,
+                "bits_per_second": 27769032075.790474,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000294,
+                  "end": 8.000249,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 3482583040,
+                  "bits_per_second": 27861918148.299164,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000294,
+                "end": 8.000249,
+                "seconds": 0.9999549984931946,
+                "bytes": 3482583040,
+                "bits_per_second": 27861918148.299164,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000249,
+                  "end": 9.000268,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 3388211200,
+                  "bits_per_second": 27105175840.98793,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000249,
+                "end": 9.000268,
+                "seconds": 1.0000189542770386,
+                "bytes": 3388211200,
+                "bits_per_second": 27105175840.98793,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000268,
+                  "end": 10.000366,
+                  "seconds": 1.0000979900360107,
+                  "bytes": 3389521920,
+                  "bits_per_second": 27113518505.345284,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 31,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000268,
+                "end": 10.000366,
+                "seconds": 1.0000979900360107,
+                "bytes": 3389521920,
+                "bits_per_second": 27113518505.345284,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000366,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27109940256.186626,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 663216,
+                  "max_rtt": 37,
+                  "min_rtt": 31,
+                  "mean_rtt": 33,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039647,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27003870235.676613,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000366,
+              "seconds": 10.000366,
+              "bytes": 33888665600,
+              "bits_per_second": 27109940256.186626,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039647,
+              "seconds": 10.039647,
+              "bytes": 33888665600,
+              "bits_per_second": 27003870235.676613,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.6366144037512,
+              "host_user": 0.5079154773387307,
+              "host_system": 98.12868897353042,
+              "remote_total": 69.33475570009895,
+              "remote_user": 1.8358332803622874,
+              "remote_system": 67.4989133777374
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 41272,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:50 UTC",
+              "timesecs": 1711485290
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000015,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 3679605064,
+                  "bits_per_second": 29436398366.39084,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000015,
+                "seconds": 1.0000150203704834,
+                "bytes": 3679605064,
+                "bits_per_second": 29436398366.39084,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000015,
+                  "end": 2.00001,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 3648388804,
+                  "bits_per_second": 29187256566.469006,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000015,
+                "end": 2.00001,
+                "seconds": 0.9999949932098389,
+                "bytes": 3648388804,
+                "bits_per_second": 29187256566.469006,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000028,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 3632922940,
+                  "bits_per_second": 29062860370.99649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000028,
+                "seconds": 1.0000180006027222,
+                "bytes": 3632922940,
+                "bits_per_second": 29062860370.99649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000028,
+                  "end": 4.000024,
+                  "seconds": 0.9999960064888,
+                  "bytes": 3643932672,
+                  "bits_per_second": 29151577793.152412,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000028,
+                "end": 4.000024,
+                "seconds": 0.9999960064888,
+                "bytes": 3643932672,
+                "bits_per_second": 29151577793.152412,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000024,
+                  "end": 5.000031,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 3619028992,
+                  "bits_per_second": 28952028306.307198,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000024,
+                "end": 5.000031,
+                "seconds": 1.0000070333480835,
+                "bytes": 3619028992,
+                "bits_per_second": 28952028306.307198,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000037,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 3631349760,
+                  "bits_per_second": 29050624924.782085,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000037,
+                "seconds": 1.0000059604644775,
+                "bytes": 3631349760,
+                "bits_per_second": 29050624924.782085,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000037,
+                  "end": 7.000025,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 3610509312,
+                  "bits_per_second": 28884420546.770874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000037,
+                "end": 7.000025,
+                "seconds": 0.9999880194664001,
+                "bytes": 3610509312,
+                "bits_per_second": 28884420546.770874,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000025,
+                  "end": 8.000022,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3608674304,
+                  "bits_per_second": 28869480469.756413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000025,
+                "end": 8.000022,
+                "seconds": 0.9999970197677612,
+                "bytes": 3608674304,
+                "bits_per_second": 28869480469.756413,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000022,
+                  "end": 9.000038,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 3623223296,
+                  "bits_per_second": 28985323355.146187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000022,
+                "end": 9.000038,
+                "seconds": 1.0000159740447998,
+                "bytes": 3623223296,
+                "bits_per_second": 28985323355.146187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000038,
+                  "end": 10.000021,
+                  "seconds": 0.999983012676239,
+                  "bytes": 3621519360,
+                  "bits_per_second": 28972647047.73561,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000038,
+                "end": 10.000021,
+                "seconds": 0.999983012676239,
+                "bytes": 3621519360,
+                "bits_per_second": 28972647047.73561,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039809,
+                  "seconds": 10.039809,
+                  "bytes": 36320203080,
+                  "bits_per_second": 28940951430.45052,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000021,
+                  "seconds": 10.000021,
+                  "bytes": 36319154504,
+                  "bits_per_second": 29055262587.148567,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039809,
+              "seconds": 10.039809,
+              "bytes": 36320203080,
+              "bits_per_second": 28940951430.45052,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000021,
+              "seconds": 10.000021,
+              "bytes": 36319154504,
+              "bits_per_second": 29055262587.148567,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.40432984604324,
+              "host_user": 2.1048623181527053,
+              "host_system": 84.29947744708186,
+              "remote_total": 96.37010529501002,
+              "remote_user": 0.5200516733573617,
+              "remote_system": 95.85006329541284
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 35114,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:07 UTC",
+              "timesecs": 1711485307
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2927638472,
+                  "bits_per_second": 23419748144.30112,
+                  "retransmits": 368,
+                  "snd_cwnd": 2701392,
+                  "rtt": 911,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 2927638472,
+                "bits_per_second": 23419748144.30112,
+                "retransmits": 368,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000132,
+                  "seconds": 1.000074028968811,
+                  "bytes": 2915041280,
+                  "bits_per_second": 23318603987.79267,
+                  "retransmits": 202,
+                  "snd_cwnd": 2724308,
+                  "rtt": 935,
+                  "rttvar": 42,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000132,
+                "seconds": 1.000074028968811,
+                "bytes": 2915041280,
+                "bits_per_second": 23318603987.79267,
+                "retransmits": 202,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000132,
+                  "end": 3.000059,
+                  "seconds": 0.9999269843101501,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416411845.464706,
+                  "retransmits": 13,
+                  "snd_cwnd": 2744528,
+                  "rtt": 900,
+                  "rttvar": 30,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000132,
+                "end": 3.000059,
+                "seconds": 0.9999269843101501,
+                "bytes": 2926837760,
+                "bits_per_second": 23416411845.464706,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000057,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23404263750.09612,
+                  "retransmits": 6,
+                  "snd_cwnd": 2345520,
+                  "rtt": 798,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000057,
+                "seconds": 0.9999979734420776,
+                "bytes": 2925527040,
+                "bits_per_second": 23404263750.09612,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000144,
+                  "seconds": 1.000087022781372,
+                  "bytes": 2929459200,
+                  "bits_per_second": 23433634339.962082,
+                  "retransmits": 4,
+                  "snd_cwnd": 2325300,
+                  "rtt": 778,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000144,
+                "seconds": 1.000087022781372,
+                "bytes": 2929459200,
+                "bits_per_second": 23433634339.962082,
+                "retransmits": 4,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000144,
+                  "end": 6.000058,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416716140.103306,
+                  "retransmits": 0,
+                  "snd_cwnd": 3097704,
+                  "rtt": 1023,
+                  "rttvar": 3,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000144,
+                "end": 6.000058,
+                "seconds": 0.9999139904975891,
+                "bytes": 2926837760,
+                "bits_per_second": 23416716140.103306,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000149,
+                  "seconds": 1.0000909566879272,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23423057356.281742,
+                  "retransmits": 0,
+                  "snd_cwnd": 3165104,
+                  "rtt": 1109,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000149,
+                "seconds": 1.0000909566879272,
+                "bytes": 2928148480,
+                "bits_per_second": 23423057356.281742,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000149,
+                  "end": 8.000068,
+                  "seconds": 0.9999189972877502,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416598888.021595,
+                  "retransmits": 711,
+                  "snd_cwnd": 2543676,
+                  "rtt": 841,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000149,
+                "end": 8.000068,
+                "seconds": 0.9999189972877502,
+                "bytes": 2926837760,
+                "bits_per_second": 23416598888.021595,
+                "retransmits": 711,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000068,
+                  "end": 9.000241,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23421136623.249817,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 1059,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000068,
+                "end": 9.000241,
+                "seconds": 1.0001729726791382,
+                "bytes": 2928148480,
+                "bits_per_second": 23421136623.249817,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000241,
+                  "end": 10.000231,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414936547.34786,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 781,
+                  "rttvar": 78,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000241,
+                "end": 10.000231,
+                "seconds": 0.9999899864196777,
+                "bytes": 2926837760,
+                "bits_per_second": 23414936547.34786,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000231,
+                  "seconds": 10.000231,
+                  "bytes": 29261313992,
+                  "bits_per_second": 23408510457.008446,
+                  "retransmits": 1304,
+                  "max_snd_cwnd": 3165104,
+                  "max_rtt": 1109,
+                  "min_rtt": 778,
+                  "mean_rtt": 913,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000231,
+                  "bytes": 29260124328,
+                  "bits_per_second": 23314036650.131382,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000231,
+              "seconds": 10.000231,
+              "bytes": 29261313992,
+              "bits_per_second": 23408510457.008446,
+              "retransmits": 1304,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 29260124328,
+              "bits_per_second": 23314036650.131382,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.97762289166434,
+              "host_user": 0.5691962216451614,
+              "host_system": 34.40843658477508,
+              "remote_total": 62.9251445256492,
+              "remote_user": 2.6124474135751976,
+              "remote_system": 60.31269711207401
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55052,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:19 UTC",
+              "timesecs": 1711485319
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2924870228,
+                  "bits_per_second": 23398635471.838806,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 2924870228,
+                "bits_per_second": 23398635471.838806,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000028,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2928633648,
+                  "bits_per_second": 23428742411.922653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000028,
+                "seconds": 1.0000139474868774,
+                "bytes": 2928633648,
+                "bits_per_second": 23428742411.922653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000028,
+                  "end": 3.000026,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2912575888,
+                  "bits_per_second": 23300654324.125618,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000028,
+                "end": 3.000026,
+                "seconds": 0.9999979734420776,
+                "bytes": 2912575888,
+                "bits_per_second": 23300654324.125618,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000009,
+                  "seconds": 0.999983012676239,
+                  "bytes": 2928793176,
+                  "bits_per_second": 23430743433.62467,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000009,
+                "seconds": 0.999983012676239,
+                "bytes": 2928793176,
+                "bits_per_second": 23430743433.62467,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000009,
+                  "end": 5.000024,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2927518936,
+                  "bits_per_second": 23419799713.93165,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000009,
+                "end": 5.000024,
+                "seconds": 1.0000150203704834,
+                "bytes": 2927518936,
+                "bits_per_second": 23419799713.93165,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000024,
+                  "end": 6.000039,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2928627108,
+                  "bits_per_second": 23428664956.77242,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000024,
+                "end": 6.000039,
+                "seconds": 1.0000150203704834,
+                "bytes": 2928627108,
+                "bits_per_second": 23428664956.77242,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000039,
+                  "end": 7.000044,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2924520712,
+                  "bits_per_second": 23396048556.894276,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000039,
+                "end": 7.000044,
+                "seconds": 1.0000050067901611,
+                "bytes": 2924520712,
+                "bits_per_second": 23396048556.894276,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000044,
+                  "end": 8.00003,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 2928023612,
+                  "bits_per_second": 23424517005.353558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000044,
+                "end": 8.00003,
+                "seconds": 0.9999859929084778,
+                "bytes": 2928023612,
+                "bits_per_second": 23424517005.353558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000029,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927982060,
+                  "bits_per_second": 23423880214.92501,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000029,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927982060,
+                "bits_per_second": 23423880214.92501,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000013,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2927753088,
+                  "bits_per_second": 23422398854.44862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000013,
+                "seconds": 0.9999840259552002,
+                "bytes": 2927753088,
+                "bits_per_second": 23422398854.44862,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039882,
+                  "seconds": 10.039882,
+                  "bytes": 29263263664,
+                  "bits_per_second": 23317615616.597885,
+                  "retransmits": 2270,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000013,
+                  "seconds": 10.000013,
+                  "bytes": 29259298456,
+                  "bits_per_second": 23407408335.169167,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039882,
+              "seconds": 10.039882,
+              "bytes": 29263263664,
+              "bits_per_second": 23317615616.597885,
+              "retransmits": 2270,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000013,
+              "seconds": 10.000013,
+              "bytes": 29259298456,
+              "bits_per_second": 23407408335.169167,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 88.6667781634535,
+              "host_user": 2.169277119907057,
+              "host_system": 86.4975109631894,
+              "remote_total": 22.440235970749637,
+              "remote_user": 0.4127789042736779,
+              "remote_system": 22.027466720316273
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 50458,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:37 UTC",
+              "timesecs": 1711485337
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000278,
+                  "seconds": 1.0002779960632324,
+                  "bytes": 3395979324,
+                  "bits_per_second": 27160284139.932823,
+                  "retransmits": 0,
+                  "snd_cwnd": 884288,
+                  "rtt": 40,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000278,
+                "seconds": 1.0002779960632324,
+                "bytes": 3395979324,
+                "bits_per_second": 27160284139.932823,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000278,
+                  "end": 2.000255,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27473323289.542732,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000278,
+                "end": 2.000255,
+                "seconds": 0.9999769926071167,
+                "bytes": 3434086400,
+                "bits_per_second": 27473323289.542732,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000255,
+                  "end": 3.000046,
+                  "seconds": 0.9997910261154175,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530873233.52556,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000255,
+                "end": 3.000046,
+                "seconds": 0.9997910261154175,
+                "bytes": 3440640000,
+                "bits_per_second": 27530873233.52556,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000267,
+                  "seconds": 1.0002210140228271,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27298885603.47408,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000267,
+                "seconds": 1.0002210140228271,
+                "bytes": 3413114880,
+                "bits_per_second": 27298885603.47408,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000044,
+                  "seconds": 0.9997770190238953,
+                  "bytes": 3420979200,
+                  "bits_per_second": 27373937467.296288,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000044,
+                "seconds": 0.9997770190238953,
+                "bytes": 3420979200,
+                "bits_per_second": 27373937467.296288,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000044,
+                  "end": 6.000099,
+                  "seconds": 1.000054955482483,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27523607426.874187,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000044,
+                "end": 6.000099,
+                "seconds": 1.000054955482483,
+                "bytes": 3440640000,
+                "bits_per_second": 27523607426.874187,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000099,
+                  "end": 7.000285,
+                  "seconds": 1.0001859664916992,
+                  "bytes": 3441950720,
+                  "bits_per_second": 27530486012.101555,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000099,
+                "end": 7.000285,
+                "seconds": 1.0001859664916992,
+                "bytes": 3441950720,
+                "bits_per_second": 27530486012.101555,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000285,
+                  "end": 8.000245,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27526220903.40532,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000285,
+                "end": 8.000245,
+                "seconds": 0.9999600052833557,
+                "bytes": 3440640000,
+                "bits_per_second": 27526220903.40532,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000245,
+                  "end": 9.000034,
+                  "seconds": 0.9997889995574951,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530929038.209633,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 33,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000245,
+                "end": 9.000034,
+                "seconds": 0.9997889995574951,
+                "bytes": 3440640000,
+                "bits_per_second": 27530929038.209633,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000143,
+                  "seconds": 1.0001089572906494,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27469698176.111774,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000143,
+                "seconds": 1.0001089572906494,
+                "bytes": 3434086400,
+                "bits_per_second": 27469698176.111774,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000143,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27441813121.272366,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1074356,
+                  "max_rtt": 40,
+                  "min_rtt": 31,
+                  "mean_rtt": 34,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039944,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27333026498.155766,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000143,
+              "seconds": 10.000143,
+              "bytes": 34302756924,
+              "bits_per_second": 27441813121.272366,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039944,
+              "seconds": 10.039944,
+              "bytes": 34302756924,
+              "bits_per_second": 27333026498.155766,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.72291319227105,
+              "host_user": 0.5304700943978504,
+              "host_system": 84.19243318754582,
+              "remote_total": 37.30641845607046,
+              "remote_user": 1.3600734652179878,
+              "remote_system": 35.946344990852474
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 53048,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:49 UTC",
+              "timesecs": 1711485349
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000028,
+                  "seconds": 1.0000280141830444,
+                  "bytes": 4393816392,
+                  "bits_per_second": 35149546450.171814,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000028,
+                "seconds": 1.0000280141830444,
+                "bytes": 4393816392,
+                "bits_per_second": 35149546450.171814,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000028,
+                  "end": 2.000009,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159421797.086105,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000028,
+                "end": 2.000009,
+                "seconds": 0.9999809861183167,
+                "bytes": 4394844160,
+                "bits_per_second": 35159421797.086105,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000006,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4315414528,
+                  "bits_per_second": 34523419111.80663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000006,
+                "seconds": 0.9999970197677612,
+                "bytes": 4315414528,
+                "bits_per_second": 34523419111.80663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000006,
+                  "end": 4.000048,
+                  "seconds": 1.0000419616699219,
+                  "bytes": 4349886464,
+                  "bits_per_second": 34797631545.271034,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000006,
+                "end": 4.000048,
+                "seconds": 1.0000419616699219,
+                "bytes": 4349886464,
+                "bits_per_second": 34797631545.271034,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000048,
+                  "end": 5.000028,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4430495744,
+                  "bits_per_second": 35444675808.21641,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000048,
+                "end": 5.000028,
+                "seconds": 0.9999799728393555,
+                "bytes": 4430495744,
+                "bits_per_second": 35444675808.21641,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 4407427072,
+                  "bits_per_second": 35259311495.06316,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 4407427072,
+                "bits_per_second": 35259311495.06316,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000031,
+                  "end": 7.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 4397727744,
+                  "bits_per_second": 35182595762.019264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000031,
+                "end": 7.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 4397727744,
+                "bits_per_second": 35182595762.019264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000027,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4317599700,
+                  "bits_per_second": 34540175856.016464,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000027,
+                "seconds": 1.0000180006027222,
+                "bytes": 4317599700,
+                "bits_per_second": 34540175856.016464,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000027,
+                  "end": 9.000013,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159245758.77319,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000027,
+                "end": 9.000013,
+                "seconds": 0.9999859929084778,
+                "bytes": 4394844160,
+                "bits_per_second": 35159245758.77319,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000013,
+                  "end": 10.000067,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4418043904,
+                  "bits_per_second": 35342442676.19047,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000013,
+                "end": 10.000067,
+                "seconds": 1.0000540018081665,
+                "bytes": 4418043904,
+                "bits_per_second": 35342442676.19047,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040332,
+                  "seconds": 10.040332,
+                  "bytes": 43821410588,
+                  "bits_per_second": 34916304032.97421,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 43820099868,
+                  "bits_per_second": 35055845020.238365,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040332,
+              "seconds": 10.040332,
+              "bytes": 43821410588,
+              "bits_per_second": 34916304032.97421,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 43820099868,
+              "bits_per_second": 35055845020.238365,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.7129817857671,
+              "host_user": 1.930649372470762,
+              "host_system": 89.782322494473,
+              "remote_total": 44.03409922696862,
+              "remote_user": 0.28095210440615037,
+              "remote_system": 43.75314712256247
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 47342,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:07 UTC",
+              "timesecs": 1711485367
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000658,
+                  "seconds": 1.0006580352783203,
+                  "bytes": 1519091984,
+                  "bits_per_second": 12144744201.868994,
+                  "retransmits": 186,
+                  "snd_cwnd": 841152,
+                  "rtt": 194,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000658,
+                "seconds": 1.0006580352783203,
+                "bytes": 1519091984,
+                "bits_per_second": 12144744201.868994,
+                "retransmits": 186,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000658,
+                  "end": 2.00053,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 1496842240,
+                  "bits_per_second": 11976270537.380842,
+                  "retransmits": 69,
+                  "snd_cwnd": 831716,
+                  "rtt": 212,
+                  "rttvar": 24,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000658,
+                "end": 2.00053,
+                "seconds": 0.9998720288276672,
+                "bytes": 1496842240,
+                "bits_per_second": 11976270537.380842,
+                "retransmits": 69,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00053,
+                  "end": 3.000069,
+                  "seconds": 0.9995390176773071,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12347431467.637243,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 240,
+                  "rttvar": 28,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.00053,
+                "end": 3.000069,
+                "seconds": 0.9995390176773071,
+                "bytes": 1542717440,
+                "bits_per_second": 12347431467.637243,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000069,
+                  "end": 4.000792,
+                  "seconds": 1.0007230043411255,
+                  "bytes": 1482424320,
+                  "bits_per_second": 11850826361.095003,
+                  "retransmits": 21,
+                  "snd_cwnd": 683436,
+                  "rtt": 355,
+                  "rttvar": 32,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000069,
+                "end": 4.000792,
+                "seconds": 1.0007230043411255,
+                "bytes": 1482424320,
+                "bits_per_second": 11850826361.095003,
+                "retransmits": 21,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000792,
+                  "end": 5.000133,
+                  "seconds": 0.9993410110473633,
+                  "bytes": 1537474560,
+                  "bits_per_second": 12307907254.911064,
+                  "retransmits": 0,
+                  "snd_cwnd": 789928,
+                  "rtt": 201,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000792,
+                "end": 5.000133,
+                "seconds": 0.9993410110473633,
+                "bytes": 1537474560,
+                "bits_per_second": 12307907254.911064,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000133,
+                  "end": 6.000434,
+                  "seconds": 1.0003010034561157,
+                  "bytes": 1528299520,
+                  "bits_per_second": 12222717079.915821,
+                  "retransmits": 22,
+                  "snd_cwnd": 798016,
+                  "rtt": 187,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000133,
+                "end": 6.000434,
+                "seconds": 1.0003010034561157,
+                "bytes": 1528299520,
+                "bits_per_second": 12222717079.915821,
+                "retransmits": 22,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000434,
+                  "end": 7.000335,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 1551892480,
+                  "bits_per_second": 12416369101.700983,
+                  "retransmits": 0,
+                  "snd_cwnd": 823628,
+                  "rtt": 270,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000434,
+                "end": 7.000335,
+                "seconds": 0.9999009966850281,
+                "bytes": 1551892480,
+                "bits_per_second": 12416369101.700983,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000335,
+                  "end": 8.00007,
+                  "seconds": 0.9997349977493286,
+                  "bytes": 1550581760,
+                  "bits_per_second": 12407942212.612543,
+                  "retransmits": 0,
+                  "snd_cwnd": 924728,
+                  "rtt": 210,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000335,
+                "end": 8.00007,
+                "seconds": 0.9997349977493286,
+                "bytes": 1550581760,
+                "bits_per_second": 12407942212.612543,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00007,
+                  "end": 9.000638,
+                  "seconds": 1.0005680322647095,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12355692607.945854,
+                  "retransmits": 35,
+                  "snd_cwnd": 802060,
+                  "rtt": 187,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00007,
+                "end": 9.000638,
+                "seconds": 1.0005680322647095,
+                "bytes": 1545338880,
+                "bits_per_second": 12355692607.945854,
+                "retransmits": 35,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000638,
+                  "end": 10.000796,
+                  "seconds": 1.0001579523086548,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12339790421.61459,
+                  "retransmits": 0,
+                  "snd_cwnd": 851936,
+                  "rtt": 272,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000638,
+                "end": 10.000796,
+                "seconds": 1.0001579523086548,
+                "bytes": 1542717440,
+                "bits_per_second": 12339790421.61459,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000796,
+                  "seconds": 10.000796,
+                  "bytes": 15297380624,
+                  "bits_per_second": 12236930439.537014,
+                  "retransmits": 333,
+                  "max_snd_cwnd": 924728,
+                  "max_rtt": 355,
+                  "min_rtt": 187,
+                  "mean_rtt": 232,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040404,
+                  "seconds": 10.000796,
+                  "bytes": 15297378960,
+                  "bits_per_second": 12188656121.805456,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000796,
+              "seconds": 10.000796,
+              "bytes": 15297380624,
+              "bits_per_second": 12236930439.537014,
+              "retransmits": 333,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040404,
+              "seconds": 10.040404,
+              "bytes": 15297378960,
+              "bits_per_second": 12188656121.805456,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 94.61572077164762,
+              "host_user": 0.29949784294138804,
+              "host_system": 94.31623284257061,
+              "remote_total": 24.200736107154952,
+              "remote_user": 0.7375246434410879,
+              "remote_system": 23.463211463713865
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 48142,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:19 UTC",
+              "timesecs": 1711485379
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000003,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1743350008,
+                  "bits_per_second": 13946758499.420694,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000003,
+                "seconds": 1.0000029802322388,
+                "bytes": 1743350008,
+                "bits_per_second": 13946758499.420694,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000003,
+                  "end": 2.000012,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 1755937152,
+                  "bits_per_second": 14047371622.71066,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000003,
+                "end": 2.000012,
+                "seconds": 1.0000089406967163,
+                "bytes": 1755937152,
+                "bits_per_second": 14047371622.71066,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000012,
+                  "end": 3.00001,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1733808384,
+                  "bits_per_second": 13870495181.361897,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000012,
+                "end": 3.00001,
+                "seconds": 0.9999979734420776,
+                "bytes": 1733808384,
+                "bits_per_second": 13870495181.361897,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00001,
+                  "end": 4.000018,
+                  "seconds": 1.0000079870224,
+                  "bytes": 1738644752,
+                  "bits_per_second": 13909046924.130655,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.00001,
+                "end": 4.000018,
+                "seconds": 1.0000079870224,
+                "bytes": 1738644752,
+                "bits_per_second": 13909046924.130655,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000023,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900420131.51325,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000023,
+                "seconds": 1.0000050067901611,
+                "bytes": 1737561216,
+                "bits_per_second": 13900420131.51325,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000023,
+                  "end": 6.000056,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1736454280,
+                  "bits_per_second": 13891175539.864704,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000023,
+                "end": 6.000056,
+                "seconds": 1.0000330209732056,
+                "bytes": 1736454280,
+                "bits_per_second": 13891175539.864704,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000026,
+                  "seconds": 0.999970018863678,
+                  "bytes": 1727790912,
+                  "bits_per_second": 13822741717.503777,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000026,
+                "seconds": 0.999970018863678,
+                "bytes": 1727790912,
+                "bits_per_second": 13822741717.503777,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000019,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1724361600,
+                  "bits_per_second": 13794989002.714045,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000019,
+                "seconds": 0.9999930262565613,
+                "bytes": 1724361600,
+                "bits_per_second": 13794989002.714045,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000019,
+                  "end": 9.000026,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1740731712,
+                  "bits_per_second": 13925755751.312475,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000019,
+                "end": 9.000026,
+                "seconds": 1.0000070333480835,
+                "bytes": 1740731712,
+                "bits_per_second": 13925755751.312475,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000039,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1729926144,
+                  "bits_per_second": 13839229327.648127,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000039,
+                "seconds": 1.000012993812561,
+                "bytes": 1729926144,
+                "bits_per_second": 13839229327.648127,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039511,
+                  "seconds": 10.039511,
+                  "bytes": 17371187600,
+                  "bits_per_second": 13842257934.674309,
+                  "retransmits": 2068,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000039,
+                  "seconds": 10.000039,
+                  "bytes": 17368566160,
+                  "bits_per_second": 13894798738.284922,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039511,
+              "seconds": 10.039511,
+              "bytes": 17371187600,
+              "bits_per_second": 13842257934.674309,
+              "retransmits": 2068,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000039,
+              "seconds": 10.000039,
+              "bytes": 17368566160,
+              "bits_per_second": 13894798738.284922,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.48791626719862,
+              "host_user": 1.6040884366461445,
+              "host_system": 42.883837750090144,
+              "remote_total": 12.877414932148609,
+              "remote_user": 0.20340289771075803,
+              "remote_system": 12.674021700497715
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39362,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:36 UTC",
+              "timesecs": 1711485396
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000203,
+                  "seconds": 1.000203013420105,
+                  "bytes": 3477340160,
+                  "bits_per_second": 27813074852.55055,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000203,
+                "seconds": 1.000203013420105,
+                "bytes": 3477340160,
+                "bits_per_second": 27813074852.55055,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000203,
+                  "end": 2.000079,
+                  "seconds": 0.9998760223388672,
+                  "bytes": 3461611520,
+                  "bits_per_second": 27696325885.70528,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000203,
+                "end": 2.000079,
+                "seconds": 0.9998760223388672,
+                "bytes": 3461611520,
+                "bits_per_second": 27696325885.70528,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000079,
+                  "end": 3.000169,
+                  "seconds": 1.0000900030136108,
+                  "bytes": 3432745096,
+                  "bits_per_second": 27459489331.207977,
+                  "retransmits": 0,
+                  "snd_cwnd": 599860,
+                  "rtt": 31,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000079,
+                "end": 3.000169,
+                "seconds": 1.0000900030136108,
+                "bytes": 3432745096,
+                "bits_per_second": 27459489331.207977,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000169,
+                  "end": 4.000043,
+                  "seconds": 0.9998739957809448,
+                  "bytes": 3490447360,
+                  "bits_per_second": 27927097812.1503,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 31,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000169,
+                "end": 4.000043,
+                "seconds": 0.9998739957809448,
+                "bytes": 3490447360,
+                "bits_per_second": 27927097812.1503,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000043,
+                  "end": 5.000105,
+                  "seconds": 1.0000619888305664,
+                  "bytes": 3575644160,
+                  "bits_per_second": 28603380189.91178,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000043,
+                "end": 5.000105,
+                "seconds": 1.0000619888305664,
+                "bytes": 3575644160,
+                "bits_per_second": 28603380189.91178,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000105,
+                  "end": 6.000004,
+                  "seconds": 0.9998990297317505,
+                  "bytes": 3565158400,
+                  "bits_per_second": 28524147290.80354,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000105,
+                "end": 6.000004,
+                "seconds": 0.9998990297317505,
+                "bytes": 3565158400,
+                "bits_per_second": 28524147290.80354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000302,
+                  "seconds": 1.000298023223877,
+                  "bytes": 3586129920,
+                  "bits_per_second": 28680491907.339397,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000302,
+                "seconds": 1.000298023223877,
+                "bytes": 3586129920,
+                "bits_per_second": 28680491907.339397,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000302,
+                  "end": 8.000114,
+                  "seconds": 0.9998120069503784,
+                  "bytes": 3579576320,
+                  "bits_per_second": 28641995055.99782,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000302,
+                "end": 8.000114,
+                "seconds": 0.9998120069503784,
+                "bytes": 3579576320,
+                "bits_per_second": 28641995055.99782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000114,
+                  "end": 9.000032,
+                  "seconds": 0.9999179840087891,
+                  "bytes": 3584819200,
+                  "bits_per_second": 28680905892.925636,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000114,
+                "end": 9.000032,
+                "seconds": 0.9999179840087891,
+                "bytes": 3584819200,
+                "bits_per_second": 28680905892.925636,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000166,
+                  "seconds": 1.000133991241455,
+                  "bytes": 3587440640,
+                  "bits_per_second": 28695680150.192276,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000166,
+                "seconds": 1.000133991241455,
+                "bytes": 3587440640,
+                "bits_per_second": 28695680150.192276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000166,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28272260901.26904,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 769708,
+                  "max_rtt": 33,
+                  "min_rtt": 31,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040211,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28159498063.138317,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000166,
+              "seconds": 10.000166,
+              "bytes": 35340912776,
+              "bits_per_second": 28272260901.26904,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040211,
+              "seconds": 10.040211,
+              "bytes": 35340912776,
+              "bits_per_second": 28159498063.138317,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.19888011381254,
+              "host_user": 0.5898692408770353,
+              "host_system": 97.6090108729355,
+              "remote_total": 71.89727658532618,
+              "remote_user": 1.9320023444980647,
+              "remote_system": 69.96528325535468
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37670,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:48 UTC",
+              "timesecs": 1711485408
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000002,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 3779153100,
+                  "bits_per_second": 30233163530.742928,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000002,
+                "seconds": 1.0000020265579224,
+                "bytes": 3779153100,
+                "bits_per_second": 30233163530.742928,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000002,
+                  "end": 2.000029,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30331340786.265507,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000002,
+                "end": 2.000029,
+                "seconds": 1.0000269412994385,
+                "bytes": 3791519744,
+                "bits_per_second": 30331340786.265507,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000029,
+                  "end": 3.000014,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30332613559.093388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000029,
+                "end": 3.000014,
+                "seconds": 0.9999849796295166,
+                "bytes": 3791519744,
+                "bits_per_second": 30332613559.093388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000014,
+                  "end": 4.000004,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 3793747968,
+                  "bits_per_second": 30350287659.043278,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000014,
+                "end": 4.000004,
+                "seconds": 0.9999899864196777,
+                "bytes": 3793747968,
+                "bits_per_second": 30350287659.043278,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000004,
+                  "end": 5.000013,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 3797024768,
+                  "bits_per_second": 30375926562.05313,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000004,
+                "end": 5.000013,
+                "seconds": 1.0000089406967163,
+                "bytes": 3797024768,
+                "bits_per_second": 30375926562.05313,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000018,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 3796106948,
+                  "bits_per_second": 30368703534.273937,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000018,
+                "seconds": 1.0000050067901611,
+                "bytes": 3796106948,
+                "bits_per_second": 30368703534.273937,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 3778281788,
+                  "bits_per_second": 30226526351.846264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 3778281788,
+                "bits_per_second": 30226526351.846264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000013,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3812884480,
+                  "bits_per_second": 30502952208.001095,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000013,
+                "seconds": 1.0000040531158447,
+                "bytes": 3812884480,
+                "bits_per_second": 30502952208.001095,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000013,
+                  "end": 9.000017,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3806855168,
+                  "bits_per_second": 30454717907.5003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000013,
+                "end": 9.000017,
+                "seconds": 1.0000040531158447,
+                "bytes": 3806855168,
+                "bits_per_second": 30454717907.5003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000017,
+                  "end": 10.000014,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3791650816,
+                  "bits_per_second": 30333296928.269413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000017,
+                "end": 10.000014,
+                "seconds": 0.9999970197677612,
+                "bytes": 3791650816,
+                "bits_per_second": 30333296928.269413,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040168,
+                  "seconds": 10.040168,
+                  "bytes": 37939793100,
+                  "bits_per_second": 30230404989.239223,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000014,
+                  "seconds": 10.000014,
+                  "bytes": 37938744524,
+                  "bits_per_second": 30350953127.86562,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040168,
+              "seconds": 10.040168,
+              "bytes": 37939793100,
+              "bits_per_second": 30230404989.239223,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000014,
+              "seconds": 10.000014,
+              "bytes": 37938744524,
+              "bits_per_second": 30350953127.86562,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 89.35457193175537,
+              "host_user": 2.1531064410889655,
+              "host_system": 87.20146549066642,
+              "remote_total": 96.25175156651449,
+              "remote_user": 0.5483803525296743,
+              "remote_system": 95.70338087979988
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39876,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:05 UTC",
+              "timesecs": 1711485425
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000173,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2929832972,
+                  "bits_per_second": 23434610228.684185,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1011,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000173,
+                "seconds": 1.0001729726791382,
+                "bytes": 2929832972,
+                "bits_per_second": 23434610228.684185,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000173,
+                  "end": 2.000056,
+                  "seconds": 0.9998829960823059,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23417442012.457832,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1030,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000173,
+                "end": 2.000056,
+                "seconds": 0.9998829960823059,
+                "bytes": 2926837760,
+                "bits_per_second": 23417442012.457832,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000045,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393988522.219513,
+                  "retransmits": 1071,
+                  "snd_cwnd": 2109620,
+                  "rtt": 718,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000045,
+                "seconds": 0.9999889731407166,
+                "bytes": 2924216320,
+                "bits_per_second": 23393988522.219513,
+                "retransmits": 1071,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000045,
+                  "end": 4.000057,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414420167.144268,
+                  "retransmits": 0,
+                  "snd_cwnd": 2934596,
+                  "rtt": 882,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000045,
+                "end": 4.000057,
+                "seconds": 1.0000120401382446,
+                "bytes": 2926837760,
+                "bits_per_second": 23414420167.144268,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000134,
+                  "seconds": 1.0000770092010498,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23402414118.786076,
+                  "retransmits": 680,
+                  "snd_cwnd": 2067832,
+                  "rtt": 699,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000134,
+                "seconds": 1.0000770092010498,
+                "bytes": 2925527040,
+                "bits_per_second": 23402414118.786076,
+                "retransmits": 680,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000134,
+                  "end": 6.000072,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23405667209.938972,
+                  "retransmits": 576,
+                  "snd_cwnd": 2143320,
+                  "rtt": 731,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000134,
+                "end": 6.000072,
+                "seconds": 0.9999380111694336,
+                "bytes": 2925527040,
+                "bits_per_second": 23405667209.938972,
+                "retransmits": 576,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000072,
+                  "end": 7.000057,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23415053782.782707,
+                  "retransmits": 0,
+                  "snd_cwnd": 2985820,
+                  "rtt": 1004,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000072,
+                "end": 7.000057,
+                "seconds": 0.9999849796295166,
+                "bytes": 2926837760,
+                "bits_per_second": 23415053782.782707,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000151,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422984764.712734,
+                  "retransmits": 0,
+                  "snd_cwnd": 3150276,
+                  "rtt": 1131,
+                  "rttvar": 47,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000151,
+                "seconds": 1.0000940561294556,
+                "bytes": 2928148480,
+                "bits_per_second": 23422984764.712734,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000151,
+                  "end": 9.00006,
+                  "seconds": 0.999908983707428,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416833393.35924,
+                  "retransmits": 536,
+                  "snd_cwnd": 2446620,
+                  "rtt": 816,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000151,
+                "end": 9.00006,
+                "seconds": 0.999908983707428,
+                "bytes": 2926837760,
+                "bits_per_second": 23416833393.35924,
+                "retransmits": 536,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00006,
+                  "end": 10.000062,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425140367.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 3163756,
+                  "rtt": 1040,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.00006,
+                "end": 10.000062,
+                "seconds": 1.0000020265579224,
+                "bytes": 2928148480,
+                "bits_per_second": 23425140367.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 29268751372,
+                  "bits_per_second": 23414855925.493263,
+                  "retransmits": 2863,
+                  "max_snd_cwnd": 3301252,
+                  "max_rtt": 1131,
+                  "min_rtt": 699,
+                  "mean_rtt": 906,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040299,
+                  "seconds": 10.000062,
+                  "bytes": 29268042576,
+                  "bits_per_second": 23320454959.35928,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 29268751372,
+              "bits_per_second": 23414855925.493263,
+              "retransmits": 2863,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040299,
+              "seconds": 10.040299,
+              "bytes": 29268042576,
+              "bits_per_second": 23320454959.35928,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 36.61979232353807,
+              "host_user": 0.5177138138716962,
+              "host_system": 36.10208842470637,
+              "remote_total": 63.645622998347704,
+              "remote_user": 2.779808989119691,
+              "remote_system": 60.86582297594884
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 49506,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:17 UTC",
+              "timesecs": 1711485437
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00003,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 2928081096,
+                  "bits_per_second": 23423945095.33297,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00003,
+                "seconds": 1.0000300407409668,
+                "bytes": 2928081096,
+                "bits_per_second": 23423945095.33297,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00003,
+                  "end": 2.00001,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2924874236,
+                  "bits_per_second": 23399462512.79474,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00003,
+                "end": 2.00001,
+                "seconds": 0.9999799728393555,
+                "bytes": 2924874236,
+                "bits_per_second": 23399462512.79474,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 2928934064,
+                  "bits_per_second": 23431098222.587284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 2928934064,
+                "bits_per_second": 23431098222.587284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2927109320,
+                  "bits_per_second": 23417343542.901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 2927109320,
+                "bits_per_second": 23417343542.901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000006,
+                  "end": 5.000015,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 2928650940,
+                  "bits_per_second": 23428998048.434082,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000006,
+                "end": 5.000015,
+                "seconds": 1.0000089406967163,
+                "bytes": 2928650940,
+                "bits_per_second": 23428998048.434082,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000015,
+                  "end": 6.00002,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2928599620,
+                  "bits_per_second": 23428679657.517204,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000015,
+                "end": 6.00002,
+                "seconds": 1.0000050067901611,
+                "bytes": 2928599620,
+                "bits_per_second": 23428679657.517204,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000018,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2903162060,
+                  "bits_per_second": 23225343547.503967,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000018,
+                "seconds": 0.9999979734420776,
+                "bytes": 2903162060,
+                "bits_per_second": 23225343547.503967,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000018,
+                  "end": 8.000028,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 2520932544,
+                  "bits_per_second": 20167258405.538074,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000018,
+                "end": 8.000028,
+                "seconds": 1.0000100135803223,
+                "bytes": 2520932544,
+                "bits_per_second": 20167258405.538074,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000028,
+                  "end": 9.000012,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2699663148,
+                  "bits_per_second": 21597650185.83164,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000028,
+                "end": 9.000012,
+                "seconds": 0.9999840259552002,
+                "bytes": 2699663148,
+                "bits_per_second": 21597650185.83164,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000012,
+                  "end": 10.000011,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927449024,
+                  "bits_per_second": 23419615922.60409,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000012,
+                "end": 10.000011,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927449024,
+                "bits_per_second": 23419615922.60409,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039579,
+                  "seconds": 10.039579,
+                  "bytes": 28621053072,
+                  "bits_per_second": 22806576309.225716,
+                  "retransmits": 2146,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000011,
+                  "seconds": 10.000011,
+                  "bytes": 28617456052,
+                  "bits_per_second": 22893939658.266373,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039579,
+              "seconds": 10.039579,
+              "bytes": 28621053072,
+              "bits_per_second": 22806576309.225716,
+              "retransmits": 2146,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000011,
+              "seconds": 10.000011,
+              "bytes": 28617456052,
+              "bits_per_second": 22893939658.266373,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.71637462053445,
+              "host_user": 2.3097157068484533,
+              "host_system": 84.40665891368599,
+              "remote_total": 20.40828750936386,
+              "remote_user": 0.3775983988088474,
+              "remote_system": 20.030689110555013
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 38034,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:34 UTC",
+              "timesecs": 1711485454
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1174382536,
+                  "bits_per_second": 9394514890.15193,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2566,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1174382536,
+                "bits_per_second": 9394514890.15193,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000058,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2504,
+                  "rttvar": 111,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000058,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374766195.07232,
+                  "retransmits": 13,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2578,
+                  "rttvar": 100,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1171783680,
+                "bits_per_second": 9374766195.07232,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.000059,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373763239.835724,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2548,
+                  "rttvar": 49,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.000059,
+                "seconds": 1.0000540018081665,
+                "bytes": 1171783680,
+                "bits_per_second": 9373763239.835724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000059,
+                  "end": 5.000059,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2544,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000059,
+                "end": 5.000059,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000092,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373959902.721222,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2626,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000092,
+                "seconds": 1.0000330209732056,
+                "bytes": 1171783680,
+                "bits_per_second": 9373959902.721222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000092,
+                  "end": 7.000102,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374175570.939966,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2637,
+                  "rttvar": 87,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000092,
+                "end": 7.000102,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171783680,
+                "bits_per_second": 9374175570.939966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000102,
+                  "end": 8.000204,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373312957.602478,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2584,
+                  "rttvar": 65,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000102,
+                "end": 8.000204,
+                "seconds": 1.0001020431518555,
+                "bytes": 1171783680,
+                "bits_per_second": 9373312957.602478,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000204,
+                  "end": 9.000059,
+                  "seconds": 0.9998549818992615,
+                  "bytes": 1170472960,
+                  "bits_per_second": 9365141795.07627,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2646,
+                  "rttvar": 50,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000204,
+                "end": 9.000059,
+                "seconds": 0.9998549818992615,
+                "bytes": 1170472960,
+                "bits_per_second": 9365141795.07627,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000059,
+                  "end": 10.000063,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374231445.153997,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2624,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000059,
+                "end": 10.000063,
+                "seconds": 1.0000040531158447,
+                "bytes": 1171783680,
+                "bits_per_second": 9374231445.153997,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9375240884.782425,
+                  "retransmits": 13,
+                  "max_snd_cwnd": 3298556,
+                  "max_rtt": 2646,
+                  "min_rtt": 2504,
+                  "mean_rtt": 2585,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042436,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9335683044.23349,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 11719124936,
+              "bits_per_second": 9375240884.782425,
+              "retransmits": 13,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042436,
+              "seconds": 10.042436,
+              "bytes": 11719124936,
+              "bits_per_second": 9335683044.23349,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 8.581878883067088,
+              "host_user": 0.24757613109832505,
+              "host_system": 8.334302751968762,
+              "remote_total": 17.882794832888134,
+              "remote_user": 0.6213889785332932,
+              "remote_system": 17.261397456752558
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 59786,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:44 UTC",
+              "timesecs": 1711485464
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00001,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171526660,
+                  "bits_per_second": 9372119431.529282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00001,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171526660,
+                "bits_per_second": 9372119431.529282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00001,
+                  "end": 2.00001,
+                  "seconds": 1,
+                  "bytes": 1171728636,
+                  "bits_per_second": 9373829088,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00001,
+                "end": 2.00001,
+                "seconds": 1,
+                "bytes": 1171728636,
+                "bits_per_second": 9373829088,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171634728,
+                  "bits_per_second": 9372928100.426619,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171634728,
+                "bits_per_second": 9372928100.426619,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000003,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1171698712,
+                  "bits_per_second": 9373805362.822794,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000003,
+                "seconds": 0.9999769926071167,
+                "bytes": 1171698712,
+                "bits_per_second": 9373805362.822794,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000003,
+                  "end": 5.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171728612,
+                  "bits_per_second": 9373679160.429152,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000003,
+                "end": 5.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171728612,
+                "bits_per_second": 9373679160.429152,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000019,
+                  "end": 6.000033,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1171430044,
+                  "bits_per_second": 9371309645.78169,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000019,
+                "end": 6.000033,
+                "seconds": 1.0000139474868774,
+                "bytes": 1171430044,
+                "bits_per_second": 9371309645.78169,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000033,
+                  "end": 7.000019,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171711552,
+                  "bits_per_second": 9373823716.006702,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000033,
+                "end": 7.000019,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171711552,
+                "bits_per_second": 9373823716.006702,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.000005,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171704164,
+                  "bits_per_second": 9373764611.178816,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.000005,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171704164,
+                "bits_per_second": 9373764611.178816,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000005,
+                  "end": 9.000005,
+                  "seconds": 1,
+                  "bytes": 1171264340,
+                  "bits_per_second": 9370114720,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000005,
+                "end": 9.000005,
+                "seconds": 1,
+                "bytes": 1171264340,
+                "bits_per_second": 9370114720,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000005,
+                  "end": 10.000025,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 1171724928,
+                  "bits_per_second": 9373611697.172722,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000005,
+                "end": 10.000025,
+                "seconds": 1.0000200271606445,
+                "bytes": 1171724928,
+                "bits_per_second": 9373611697.172722,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040362,
+                  "seconds": 10.040362,
+                  "bytes": 11719168912,
+                  "bits_per_second": 9337646520.713099,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000025,
+                  "seconds": 10.000025,
+                  "bytes": 11716152376,
+                  "bits_per_second": 9372898468.553827,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040362,
+              "seconds": 10.040362,
+              "bytes": 11719168912,
+              "bits_per_second": 9337646520.713099,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000025,
+              "seconds": 10.000025,
+              "bytes": 11716152376,
+              "bits_per_second": 9372898468.553827,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.12079215423493,
+              "host_user": 1.449299942928998,
+              "host_system": 32.671502129797744,
+              "remote_total": 9.21759648553234,
+              "remote_user": 0.13056616222089867,
+              "remote_system": 9.087020816528113
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 42748,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:01 UTC",
+              "timesecs": 1711485481
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000059,
+                  "seconds": 1.0000590085983276,
+                  "bytes": 1180082728,
+                  "bits_per_second": 9440104776.649063,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2528,
+                  "rttvar": 68,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000059,
+                "seconds": 1.0000590085983276,
+                "bytes": 1180082728,
+                "bits_per_second": 9440104776.649063,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000059,
+                  "end": 2.000103,
+                  "seconds": 1.0000439882278442,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9415798295.719233,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2635,
+                  "rttvar": 38,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000059,
+                "end": 2.000103,
+                "seconds": 1.0000439882278442,
+                "bytes": 1177026560,
+                "bits_per_second": 9415798295.719233,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000103,
+                  "end": 3.000059,
+                  "seconds": 0.9999560117721558,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9406140479.450544,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2580,
+                  "rttvar": 45,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000103,
+                "end": 3.000059,
+                "seconds": 0.9999560117721558,
+                "bytes": 1175715840,
+                "bits_per_second": 9406140479.450544,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2614,
+                  "rttvar": 61,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000059,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416203500.008564,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2540,
+                  "rttvar": 36,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000059,
+                "seconds": 1.0000009536743164,
+                "bytes": 1177026560,
+                "bits_per_second": 9416203500.008564,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2532,
+                  "rttvar": 66,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416193397.538671,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2621,
+                  "rttvar": 26,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 1177026560,
+                "bits_per_second": 9416193397.538671,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.00006,
+                  "end": 8.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9405745781.28863,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2647,
+                  "rttvar": 79,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.00006,
+                "end": 8.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 1175715840,
+                "bits_per_second": 9405745781.28863,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416212480,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2616,
+                  "rttvar": 57,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1177026560,
+                "bits_per_second": 9416212480,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000062,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416174315.154686,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2608,
+                  "rttvar": 75,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000062,
+                "seconds": 1.0000040531158447,
+                "bytes": 1177026560,
+                "bits_per_second": 9416174315.154686,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 11770700328,
+                  "bits_per_second": 9416501880.088345,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 3302888,
+                  "max_rtt": 2647,
+                  "min_rtt": 2528,
+                  "mean_rtt": 2592,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042832,
+                  "seconds": 10.000062,
+                  "bytes": 11770469264,
+                  "bits_per_second": 9376215206.228682,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 11770700328,
+              "bits_per_second": 9416501880.088345,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042832,
+              "seconds": 10.042832,
+              "bytes": 11770469264,
+              "bits_per_second": 9376215206.228682,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 9.991931328513951,
+              "host_user": 0.30260245650629003,
+              "host_system": 9.689348708938175,
+              "remote_total": 19.41962833866342,
+              "remote_user": 0.6099473016485951,
+              "remote_system": 18.809681037014826
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 58986,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:11 UTC",
+              "timesecs": 1711485491
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1176615352,
+                  "bits_per_second": 9412866710.942337,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1176615352,
+                "bits_per_second": 9412866710.942337,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000016,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1176524120,
+                  "bits_per_second": 9412098711.193554,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000016,
+                "seconds": 1.0000100135803223,
+                "bytes": 1176524120,
+                "bits_per_second": 9412098711.193554,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000009,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1176810760,
+                  "bits_per_second": 9414551734.668388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000009,
+                "seconds": 0.9999930262565613,
+                "bytes": 1176810760,
+                "bits_per_second": 9414551734.668388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000007,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1176810048,
+                  "bits_per_second": 9414499463.028471,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000007,
+                "seconds": 0.9999979734420776,
+                "bytes": 1176810048,
+                "bits_per_second": 9414499463.028471,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000007,
+                  "end": 5.000007,
+                  "seconds": 1,
+                  "bytes": 1176803976,
+                  "bits_per_second": 9414431808,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000007,
+                "end": 5.000007,
+                "seconds": 1,
+                "bytes": 1176803976,
+                "bits_per_second": 9414431808,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000007,
+                  "end": 6.000009,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1176724064,
+                  "bits_per_second": 9413773434.442867,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000007,
+                "end": 6.000009,
+                "seconds": 1.0000020265579224,
+                "bytes": 1176724064,
+                "bits_per_second": 9413773434.442867,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000009,
+                  "end": 7.000003,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1176792016,
+                  "bits_per_second": 9414392803.29542,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000009,
+                "end": 7.000003,
+                "seconds": 0.9999939799308777,
+                "bytes": 1176792016,
+                "bits_per_second": 9414392803.29542,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000003,
+                  "end": 8.000015,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 1176820328,
+                  "bits_per_second": 9414449272.72926,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000003,
+                "end": 8.000015,
+                "seconds": 1.0000120401382446,
+                "bytes": 1176820328,
+                "bits_per_second": 9414449272.72926,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000011,
+                  "seconds": 0.9999960064888,
+                  "bytes": 1176491696,
+                  "bits_per_second": 9411971154.81222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000011,
+                "seconds": 0.9999960064888,
+                "bytes": 1176491696,
+                "bits_per_second": 9411971154.81222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000011,
+                  "end": 10.000015,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1176819760,
+                  "bits_per_second": 9414519921.860134,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000011,
+                "end": 10.000015,
+                "seconds": 1.0000040531158447,
+                "bytes": 1176819760,
+                "bits_per_second": 9414519921.860134,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040305,
+                  "seconds": 10.040305,
+                  "bytes": 11770238744,
+                  "bits_per_second": 9378391388.707813,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000015,
+                  "seconds": 10.000015,
+                  "bytes": 11767212120,
+                  "bits_per_second": 9413755575.366638,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040305,
+              "seconds": 10.040305,
+              "bytes": 11770238744,
+              "bits_per_second": 9378391388.707813,
+              "retransmits": 0,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000015,
+              "seconds": 10.000015,
+              "bytes": 11767212120,
+              "bits_per_second": 9413755575.366638,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 48.724054060084946,
+              "host_user": 3.9110899538590087,
+              "host_system": 44.81297402368786,
+              "remote_total": 7.595950273368541,
+              "remote_user": 0.15972436790366432,
+              "remote_system": 7.436225905464877
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    }
+  ]
+}

--- a/tests/input4.json
+++ b/tests/input4.json
@@ -1,1 +1,15204 @@
-{"tft-tests": [{"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "invalid_pod_type", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 56762, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:32 UTC", "timesecs": 1711484912}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "snd_cwnd": 477192, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000191, "seconds": 1.0001909732818604, "bytes": 4895539200, "bits_per_second": 39156835690.5809, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "snd_cwnd": 477192, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000191, "end": 2.000081, "seconds": 0.9998900294303894, "bytes": 4911267840, "bits_per_second": 39294463954.583626, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "snd_cwnd": 477192, "rtt": 27, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000081, "end": 3.000218, "seconds": 1.0001369714736938, "bytes": 4848353280, "bits_per_second": 38781514278.83715, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "snd_cwnd": 502804, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000218, "end": 4.000267, "seconds": 1.0000489950180054, "bytes": 4840488960, "bits_per_second": 38722014494.20265, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "snd_cwnd": 528416, "rtt": 29, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000247, "seconds": 0.9999799728393555, "bytes": 4881121280, "bits_per_second": 39049752295.66235, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "snd_cwnd": 528416, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000247, "end": 6.00002, "seconds": 0.9997730255126953, "bytes": 4856217600, "bits_per_second": 38858560701.89271, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "snd_cwnd": 528416, "rtt": 30, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00002, "end": 7.000117, "seconds": 1.0000970363616943, "bytes": 4853596160, "bits_per_second": 38825001843.07837, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "snd_cwnd": 591772, "rtt": 26, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000117, "end": 8.000116, "seconds": 0.9999989867210388, "bytes": 4864081920, "bits_per_second": 38912694789.414955, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "snd_cwnd": 621428, "rtt": 27, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000116, "end": 9.000019, "seconds": 0.9999030232429504, "bytes": 4836556800, "bits_per_second": 38696207032.668144, "retransmits": 99, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "snd_cwnd": 621428, "rtt": 25, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000019, "end": 10.000269, "seconds": 1.000249981880188, "bytes": 4773642240, "bits_per_second": 38179593713.378716, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "max_snd_cwnd": 621428, "max_rtt": 30, "min_rtt": 25, "mean_rtt": 26, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040752, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000269, "seconds": 10.000269, "bytes": 48560865280, "bits_per_second": 38847647222.28973, "retransmits": 99, "sender": true}, "sum_received": {"start": 0, "end": 10.040752, "seconds": 10.040752, "bytes": 48560865280, "bits_per_second": 38691018585.06216, "sender": true}, "cpu_utilization_percent": {"host_total": 51.95896032207571, "host_user": 0.46109579260875955, "host_system": 51.4978546106554, "remote_total": 46.34560190202221, "remote_user": 1.2743335369337774, "remote_system": 45.07127657478376}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.180", "local_port": 54270, "remote_host": "10.131.1.179", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:28:43 UTC", "timesecs": 1711484923}, "connecting_to": {"host": "10.131.1.179", "port": 5201}, "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000023, "seconds": 1.0000230073928833, "bytes": 5267935560, "bits_per_second": 42142514890.60282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}], "sum": {"start": 1.000023, "end": 2.000011, "seconds": 0.9999880194664001, "bytes": 5283380932, "bits_per_second": 42267553843.84901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}], "sum": {"start": 2.000011, "end": 3.000025, "seconds": 1.0000139474868774, "bytes": 5144593776, "bits_per_second": 41156176182.772766, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}], "sum": {"start": 3.000025, "end": 4.000023, "seconds": 0.9999979734420776, "bytes": 5313921024, "bits_per_second": 42511454343.92459, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.000026, "seconds": 1.0000029802322388, "bytes": 5324144640, "bits_per_second": 42593030182.8783, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}], "sum": {"start": 5.000026, "end": 6.000006, "seconds": 0.9999799728393555, "bytes": 5340397568, "bits_per_second": 42724036185.13606, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}], "sum": {"start": 6.000006, "end": 7.000013, "seconds": 1.0000070333480835, "bytes": 5317722112, "bits_per_second": 42541477686.97944, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}], "sum": {"start": 7.000013, "end": 8.000023, "seconds": 1.0000100135803223, "bytes": 5339086848, "bits_per_second": 42712267081.28284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}], "sum": {"start": 8.000023, "end": 9.000043, "seconds": 1.0000200271606445, "bytes": 5329256448, "bits_per_second": 42633197762.099625, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}], "sum": {"start": 9.000043, "end": 10.000027, "seconds": 0.9999840259552002, "bytes": 5294784512, "bits_per_second": 42358952739.80874, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040745, "seconds": 10.040745, "bytes": 52956665212, "bits_per_second": 42193415099.77596, "retransmits": 220, "sender": false}, "sum_received": {"start": 0, "end": 10.000027, "seconds": 10.000027, "bytes": 52955223420, "bits_per_second": 42364064353.02625, "sender": false}, "cpu_utilization_percent": {"host_total": 59.961165048543684, "host_user": 1.7074681645153693, "host_system": 58.25370680355615, "remote_total": 54.92808068462117, "remote_user": 0.35009864909523675, "remote_system": 54.57798203552594}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 43488, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:03 UTC", "timesecs": 1711484943}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "snd_cwnd": 858676, "rtt": 477, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1552629896, "bits_per_second": 12420331432.172485, "retransmits": 1162, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "snd_cwnd": 864068, "rtt": 582, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000057, "seconds": 1, "bytes": 1785895104, "bits_per_second": 14287160832, "retransmits": 250, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "snd_cwnd": 897768, "rtt": 469, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000058, "seconds": 1.0000009536743164, "bytes": 1781226624, "bits_per_second": 14249799402.332296, "retransmits": 41, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "snd_cwnd": 843848, "rtt": 459, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000058, "end": 4.000033, "seconds": 0.9999750256538391, "bytes": 1770754368, "bits_per_second": 14166388740.29625, "retransmits": 43, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "snd_cwnd": 931468, "rtt": 278, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000033, "end": 5.00012, "seconds": 1.000087022781372, "bytes": 1756157248, "bits_per_second": 14048035484.879292, "retransmits": 508, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "snd_cwnd": 773752, "rtt": 389, "rttvar": 21, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.00012, "end": 6.000058, "seconds": 0.9999380111694336, "bytes": 1776470548, "bits_per_second": 14212645409.268175, "retransmits": 774, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "snd_cwnd": 706352, "rtt": 351, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000214, "seconds": 1.000156044960022, "bytes": 1780520960, "bits_per_second": 14241945296.215616, "retransmits": 107, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "snd_cwnd": 957080, "rtt": 494, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000214, "end": 8.000165, "seconds": 0.9999510049819946, "bytes": 1782724608, "bits_per_second": 14262495655.23143, "retransmits": 103, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "snd_cwnd": 668608, "rtt": 406, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000165, "end": 9.000061, "seconds": 0.9998959898948669, "bytes": 1708298368, "bits_per_second": 13667808534.202581, "retransmits": 636, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "snd_cwnd": 835760, "rtt": 417, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000061, "end": 10.000067, "seconds": 1.0000059604644775, "bytes": 1711744320, "bits_per_second": 13693872938.156792, "retransmits": 37, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "max_snd_cwnd": 957080, "max_rtt": 582, "min_rtt": 278, "mean_rtt": 432, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040323, "seconds": 10.000067, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 17406422044, "bits_per_second": 13925044337.40294, "retransmits": 3661, "sender": true}, "sum_received": {"start": 0, "end": 10.040323, "seconds": 10.040323, "bytes": 17404804444, "bits_per_second": 13867923925.554983, "sender": true}, "cpu_utilization_percent": {"host_total": 13.428581942246796, "host_user": 0.18264039451277397, "host_system": 13.245951466295686, "remote_total": 23.0189867907264, "remote_user": 0.650631880001117, "remote_system": 22.368346697024506}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.181", "local_port": 52702, "remote_host": "10.129.2.18", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:14 UTC", "timesecs": 1711484954}, "connecting_to": {"host": "10.129.2.18", "port": 5201}, "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 1769360536, "bits_per_second": 14154529944.193699, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000056, "seconds": 1.0000309944152832, "bytes": 1654294820, "bits_per_second": 13233948381.508026, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}], "sum": {"start": 2.000056, "end": 3.000002, "seconds": 0.9999459981918335, "bytes": 1693522048, "bits_per_second": 13548908049.533356, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}], "sum": {"start": 3.000002, "end": 4.000058, "seconds": 1.0000560283660889, "bytes": 1778357520, "bits_per_second": 14226063096.928802, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}], "sum": {"start": 4.000058, "end": 5.000058, "seconds": 1, "bytes": 1699132892, "bits_per_second": 13593063136, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}], "sum": {"start": 5.000058, "end": 6.000005, "seconds": 0.9999470114707947, "bytes": 1776734848, "bits_per_second": 14214631996.442686, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}], "sum": {"start": 6.000005, "end": 7.000019, "seconds": 1.0000139474868774, "bytes": 1770689664, "bits_per_second": 14165319741.388792, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.00003, "seconds": 1.0000109672546387, "bytes": 1596714580, "bits_per_second": 12773576548.933342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000056, "seconds": 1.000025987625122, "bytes": 1650146112, "bits_per_second": 13200825837.886824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}], "sum": {"start": 9.000056, "end": 10.00005, "seconds": 0.9999939799308777, "bytes": 1544969596, "bits_per_second": 12359831175.038013, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039981, "seconds": 10.039981, "bytes": 16936819512, "bits_per_second": 13495499254.032454, "retransmits": 2334, "sender": false}, "sum_received": {"start": 0, "end": 10.00005, "seconds": 10.00005, "bytes": 16933922616, "bits_per_second": 13547070357.448214, "sender": false}, "cpu_utilization_percent": {"host_total": 27.136162389258295, "host_user": 1.0734065668100488, "host_system": 26.062755822448246, "remote_total": 12.134681085322041, "remote_user": 0.20150770671204546, "remote_system": 11.933173378609997}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 37248, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:34 UTC", "timesecs": 1711484974}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "snd_cwnd": 477192, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000223, "seconds": 1.0002230405807495, "bytes": 4827381760, "bits_per_second": 38610442384.50756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000223, "end": 2.000162, "seconds": 0.9999390244483948, "bytes": 4849664000, "bits_per_second": 38799677831.7579, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000162, "end": 3.000191, "seconds": 1.0000289678573608, "bytes": 4826247500, "bits_per_second": 38608861584.00477, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "snd_cwnd": 1035264, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000191, "end": 4.00012, "seconds": 0.9999290108680725, "bytes": 4861460480, "bits_per_second": 38894444922.881874, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.00012, "end": 5.000266, "seconds": 1.0001460313796997, "bytes": 4811653120, "bits_per_second": 38487604562.00447, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000266, "end": 6.000154, "seconds": 0.999888002872467, "bytes": 4818206720, "bits_per_second": 38549971246.046036, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000154, "end": 7.000089, "seconds": 0.99993497133255, "bytes": 4853596160, "bits_per_second": 38831294427.33196, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000089, "end": 8.000143, "seconds": 1.0000540018081665, "bytes": 4870635520, "bits_per_second": 38962980088.62366, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000143, "end": 9.000159, "seconds": 1.0000159740447998, "bytes": 4849664000, "bits_per_second": 38796692259.89976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "snd_cwnd": 1412704, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000159, "end": 10.000248, "seconds": 1.0000890493392944, "bytes": 4823449600, "bits_per_second": 38584160905.964096, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "max_snd_cwnd": 1412704, "max_rtt": 24, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040463, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000248, "seconds": 10.000248, "bytes": 48391958860, "bits_per_second": 38712607015.34602, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040463, "seconds": 10.040463, "bytes": 48391958860, "bits_per_second": 38557551666.69106, "sender": true}, "cpu_utilization_percent": {"host_total": 51.42879332323217, "host_user": 0.48554830964161494, "host_system": 50.94323509492755, "remote_total": 45.16438235241609, "remote_user": 1.4607549345618025, "remote_system": 43.703627417854285}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.183", "local_port": 42348, "remote_host": "172.30.76.3", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:29:45 UTC", "timesecs": 1711484985}, "connecting_to": {"host": "172.30.76.3", "port": 5201}, "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 5317084948, "bits_per_second": 42536086312.49434, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000016, "seconds": 1.0000020265579224, "bytes": 5316804608, "bits_per_second": 42534350665.67468, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000013, "seconds": 0.9999970197677612, "bytes": 5298323456, "bits_per_second": 42386713970.25147, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}], "sum": {"start": 3.000013, "end": 4.000027, "seconds": 1.0000139474868774, "bytes": 5347213312, "bits_per_second": 42777109862.82153, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}], "sum": {"start": 4.000027, "end": 5.000006, "seconds": 0.9999790191650391, "bytes": 5329387520, "bits_per_second": 42635994698.76817, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}], "sum": {"start": 5.000006, "end": 6.000018, "seconds": 1.0000120401382446, "bytes": 5332271104, "bits_per_second": 42657655227.93386, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000031, "seconds": 1.000012993812561, "bytes": 5274468352, "bits_per_second": 42195198539.4992, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}], "sum": {"start": 7.000031, "end": 8.000009, "seconds": 0.9999780058860779, "bytes": 5300420608, "bits_per_second": 42404297508.9502, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}], "sum": {"start": 8.000009, "end": 9.000029, "seconds": 1.0000200271606445, "bytes": 5310644224, "bits_per_second": 42484302952.03991, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000028, "seconds": 0.9999989867210388, "bytes": 5294129152, "bits_per_second": 42353076131.48099, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040317, "seconds": 10.040317, "bytes": 53121271572, "bits_per_second": 42326370031.54382, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 53120747284, "bits_per_second": 42496478837.05926, "sender": false}, "cpu_utilization_percent": {"host_total": 58.9131700562321, "host_user": 1.8313076617106898, "host_system": 57.08186239452141, "remote_total": 54.91579537328721, "remote_user": 0.4710685503353111, "remote_system": 54.44472682295189}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 45258, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:05 UTC", "timesecs": 1711485005}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "snd_cwnd": 958428, "rtt": 667, "rttvar": 176, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1756790944, "bits_per_second": 14053511676.447533, "retransmits": 563, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "snd_cwnd": 913944, "rtt": 617, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000057, "seconds": 0.9999989867210388, "bytes": 1762679616, "bits_per_second": 14101451216.70384, "retransmits": 117, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "snd_cwnd": 698264, "rtt": 354, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000057, "end": 3.000057, "seconds": 1, "bytes": 1743596572, "bits_per_second": 13948772576, "retransmits": 76, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "snd_cwnd": 789928, "rtt": 504, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1585909824, "bits_per_second": 12687278592, "retransmits": 93, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "snd_cwnd": 698264, "rtt": 352, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1719381848, "bits_per_second": 13755041666.170042, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "snd_cwnd": 947644, "rtt": 487, "rttvar": 19, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.00008, "seconds": 1.000022053718567, "bytes": 1698620928, "bits_per_second": 13588667743.34589, "retransmits": 427, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "snd_cwnd": 706352, "rtt": 362, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.00008, "end": 7.000196, "seconds": 1.000115990638733, "bytes": 1755761024, "bits_per_second": 14044459166.210653, "retransmits": 62, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "snd_cwnd": 684784, "rtt": 352, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000196, "end": 8.000057, "seconds": 0.9998610019683838, "bytes": 1783120320, "bits_per_second": 14266945637.36077, "retransmits": 88, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "snd_cwnd": 877548, "rtt": 463, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000057, "end": 9.000034, "seconds": 0.9999769926071167, "bytes": 1733497792, "bits_per_second": 13868301409.459152, "retransmits": 177, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "snd_cwnd": 858676, "rtt": 461, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000063, "seconds": 1.0000289678573608, "bytes": 1775311360, "bits_per_second": 14202079476.187506, "retransmits": 53, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "max_snd_cwnd": 958428, "max_rtt": 667, "min_rtt": 352, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039933, "seconds": 10.000063, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17314670228, "bits_per_second": 13851648917.011822, "retransmits": 1735, "sender": true}, "sum_received": {"start": 0, "end": 10.039933, "seconds": 10.039933, "bytes": 17312453588, "bits_per_second": 13794875792.896229, "sender": true}, "cpu_utilization_percent": {"host_total": 12.965573157783645, "host_user": 0.2766736708792456, "host_system": 12.688899486904399, "remote_total": 23.378925135581515, "remote_user": 0.7967034489409502, "remote_system": 22.582213415818792}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.185", "local_port": 46944, "remote_host": "172.30.243.134", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:16 UTC", "timesecs": 1711485016}, "connecting_to": {"host": "172.30.243.134", "port": 5201}, "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000056, "seconds": 1.0000560283660889, "bytes": 1588301472, "bits_per_second": 12705699896.394789, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}], "sum": {"start": 1.000056, "end": 2.000025, "seconds": 0.9999690055847168, "bytes": 1717632384, "bits_per_second": 13741484981.292118, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}], "sum": {"start": 2.000025, "end": 3.000046, "seconds": 1.000020980834961, "bytes": 1637153304, "bits_per_second": 13096951647.019003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}], "sum": {"start": 3.000046, "end": 4.000057, "seconds": 1.0000109672546387, "bytes": 1548560832, "bits_per_second": 12388350789.802336, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}], "sum": {"start": 4.000057, "end": 5.000057, "seconds": 1, "bytes": 1661339904, "bits_per_second": 13290719232, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}], "sum": {"start": 5.000057, "end": 6.000057, "seconds": 1, "bytes": 1734958228, "bits_per_second": 13879665824, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}], "sum": {"start": 6.000057, "end": 7.000024, "seconds": 0.9999669790267944, "bytes": 1733693804, "bits_per_second": 13870008433.176832, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000056, "seconds": 1.0000319480895996, "bytes": 1624242608, "bits_per_second": 12993525745.675262, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}], "sum": {"start": 8.000056, "end": 9.000015, "seconds": 0.9999589920043945, "bytes": 1732061376, "bits_per_second": 13857059258.225166, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}], "sum": {"start": 9.000015, "end": 10.000028, "seconds": 1.000012993812561, "bytes": 1706050368, "bits_per_second": 13648225601.514744, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03969, "seconds": 10.03969, "bytes": 16687168488, "bits_per_second": 13296959159.49596, "retransmits": 2081, "sender": false}, "sum_received": {"start": 0, "end": 10.000028, "seconds": 10.000028, "bytes": 16683994280, "bits_per_second": 13347158051.957455, "sender": false}, "cpu_utilization_percent": {"host_total": 26.49645360241422, "host_user": 1.0953846141637273, "host_system": 25.40107890796627, "remote_total": 12.308727742765743, "remote_user": 0.1856302180705536, "remote_system": 12.12309752469519}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 39718, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:35 UTC", "timesecs": 1711485035}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "snd_cwnd": 551332, "rtt": 31, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000101, "seconds": 1.0001009702682495, "bytes": 4825423936, "bits_per_second": 38599494086.72777, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "snd_cwnd": 551332, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000101, "end": 2.000064, "seconds": 0.9999629855155945, "bytes": 4806410240, "bits_per_second": 38452705227.057976, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "snd_cwnd": 707700, "rtt": 27, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000064, "end": 3.000036, "seconds": 0.9999719858169556, "bytes": 4803788800, "bits_per_second": 38431387023.910736, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000036, "end": 4.000268, "seconds": 1.0002319812774658, "bytes": 4790681600, "bits_per_second": 38316564074.51789, "retransmits": 78, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "snd_cwnd": 808800, "rtt": 30, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000268, "end": 5.000265, "seconds": 0.9999970197677612, "bytes": 4696309760, "bits_per_second": 37570590049.083694, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000265, "end": 6.000018, "seconds": 0.9997529983520508, "bytes": 4778885120, "bits_per_second": 38240526433.04741, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "snd_cwnd": 808800, "rtt": 28, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000018, "end": 7.000112, "seconds": 1.0000940561294556, "bytes": 4764467200, "bits_per_second": 38112152918.41128, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "snd_cwnd": 808800, "rtt": 26, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000112, "end": 8.000259, "seconds": 1.0001469850540161, "bytes": 4839178240, "bits_per_second": 38707736461.265396, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000259, "end": 9.000227, "seconds": 0.9999679923057556, "bytes": 4712038400, "bits_per_second": 37697513810.49582, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "snd_cwnd": 808800, "rtt": 29, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000227, "end": 10.000156, "seconds": 0.9999290108680725, "bytes": 4784128000, "bits_per_second": 38275741161.63895, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "max_snd_cwnd": 808800, "max_rtt": 31, "min_rtt": 26, "mean_rtt": 28, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000156, "seconds": 10.000156, "bytes": 47801311296, "bits_per_second": 38240452485.74122, "retransmits": 78, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 47801311296, "bits_per_second": 38087381686.64706, "sender": true}, "cpu_utilization_percent": {"host_total": 50.79991850744037, "host_user": 0.5093780915545499, "host_system": 50.29054041588581, "remote_total": 69.18971718930246, "remote_user": 1.6048329699753412, "remote_system": 67.58487595116893}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.186", "local_port": 45210, "remote_host": "172.30.74.186", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:30:46 UTC", "timesecs": 1711485046}, "connecting_to": {"host": "172.30.74.186", "port": 5201}, "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000004, "seconds": 1.0000040531158447, "bytes": 4517548360, "bits_per_second": 36140240399.41901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}], "sum": {"start": 1.000004, "end": 2.000005, "seconds": 1.0000009536743164, "bytes": 4473749504, "bits_per_second": 35789961900.03255, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000019, "seconds": 1.0000139474868774, "bytes": 4472438784, "bits_per_second": 35779011244.710175, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000014, "seconds": 0.9999949932098389, "bytes": 4757520384, "bits_per_second": 38060353632.204094, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}], "sum": {"start": 4.000014, "end": 5.000022, "seconds": 1.0000079870224, "bytes": 4763942596, "bits_per_second": 38111236372.7014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}], "sum": {"start": 5.000022, "end": 6.000016, "seconds": 0.9999939799308777, "bytes": 4744937788, "bits_per_second": 37959730824.20342, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}], "sum": {"start": 6.000016, "end": 7.000004, "seconds": 0.9999880194664001, "bytes": 4736604700, "bits_per_second": 37893291581.853004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}], "sum": {"start": 7.000004, "end": 8.000015, "seconds": 1.0000109672546387, "bytes": 4758175744, "bits_per_second": 38064988483.57848, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000031, "seconds": 1.0000159740447998, "bytes": 4740612096, "bits_per_second": 37924290963.67715, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}], "sum": {"start": 9.000031, "end": 10.000012, "seconds": 0.9999809861183167, "bytes": 4774428672, "bits_per_second": 38196155633.18397, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040275, "seconds": 10.040275, "bytes": 46740351844, "bits_per_second": 37242288159.63706, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000012, "seconds": 10.000012, "bytes": 46739958628, "bits_per_second": 37391922032.09356, "sender": false}, "cpu_utilization_percent": {"host_total": 53.87293306289964, "host_user": 1.9549507299646565, "host_system": 51.91798233293498, "remote_total": 84.71007116240497, "remote_user": 0.4765840963192183, "remote_system": 84.23349673055752}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 42424, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:05 UTC", "timesecs": 1711485065}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 397, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.00002, "seconds": 1.0000200271606445, "bytes": 2929396644, "bits_per_second": 23434703821.421913, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "snd_cwnd": 1763184, "rtt": 398, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.00002, "end": 2.000058, "seconds": 1.0000380277633667, "bytes": 2928148480, "bits_per_second": 23424297066.37413, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "snd_cwnd": 760272, "rtt": 242, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.00006, "seconds": 1.0000020265579224, "bytes": 2924216320, "bits_per_second": 23393683151.346077, "retransmits": 655, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "snd_cwnd": 1517848, "rtt": 400, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00006, "end": 4.000058, "seconds": 0.9999979734420776, "bytes": 2928148480, "bits_per_second": 23425235312.596207, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 393, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000057, "seconds": 0.9999989867210388, "bytes": 2928148480, "bits_per_second": 23425211576.27405, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "snd_cwnd": 1565028, "rtt": 373, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000057, "end": 6.000027, "seconds": 0.999970018863678, "bytes": 2928148480, "bits_per_second": 23425890174.806797, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "snd_cwnd": 1442360, "rtt": 379, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000027, "end": 7.000129, "seconds": 1.0001020431518555, "bytes": 2928148480, "bits_per_second": 23422797703.897022, "retransmits": 152, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "snd_cwnd": 1544808, "rtt": 397, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000129, "end": 8.000058, "seconds": 0.9999290108680725, "bytes": 2926837760, "bits_per_second": 23416364387.380756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "snd_cwnd": 1569072, "rtt": 419, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 2928148480, "bits_per_second": 23425187840, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "snd_cwnd": 1606816, "rtt": 410, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000116, "seconds": 1.0000580549240112, "bytes": 2921594880, "bits_per_second": 23371402215.02037, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "max_snd_cwnd": 1763184, "max_rtt": 419, "min_rtt": 242, "mean_rtt": 380, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039772, "seconds": 10.000116, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000116, "seconds": 10.000116, "bytes": 29270936484, "bits_per_second": 23416477556.06035, "retransmits": 807, "sender": true}, "sum_received": {"start": 0, "end": 10.039772, "seconds": 10.039772, "bytes": 29268240456, "bits_per_second": 23321836755.65541, "sender": true}, "cpu_utilization_percent": {"host_total": 19.865083177612643, "host_user": 0.41521108861582645, "host_system": 19.449872088996816, "remote_total": 59.10663386005702, "remote_user": 2.4033524078476156, "remote_system": 56.70327318135753}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.187", "local_port": 38322, "remote_host": "172.30.139.14", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:16 UTC", "timesecs": 1711485076}, "connecting_to": {"host": "172.30.139.14", "port": 5201}, "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000018, "seconds": 1.0000180006027222, "bytes": 2577850256, "bits_per_second": 20622430831.81543, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}], "sum": {"start": 1.000018, "end": 2.000009, "seconds": 0.9999909996986389, "bytes": 2421676608, "bits_per_second": 19373587232.123535, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000009, "seconds": 1, "bytes": 2353155072, "bits_per_second": 18825240576, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000015, "seconds": 1.0000059604644775, "bytes": 2349402240, "bits_per_second": 18795105892.438976, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}], "sum": {"start": 4.000015, "end": 5.000028, "seconds": 1.000012993812561, "bytes": 2327467584, "bits_per_second": 18619498733.723473, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000022, "seconds": 0.9999939799308777, "bytes": 2343643584, "bits_per_second": 18749261543.850487, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}], "sum": {"start": 6.000022, "end": 7.000011, "seconds": 0.9999889731407166, "bytes": 2349466944, "bits_per_second": 18795942812.21649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}], "sum": {"start": 7.000011, "end": 8.00003, "seconds": 1.0000189542770386, "bytes": 2404465344, "bits_per_second": 19235358159.692505, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.00003, "seconds": 1, "bytes": 2575413312, "bits_per_second": 20603306496, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.000034, "seconds": 1.0000040531158447, "bytes": 2567907648, "bits_per_second": 20543177920.12007, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039536, "seconds": 10.039536, "bytes": 24273090960, "bits_per_second": 19342002227.991413, "retransmits": 2404, "sender": false}, "sum_received": {"start": 0, "end": 10.000034, "seconds": 10.000034, "bytes": 24270448592, "bits_per_second": 19416292858.204285, "sender": false}, "cpu_utilization_percent": {"host_total": 37.45748338542608, "host_user": 1.3319334804012157, "host_system": 36.125549905024855, "remote_total": 15.928314062618693, "remote_user": 0.36963858784471143, "remote_system": 15.558675474773981}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 47958, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:36 UTC", "timesecs": 1711485096}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "snd_cwnd": 579640, "rtt": 26, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000048, "seconds": 1.000048041343689, "bytes": 4818672896, "bits_per_second": 38547531292.800804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "snd_cwnd": 579640, "rtt": 24, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000048, "end": 2.000066, "seconds": 1.0000180006027222, "bytes": 4807720960, "bits_per_second": 38461075357.46222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "snd_cwnd": 899116, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000066, "end": 3.000236, "seconds": 1.0001699924468994, "bytes": 4804968024, "bits_per_second": 38433210836.44771, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000236, "end": 4.000147, "seconds": 0.9999110102653503, "bytes": 4799728368, "bits_per_second": 38401244260.536964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 26, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000147, "end": 5.000114, "seconds": 0.9999669790267944, "bytes": 4824760320, "bits_per_second": 38599357148.33815, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 24, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000114, "end": 6.000145, "seconds": 1.0000309944152832, "bytes": 4833935360, "bits_per_second": 38670284317.14876, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000145, "end": 7.000159, "seconds": 1.0000139474868774, "bytes": 4801167360, "bits_per_second": 38408803173.721756, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000159, "end": 8.00016, "seconds": 1.0000009536743164, "bytes": 4820828160, "bits_per_second": 38566588500.03507, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00016, "end": 9.000032, "seconds": 0.9998720288276672, "bytes": 4795924480, "bits_per_second": 38372306389.033714, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "snd_cwnd": 1043352, "rtt": 22, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000128, "seconds": 1.0000959634780884, "bytes": 4848353280, "bits_per_second": 38783104478.40319, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "max_snd_cwnd": 1043352, "max_rtt": 26, "min_rtt": 22, "mean_rtt": 23, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040386, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000128, "seconds": 10.000128, "bytes": 48156059208, "bits_per_second": 38524354254.66554, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040386, "seconds": 10.040386, "bytes": 48156059208, "bits_per_second": 38369886741.80455, "sender": true}, "cpu_utilization_percent": {"host_total": 51.71680226694355, "host_user": 0.47637317598252343, "host_system": 51.24043901002937, "remote_total": 45.230156070887375, "remote_user": 1.3387075643093247, "remote_system": 43.891456788045936}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.189", "local_port": 60988, "remote_host": "172.30.32.96", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:31:48 UTC", "timesecs": 1711485108}, "connecting_to": {"host": "172.30.32.96", "port": 5201}, "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000022, "seconds": 1.000022053718567, "bytes": 5308961096, "bits_per_second": 42470752129.9852, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}], "sum": {"start": 1.000022, "end": 2.000005, "seconds": 0.999983012676239, "bytes": 5317292584, "bits_per_second": 42539063296.84071, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}], "sum": {"start": 2.000005, "end": 3.000026, "seconds": 1.000020980834961, "bytes": 5243928576, "bits_per_second": 41950548450.46644, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000023, "seconds": 0.9999970197677612, "bytes": 5279918676, "bits_per_second": 42239475291.446014, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}], "sum": {"start": 4.000023, "end": 5.00002, "seconds": 0.9999970197677612, "bytes": 5323227136, "bits_per_second": 42585944004.00324, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}], "sum": {"start": 5.00002, "end": 6.000004, "seconds": 0.9999840259552002, "bytes": 5266341888, "bits_per_second": 42131408113.00068, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}], "sum": {"start": 6.000004, "end": 7.000028, "seconds": 1.0000239610671997, "bytes": 5331222528, "bits_per_second": 42648758314.236046, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}], "sum": {"start": 7.000028, "end": 8.000016, "seconds": 0.9999880194664001, "bytes": 5229510656, "bits_per_second": 41836586472.62994, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}], "sum": {"start": 8.000016, "end": 9.000006, "seconds": 0.9999899864196777, "bytes": 5216403456, "bits_per_second": 41731645531.18451, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}], "sum": {"start": 9.000006, "end": 10.000033, "seconds": 1.0000269412994385, "bytes": 5329518592, "bits_per_second": 42635000093.695915, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040391, "seconds": 10.040391, "bytes": 52847242692, "bits_per_second": 42107716874.37273, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000033, "seconds": 10.000033, "bytes": 52846325188, "bits_per_second": 42276920636.5619, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72172176163449, "host_user": 1.7632532126911542, "host_system": 56.958468548943344, "remote_total": 54.5440108210963, "remote_user": 0.40678669250280086, "remote_system": 54.137214462757875}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 46580, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:07 UTC", "timesecs": 1711485127}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "snd_cwnd": 812844, "rtt": 417, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1749200440, "bits_per_second": 13992791169.571945, "retransmits": 621, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "snd_cwnd": 912596, "rtt": 445, "rttvar": 23, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000151, "seconds": 1.0000929832458496, "bytes": 1770835776, "bits_per_second": 14165369066.005585, "retransmits": 57, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "snd_cwnd": 669956, "rtt": 482, "rttvar": 128, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000151, "end": 3.000227, "seconds": 1.0000760555267334, "bytes": 1781066812, "bits_per_second": 14247450898.617298, "retransmits": 87, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "snd_cwnd": 843848, "rtt": 461, "rttvar": 58, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000227, "end": 4.000645, "seconds": 1.000417947769165, "bytes": 1706121192, "bits_per_second": 13643267362.841578, "retransmits": 532, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "snd_cwnd": 838456, "rtt": 544, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000645, "end": 5.000058, "seconds": 0.999413013458252, "bytes": 1646996516, "bits_per_second": 13183710788.803326, "retransmits": 142, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "snd_cwnd": 928772, "rtt": 486, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000057, "seconds": 0.9999989867210388, "bytes": 1782799112, "bits_per_second": 14262407347.797302, "retransmits": 132, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "snd_cwnd": 831716, "rtt": 416, "rttvar": 13, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000057, "end": 7.000161, "seconds": 1.0001039505004883, "bytes": 1788102904, "bits_per_second": 14303336393.023293, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "snd_cwnd": 824976, "rtt": 580, "rttvar": 185, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000161, "end": 8.000058, "seconds": 0.9998970031738281, "bytes": 1783196620, "bits_per_second": 14267042420.088129, "retransmits": 96, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "snd_cwnd": 634908, "rtt": 423, "rttvar": 97, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000076, "seconds": 1.0000180006027222, "bytes": 1775786432, "bits_per_second": 14206035738.794409, "retransmits": 301, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "snd_cwnd": 676696, "rtt": 360, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000076, "end": 10.000063, "seconds": 0.999987006187439, "bytes": 1681309440, "bits_per_second": 13450650295.22876, "retransmits": 249, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "max_snd_cwnd": 928772, "max_rtt": 580, "min_rtt": 360, "mean_rtt": 461, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039945, "seconds": 10.000063, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 17465415244, "bits_per_second": 13972244170.061728, "retransmits": 2294, "sender": true}, "sum_received": {"start": 0, "end": 10.039945, "seconds": 10.039945, "bytes": 17463546188, "bits_per_second": 13915252474.391047, "sender": true}, "cpu_utilization_percent": {"host_total": 13.61059396129923, "host_user": 0.19270043453809127, "host_system": 13.417903445457585, "remote_total": 23.486672814565882, "remote_user": 0.5555645903789477, "remote_system": 22.931108224186932}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.190", "local_port": 50678, "remote_host": "172.30.51.52", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:19 UTC", "timesecs": 1711485139}, "connecting_to": {"host": "172.30.51.52", "port": 5201}, "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000045, "seconds": 1.0000449419021606, "bytes": 1731201352, "bits_per_second": 13848988416.117579, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}], "sum": {"start": 1.000045, "end": 2.000008, "seconds": 0.9999629855155945, "bytes": 1582543756, "bits_per_second": 12660818681.675653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}], "sum": {"start": 2.000008, "end": 3.000015, "seconds": 1.0000070333480835, "bytes": 1576707072, "bits_per_second": 12613567860.386663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1528626392, "bits_per_second": 12228852236.5862, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000013, "seconds": 0.9999849796295166, "bytes": 1714944660, "bits_per_second": 13719763355.92855, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000043, "seconds": 1.0000300407409668, "bytes": 1705468032, "bits_per_second": 13643334400.125362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}], "sum": {"start": 6.000043, "end": 7.000024, "seconds": 0.9999809861183167, "bytes": 1737755328, "bits_per_second": 13902306960.81968, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}], "sum": {"start": 7.000024, "end": 8.000011, "seconds": 0.999987006187439, "bytes": 1737625920, "bits_per_second": 13901187989.43111, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}], "sum": {"start": 8.000011, "end": 9.00003, "seconds": 1.0000189542770386, "bytes": 1625946816, "bits_per_second": 13007327983.50187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}], "sum": {"start": 9.00003, "end": 10.00004, "seconds": 1.0000100135803223, "bytes": 1604133292, "bits_per_second": 12832937832.346245, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039719, "seconds": 10.039719, "bytes": 16547546348, "bits_per_second": 13185664935.841331, "retransmits": 2136, "sender": false}, "sum_received": {"start": 0, "end": 10.00004, "seconds": 10.00004, "bytes": 16544952620, "bits_per_second": 13235909152.36339, "sender": false}, "cpu_utilization_percent": {"host_total": 26.747516641197084, "host_user": 1.0158505257156165, "host_system": 25.731666115481467, "remote_total": 11.755923477356498, "remote_user": 0.13796182174123386, "remote_system": 11.617971314101807}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 41706, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:38 UTC", "timesecs": 1711485158}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "snd_cwnd": 525720, "rtt": 24, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000041, "seconds": 1.0000410079956055, "bytes": 4768399360, "bits_per_second": 38145630604.14782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "snd_cwnd": 525720, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000041, "end": 2.000213, "seconds": 1.0001720190048218, "bytes": 4806410240, "bits_per_second": 38444668706.348434, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000213, "end": 3.00012, "seconds": 0.9999070167541504, "bytes": 4761203140, "bits_per_second": 38093167146.32596, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.00012, "end": 4.000102, "seconds": 0.9999819993972778, "bytes": 4814274560, "bits_per_second": 38514889771.22966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000102, "end": 5.000003, "seconds": 0.9999009966850281, "bytes": 4811653120, "bits_per_second": 38497036294.209724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 23, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000003, "end": 6.000056, "seconds": 1.00005304813385, "bytes": 4795924480, "bits_per_second": 38365360629.214134, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 25, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000108, "seconds": 1.0000519752502441, "bytes": 4746117120, "bits_per_second": 37966963617.564964, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 37, "rttvar": 16, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000108, "end": 8.000094, "seconds": 0.9999859929084778, "bytes": 4801167360, "bits_per_second": 38409876890.660965, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 24, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000094, "end": 9.000078, "seconds": 0.9999840259552002, "bytes": 4807720960, "bits_per_second": 38462382079.81445, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "snd_cwnd": 1202416, "rtt": 21, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000078, "end": 10.00019, "seconds": 1.0001120567321777, "bytes": 4764467200, "bits_per_second": 38111466953.55469, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "max_snd_cwnd": 1202416, "max_rtt": 37, "min_rtt": 21, "mean_rtt": 24, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040372, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00019, "seconds": 10.00019, "bytes": 47877337540, "bits_per_second": 38301142310.296104, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040372, "seconds": 10.040372, "bytes": 47877337540, "bits_per_second": 38147859493.65223, "sender": true}, "cpu_utilization_percent": {"host_total": 51.579098862767125, "host_user": 0.4361726860977011, "host_system": 51.14293609532062, "remote_total": 44.789642459824776, "remote_user": 1.3832780535675204, "remote_system": 43.40635613187544}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.192", "local_port": 57026, "remote_host": "172.30.87.166", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:32:50 UTC", "timesecs": 1711485170}, "connecting_to": {"host": "172.30.87.166", "port": 5201}, "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000025, "seconds": 1.0000250339508057, "bytes": 5283402056, "bits_per_second": 42266158359.07089, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}], "sum": {"start": 1.000025, "end": 2.000023, "seconds": 0.9999979734420776, "bytes": 5276569800, "bits_per_second": 42212643946.36801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}], "sum": {"start": 2.000023, "end": 3.000005, "seconds": 0.9999819993972778, "bytes": 5302255616, "bits_per_second": 42418808492.11961, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}], "sum": {"start": 3.000005, "end": 4.00003, "seconds": 1.0000250339508057, "bytes": 5176033280, "bits_per_second": 41407229653.44986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}], "sum": {"start": 4.00003, "end": 5.000008, "seconds": 0.9999780058860779, "bytes": 5233967104, "bits_per_second": 41872657784.00552, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}], "sum": {"start": 5.000008, "end": 6.000007, "seconds": 0.9999989867210388, "bytes": 5299765248, "bits_per_second": 42398164945.16853, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}], "sum": {"start": 6.000007, "end": 7.000021, "seconds": 1.0000139474868774, "bytes": 5302255616, "bits_per_second": 42417453311.12657, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}], "sum": {"start": 7.000021, "end": 8.000026, "seconds": 1.0000050067901611, "bytes": 5336727552, "bits_per_second": 42693606658.070244, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}], "sum": {"start": 8.000026, "end": 9.000032, "seconds": 1.0000059604644775, "bytes": 5314183168, "bits_per_second": 42513211945.510376, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}], "sum": {"start": 9.000032, "end": 10.000018, "seconds": 0.9999859929084778, "bytes": 5215485952, "bits_per_second": 41724472054.49879, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040334, "seconds": 10.040334, "bytes": 52741693968, "bits_per_second": 42023856152.99252, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000018, "seconds": 10.000018, "bytes": 52740645392, "bits_per_second": 42192440367.20734, "sender": false}, "cpu_utilization_percent": {"host_total": 58.72825614611755, "host_user": 1.7371177997142697, "host_system": 56.991148265535564, "remote_total": 54.64429253795493, "remote_user": 0.4133314501365237, "remote_system": 54.23096108781841}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 43702, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:09 UTC", "timesecs": 1711485189}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "snd_cwnd": 816888, "rtt": 591, "rttvar": 85, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1470700168, "bits_per_second": 11764930954.229, "retransmits": 1151, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "snd_cwnd": 958428, "rtt": 636, "rttvar": 81, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000057, "end": 2.000058, "seconds": 1.0000009536743164, "bytes": 1666939764, "bits_per_second": 13335505394.27101, "retransmits": 59, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "snd_cwnd": 688828, "rtt": 360, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000057, "seconds": 0.9999989867210388, "bytes": 1704166784, "bits_per_second": 13633348086.384787, "retransmits": 118, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "snd_cwnd": 804756, "rtt": 415, "rttvar": 1, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000057, "end": 4.000057, "seconds": 1, "bytes": 1593611456, "bits_per_second": 12748891648, "retransmits": 128, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "snd_cwnd": 953036, "rtt": 494, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000058, "seconds": 1.0000009536743164, "bytes": 1778151040, "bits_per_second": 14225194753.797117, "retransmits": 49, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "snd_cwnd": 850588, "rtt": 461, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000058, "end": 6.000056, "seconds": 0.9999979734420776, "bytes": 1775902848, "bits_per_second": 14207251575.818235, "retransmits": 79, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "snd_cwnd": 943600, "rtt": 507, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000056, "end": 7.000058, "seconds": 1.0000020265579224, "bytes": 1780742784, "bits_per_second": 14245913401.831335, "retransmits": 108, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "snd_cwnd": 846544, "rtt": 461, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000058, "end": 8.000058, "seconds": 1, "bytes": 1778931136, "bits_per_second": 14231449088, "retransmits": 110, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "snd_cwnd": 830368, "rtt": 478, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1771323712, "bits_per_second": 14170589696, "retransmits": 77, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "snd_cwnd": 501456, "rtt": 244, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000215, "seconds": 1.0001569986343384, "bytes": 1773207680, "bits_per_second": 14183434660.128132, "retransmits": 120, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "max_snd_cwnd": 958428, "max_rtt": 636, "min_rtt": 244, "mean_rtt": 464, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039929, "seconds": 10.000215, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000215, "seconds": 10.000215, "bytes": 17093677372, "bits_per_second": 13674647892.670307, "retransmits": 1999, "sender": true}, "sum_received": {"start": 0, "end": 10.039929, "seconds": 10.039929, "bytes": 17090819196, "bits_per_second": 13618278930.85698, "sender": true}, "cpu_utilization_percent": {"host_total": 13.005006946322178, "host_user": 0.19271754050004394, "host_system": 12.812299324888505, "remote_total": 23.26438245505795, "remote_user": 0.8376646905752849, "remote_system": 22.426726025964516}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.193", "local_port": 57004, "remote_host": "172.30.250.34", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:21 UTC", "timesecs": 1711485201}, "connecting_to": {"host": "172.30.250.34", "port": 5201}, "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000057, "seconds": 1.0000569820404053, "bytes": 1720841732, "bits_per_second": 13765949444.112558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}], "sum": {"start": 1.000057, "end": 2.000017, "seconds": 0.9999600052833557, "bytes": 1732854844, "bits_per_second": 13863393214.483341, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}], "sum": {"start": 2.000017, "end": 3.000057, "seconds": 1.000040054321289, "bytes": 1691401320, "bits_per_second": 13530668598.25271, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}], "sum": {"start": 3.000057, "end": 4.000067, "seconds": 1.0000100135803223, "bytes": 1568036736, "bits_per_second": 12544168275.963392, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}], "sum": {"start": 4.000067, "end": 5.000031, "seconds": 0.9999639987945557, "bytes": 1557489984, "bits_per_second": 12460368460.284851, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000045, "seconds": 1.0000139474868774, "bytes": 1737561216, "bits_per_second": 13900295853.805986, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}], "sum": {"start": 6.000045, "end": 7.000026, "seconds": 0.9999809861183167, "bytes": 1735555392, "bits_per_second": 13884707138.178734, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000033, "seconds": 1.0000070333480835, "bytes": 1590631612, "bits_per_second": 12724963396.90308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}], "sum": {"start": 8.000033, "end": 9.000026, "seconds": 0.9999930262565613, "bytes": 1589841984, "bits_per_second": 12718824569.819391, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000026, "seconds": 1, "bytes": 1480498380, "bits_per_second": 11843987040, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}}], "sum_sent": {"start": 0, "end": 10.03968, "seconds": 10.03968, "bytes": 16408142512, "bits_per_second": 13074633862.43386, "retransmits": 1734, "sender": false}, "sum_received": {"start": 0, "end": 10.000026, "seconds": 10.000026, "bytes": 16404713200, "bits_per_second": 13123736438.285261, "sender": false}, "cpu_utilization_percent": {"host_total": 26.064632328384384, "host_user": 1.162207899423042, "host_system": 24.902424428961346, "remote_total": 11.69062967191739, "remote_user": 0.12009331046577057, "remote_system": 11.570546012927187}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56708, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:39 UTC", "timesecs": 1711485219}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000229, "seconds": 1.000229001045227, "bytes": 3386293120, "bits_per_second": 27084142663.02109, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000229, "end": 2.000133, "seconds": 0.9999039769172668, "bytes": 3393454080, "bits_per_second": 27150239689.71195, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "snd_cwnd": 798016, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000133, "end": 3.000277, "seconds": 1.0001440048217773, "bytes": 3402629120, "bits_per_second": 27217113564.41186, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000277, "end": 4.000095, "seconds": 0.9998180270195007, "bytes": 3413114880, "bits_per_second": 27309888701.844177, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000095, "end": 5.000135, "seconds": 1.000040054321289, "bytes": 3415736320, "bits_per_second": 27324796083.8385, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "snd_cwnd": 798016, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000135, "end": 6.000236, "seconds": 1.0001009702682495, "bytes": 3413114880, "bits_per_second": 27302162333.34541, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "snd_cwnd": 798016, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000236, "end": 7.000377, "seconds": 1.0001410245895386, "bytes": 3403939840, "bits_per_second": 27227678947.752304, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "snd_cwnd": 798016, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000377, "end": 8.000122, "seconds": 0.9997450113296509, "bytes": 3405250560, "bits_per_second": 27248952654.205704, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "snd_cwnd": 798016, "rtt": 32, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000122, "end": 9.000175, "seconds": 1.00005304813385, "bytes": 3457679360, "bits_per_second": 27659967570.33804, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "snd_cwnd": 798016, "rtt": 30, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000175, "end": 10.000275, "seconds": 1.000100016593933, "bytes": 3503554560, "bits_per_second": 28025633451.599354, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "max_snd_cwnd": 798016, "max_rtt": 35, "min_rtt": 30, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040107, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000275, "seconds": 10.000275, "bytes": 34194766720, "bits_per_second": 27355061111.819424, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040107, "seconds": 10.040107, "bytes": 34194766720, "bits_per_second": 27246535695.28691, "sender": true}, "cpu_utilization_percent": {"host_total": 84.44527815243438, "host_user": 0.4874417118707169, "host_system": 83.95785625929561, "remote_total": 37.5809576369255, "remote_user": 1.2945095444412822, "remote_system": 36.286448092484214}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37086, "remote_host": "172.30.108.164", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:33:51 UTC", "timesecs": 1711485231}, "connecting_to": {"host": "172.30.108.164", "port": 5201}, "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000019, "seconds": 1.0000189542770386, "bytes": 4331032904, "bits_per_second": 34647606511.66746, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}], "sum": {"start": 1.000019, "end": 2.000003, "seconds": 0.9999840259552002, "bytes": 4384751616, "bits_per_second": 35078573274.701004, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}], "sum": {"start": 2.000003, "end": 3.000019, "seconds": 1.0000159740447998, "bytes": 4398120960, "bits_per_second": 35184405642.72801, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}], "sum": {"start": 3.000019, "end": 4.000018, "seconds": 0.9999989867210388, "bytes": 4399955968, "bits_per_second": 35199683411.09864, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000002, "seconds": 0.9999840259552002, "bytes": 4368367616, "bits_per_second": 34947499180.91756, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}], "sum": {"start": 5.000002, "end": 6.000018, "seconds": 1.0000159740447998, "bytes": 4274782208, "bits_per_second": 34197711388.226234, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000016, "seconds": 0.9999979734420776, "bytes": 4378853376, "bits_per_second": 35030898000.14387, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}], "sum": {"start": 7.000016, "end": 8.000018, "seconds": 1.0000020265579224, "bytes": 4318953472, "bits_per_second": 34551557755.2669, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}], "sum": {"start": 8.000018, "end": 9.000035, "seconds": 1.0000170469284058, "bytes": 4416208896, "bits_per_second": 35329068915.89155, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}], "sum": {"start": 9.000035, "end": 10.00001, "seconds": 0.9999750256538391, "bytes": 4437573632, "bits_per_second": 35501475682.14291, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040164, "seconds": 10.040164, "bytes": 43710042440, "bits_per_second": 34828150169.65858, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.00001, "seconds": 10.00001, "bytes": 43708600648, "bits_per_second": 34966845551.55445, "sender": false}, "cpu_utilization_percent": {"host_total": 91.26294493237891, "host_user": 1.8116036545309533, "host_system": 89.45135119667133, "remote_total": 44.14246868282316, "remote_user": 0.32552835005268926, "remote_system": 43.816940332770464}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55424, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:09 UTC", "timesecs": 1711485249}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "snd_cwnd": 641648, "rtt": 391, "rttvar": 37, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000296, "seconds": 1.0002959966659546, "bytes": 1501175364, "bits_per_second": 12005849220.658731, "retransmits": 40, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "snd_cwnd": 787232, "rtt": 223, "rttvar": 31, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000296, "end": 2.000231, "seconds": 0.99993497133255, "bytes": 1529610240, "bits_per_second": 12237677719.874805, "retransmits": 12, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "snd_cwnd": 655128, "rtt": 228, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000231, "end": 3.000429, "seconds": 1.0001980066299438, "bytes": 1536163840, "bits_per_second": 12286877836.727018, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "snd_cwnd": 849240, "rtt": 193, "rttvar": 25, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000429, "end": 4.000044, "seconds": 0.9996150135993958, "bytes": 1545338880, "bits_per_second": 12367472348.664085, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "snd_cwnd": 936860, "rtt": 606, "rttvar": 12, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000044, "end": 5.000092, "seconds": 1.000048041343689, "bytes": 1523056640, "bits_per_second": 12183867790.62001, "retransmits": 2, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "snd_cwnd": 829020, "rtt": 197, "rttvar": 54, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000092, "end": 6.000681, "seconds": 1.0005890130996704, "bytes": 1547960320, "bits_per_second": 12376392702.57152, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "snd_cwnd": 917988, "rtt": 218, "rttvar": 40, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000681, "end": 7.000548, "seconds": 0.9998670220375061, "bytes": 1547960320, "bits_per_second": 12385329535.886497, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "snd_cwnd": 917988, "rtt": 200, "rttvar": 33, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000548, "end": 8.000077, "seconds": 0.9995290040969849, "bytes": 1534853120, "bits_per_second": 12284610961.43297, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "snd_cwnd": 934164, "rtt": 220, "rttvar": 26, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000077, "end": 9.000416, "seconds": 1.0003390312194824, "bytes": 1536163840, "bits_per_second": 12285145672.081276, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "snd_cwnd": 776448, "rtt": 184, "rttvar": 15, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000416, "end": 10.00071, "seconds": 1.0002939701080322, "bytes": 1544028160, "bits_per_second": 12348595162.146137, "retransmits": 50, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "max_snd_cwnd": 936860, "max_rtt": 606, "min_rtt": 184, "mean_rtt": 266, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040277, "seconds": 10.00071, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}}], "sum_sent": {"start": 0, "end": 10.00071, "seconds": 10.00071, "bytes": 15346310724, "bits_per_second": 12276176970.635086, "retransmits": 123, "sender": true}, "sum_received": {"start": 0, "end": 10.040277, "seconds": 10.040277, "bytes": 15346244356, "bits_per_second": 12227745793.069256, "sender": true}, "cpu_utilization_percent": {"host_total": 95.82562437024121, "host_user": 0.2560031758234491, "host_system": 95.56962119441776, "remote_total": 24.102997438800752, "remote_user": 1.0351409018247604, "remote_system": 23.06785653697599}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39456, "remote_host": "172.30.85.71", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:21 UTC", "timesecs": 1711485261}, "connecting_to": {"host": "172.30.85.71", "port": 5201}, "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1697801956, "bits_per_second": 13582334690.976553, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000057, "seconds": 1.0000510215759277, "bytes": 1744419840, "bits_per_second": 13954646731.932222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}], "sum": {"start": 2.000057, "end": 3.000015, "seconds": 0.9999579787254333, "bytes": 1748195168, "bits_per_second": 13986149059.809772, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}], "sum": {"start": 3.000015, "end": 4.000028, "seconds": 1.000012993812561, "bytes": 1734067200, "bits_per_second": 13872357345.188877, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}], "sum": {"start": 4.000028, "end": 5.000031, "seconds": 1.0000029802322388, "bytes": 1729473216, "bits_per_second": 13835744494.268211, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000014, "seconds": 0.999983012676239, "bytes": 1727920320, "bits_per_second": 13823597385.924335, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}], "sum": {"start": 6.000014, "end": 7.000057, "seconds": 1.0000430345535278, "bytes": 1720414656, "bits_per_second": 13762724975.275362, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}], "sum": {"start": 7.000057, "end": 8.000012, "seconds": 0.9999549984931946, "bytes": 1731396632, "bits_per_second": 13851796407.710308, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}], "sum": {"start": 8.000012, "end": 9.000057, "seconds": 1.0000449419021606, "bytes": 1731026112, "bits_per_second": 13847586559.1197, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}], "sum": {"start": 9.000057, "end": 10.000029, "seconds": 0.9999719858169556, "bytes": 1741314048, "bits_per_second": 13930902646.856724, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039465, "seconds": 10.039465, "bytes": 17308229084, "bits_per_second": 13792152537.211893, "retransmits": 2195, "sender": false}, "sum_received": {"start": 0, "end": 10.000029, "seconds": 10.000029, "bytes": 17306029148, "bits_per_second": 13844783168.528812, "sender": false}, "cpu_utilization_percent": {"host_total": 44.47684113065824, "host_user": 1.8968527601361653, "host_system": 42.57999828989936, "remote_total": 12.529305328982618, "remote_user": 0.09332895016906215, "remote_system": 12.435986036196645}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 56016, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:38 UTC", "timesecs": 1711485278}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000293, "seconds": 1.0002930164337158, "bytes": 3219128320, "bits_per_second": 25745482710.471886, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "snd_cwnd": 663216, "rtt": 37, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000293, "end": 2.000138, "seconds": 0.999845027923584, "bytes": 3219128320, "bits_per_second": 25757018178.58942, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000138, "end": 3.000088, "seconds": 0.9999499917030334, "bytes": 3282042880, "bits_per_second": 26257656140.665928, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000088, "end": 4.000243, "seconds": 1.000154972076416, "bytes": 3465543680, "bits_per_second": 27720053605.734356, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "snd_cwnd": 663216, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000243, "end": 5.000101, "seconds": 0.999858021736145, "bytes": 3481272320, "bits_per_second": 27854133241.47881, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000101, "end": 6.000015, "seconds": 0.9999139904975891, "bytes": 3489136640, "bits_per_second": 27915494117.75862, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "snd_cwnd": 663216, "rtt": 34, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000015, "end": 7.000294, "seconds": 1.0002789497375488, "bytes": 3472097280, "bits_per_second": 27769032075.790474, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "snd_cwnd": 663216, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000294, "end": 8.000249, "seconds": 0.9999549984931946, "bytes": 3482583040, "bits_per_second": 27861918148.299164, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "snd_cwnd": 663216, "rtt": 35, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000249, "end": 9.000268, "seconds": 1.0000189542770386, "bytes": 3388211200, "bits_per_second": 27105175840.98793, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "snd_cwnd": 663216, "rtt": 31, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000268, "end": 10.000366, "seconds": 1.0000979900360107, "bytes": 3389521920, "bits_per_second": 27113518505.345284, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "max_snd_cwnd": 663216, "max_rtt": 37, "min_rtt": 31, "mean_rtt": 33, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039647, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000366, "seconds": 10.000366, "bytes": 33888665600, "bits_per_second": 27109940256.186626, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039647, "seconds": 10.039647, "bytes": 33888665600, "bits_per_second": 27003870235.676613, "sender": true}, "cpu_utilization_percent": {"host_total": 98.6366144037512, "host_user": 0.5079154773387307, "host_system": 98.12868897353042, "remote_total": 69.33475570009895, "remote_user": 1.8358332803622874, "remote_system": 67.4989133777374}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 41272, "remote_host": "172.30.16.61", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:34:50 UTC", "timesecs": 1711485290}, "connecting_to": {"host": "172.30.16.61", "port": 5201}, "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000015, "seconds": 1.0000150203704834, "bytes": 3679605064, "bits_per_second": 29436398366.39084, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}], "sum": {"start": 1.000015, "end": 2.00001, "seconds": 0.9999949932098389, "bytes": 3648388804, "bits_per_second": 29187256566.469006, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000028, "seconds": 1.0000180006027222, "bytes": 3632922940, "bits_per_second": 29062860370.99649, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}], "sum": {"start": 3.000028, "end": 4.000024, "seconds": 0.9999960064888, "bytes": 3643932672, "bits_per_second": 29151577793.152412, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}], "sum": {"start": 4.000024, "end": 5.000031, "seconds": 1.0000070333480835, "bytes": 3619028992, "bits_per_second": 28952028306.307198, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}], "sum": {"start": 5.000031, "end": 6.000037, "seconds": 1.0000059604644775, "bytes": 3631349760, "bits_per_second": 29050624924.782085, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}], "sum": {"start": 6.000037, "end": 7.000025, "seconds": 0.9999880194664001, "bytes": 3610509312, "bits_per_second": 28884420546.770874, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}], "sum": {"start": 7.000025, "end": 8.000022, "seconds": 0.9999970197677612, "bytes": 3608674304, "bits_per_second": 28869480469.756413, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}], "sum": {"start": 8.000022, "end": 9.000038, "seconds": 1.0000159740447998, "bytes": 3623223296, "bits_per_second": 28985323355.146187, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}], "sum": {"start": 9.000038, "end": 10.000021, "seconds": 0.999983012676239, "bytes": 3621519360, "bits_per_second": 28972647047.73561, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039809, "seconds": 10.039809, "bytes": 36320203080, "bits_per_second": 28940951430.45052, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000021, "seconds": 10.000021, "bytes": 36319154504, "bits_per_second": 29055262587.148567, "sender": false}, "cpu_utilization_percent": {"host_total": 86.40432984604324, "host_user": 2.1048623181527053, "host_system": 84.29947744708186, "remote_total": 96.37010529501002, "remote_user": 0.5200516733573617, "remote_system": 95.85006329541284}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 35114, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:07 UTC", "timesecs": 1711485307}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "snd_cwnd": 2701392, "rtt": 911, "rttvar": 4, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 2927638472, "bits_per_second": 23419748144.30112, "retransmits": 368, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "snd_cwnd": 2724308, "rtt": 935, "rttvar": 42, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000132, "seconds": 1.000074028968811, "bytes": 2915041280, "bits_per_second": 23318603987.79267, "retransmits": 202, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "snd_cwnd": 2744528, "rtt": 900, "rttvar": 30, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000132, "end": 3.000059, "seconds": 0.9999269843101501, "bytes": 2926837760, "bits_per_second": 23416411845.464706, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "snd_cwnd": 2345520, "rtt": 798, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000057, "seconds": 0.9999979734420776, "bytes": 2925527040, "bits_per_second": 23404263750.09612, "retransmits": 6, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "snd_cwnd": 2325300, "rtt": 778, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000144, "seconds": 1.000087022781372, "bytes": 2929459200, "bits_per_second": 23433634339.962082, "retransmits": 4, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "snd_cwnd": 3097704, "rtt": 1023, "rttvar": 3, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000144, "end": 6.000058, "seconds": 0.9999139904975891, "bytes": 2926837760, "bits_per_second": 23416716140.103306, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "snd_cwnd": 3165104, "rtt": 1109, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.000149, "seconds": 1.0000909566879272, "bytes": 2928148480, "bits_per_second": 23423057356.281742, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "snd_cwnd": 2543676, "rtt": 841, "rttvar": 14, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000149, "end": 8.000068, "seconds": 0.9999189972877502, "bytes": 2926837760, "bits_per_second": 23416598888.021595, "retransmits": 711, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 1059, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000068, "end": 9.000241, "seconds": 1.0001729726791382, "bytes": 2928148480, "bits_per_second": 23421136623.249817, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "snd_cwnd": 3157016, "rtt": 781, "rttvar": 78, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000241, "end": 10.000231, "seconds": 0.9999899864196777, "bytes": 2926837760, "bits_per_second": 23414936547.34786, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "max_snd_cwnd": 3165104, "max_rtt": 1109, "min_rtt": 778, "mean_rtt": 913, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040346, "seconds": 10.000231, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000231, "seconds": 10.000231, "bytes": 29261313992, "bits_per_second": 23408510457.008446, "retransmits": 1304, "sender": true}, "sum_received": {"start": 0, "end": 10.040346, "seconds": 10.040346, "bytes": 29260124328, "bits_per_second": 23314036650.131382, "sender": true}, "cpu_utilization_percent": {"host_total": 34.97762289166434, "host_user": 0.5691962216451614, "host_system": 34.40843658477508, "remote_total": 62.9251445256492, "remote_user": 2.6124474135751976, "remote_system": 60.31269711207401}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 55052, "remote_host": "172.30.148.98", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:19 UTC", "timesecs": 1711485319}, "connecting_to": {"host": "172.30.148.98", "port": 5201}, "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000014, "seconds": 1.0000139474868774, "bytes": 2924870228, "bits_per_second": 23398635471.838806, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}], "sum": {"start": 1.000014, "end": 2.000028, "seconds": 1.0000139474868774, "bytes": 2928633648, "bits_per_second": 23428742411.922653, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}], "sum": {"start": 2.000028, "end": 3.000026, "seconds": 0.9999979734420776, "bytes": 2912575888, "bits_per_second": 23300654324.125618, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000009, "seconds": 0.999983012676239, "bytes": 2928793176, "bits_per_second": 23430743433.62467, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}], "sum": {"start": 4.000009, "end": 5.000024, "seconds": 1.0000150203704834, "bytes": 2927518936, "bits_per_second": 23419799713.93165, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}], "sum": {"start": 5.000024, "end": 6.000039, "seconds": 1.0000150203704834, "bytes": 2928627108, "bits_per_second": 23428664956.77242, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}], "sum": {"start": 6.000039, "end": 7.000044, "seconds": 1.0000050067901611, "bytes": 2924520712, "bits_per_second": 23396048556.894276, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}], "sum": {"start": 7.000044, "end": 8.00003, "seconds": 0.9999859929084778, "bytes": 2928023612, "bits_per_second": 23424517005.353558, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}], "sum": {"start": 8.00003, "end": 9.000029, "seconds": 0.9999989867210388, "bytes": 2927982060, "bits_per_second": 23423880214.92501, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}], "sum": {"start": 9.000029, "end": 10.000013, "seconds": 0.9999840259552002, "bytes": 2927753088, "bits_per_second": 23422398854.44862, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039882, "seconds": 10.039882, "bytes": 29263263664, "bits_per_second": 23317615616.597885, "retransmits": 2270, "sender": false}, "sum_received": {"start": 0, "end": 10.000013, "seconds": 10.000013, "bytes": 29259298456, "bits_per_second": 23407408335.169167, "sender": false}, "cpu_utilization_percent": {"host_total": 88.6667781634535, "host_user": 2.169277119907057, "host_system": 86.4975109631894, "remote_total": 22.440235970749637, "remote_user": 0.4127789042736779, "remote_system": 22.027466720316273}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 50458, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:37 UTC", "timesecs": 1711485337}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "snd_cwnd": 884288, "rtt": 40, "rttvar": 10, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000278, "seconds": 1.0002779960632324, "bytes": 3395979324, "bits_per_second": 27160284139.932823, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "snd_cwnd": 974604, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000278, "end": 2.000255, "seconds": 0.9999769926071167, "bytes": 3434086400, "bits_per_second": 27473323289.542732, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "snd_cwnd": 974604, "rtt": 35, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000255, "end": 3.000046, "seconds": 0.9997910261154175, "bytes": 3440640000, "bits_per_second": 27530873233.52556, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000046, "end": 4.000267, "seconds": 1.0002210140228271, "bytes": 3413114880, "bits_per_second": 27298885603.47408, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 35, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000267, "end": 5.000044, "seconds": 0.9997770190238953, "bytes": 3420979200, "bits_per_second": 27373937467.296288, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000044, "end": 6.000099, "seconds": 1.000054955482483, "bytes": 3440640000, "bits_per_second": 27523607426.874187, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000099, "end": 7.000285, "seconds": 1.0001859664916992, "bytes": 3441950720, "bits_per_second": 27530486012.101555, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 34, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000285, "end": 8.000245, "seconds": 0.9999600052833557, "bytes": 3440640000, "bits_per_second": 27526220903.40532, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 33, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000245, "end": 9.000034, "seconds": 0.9997889995574951, "bytes": 3440640000, "bits_per_second": 27530929038.209633, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "snd_cwnd": 1074356, "rtt": 31, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000034, "end": 10.000143, "seconds": 1.0001089572906494, "bytes": 3434086400, "bits_per_second": 27469698176.111774, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "max_snd_cwnd": 1074356, "max_rtt": 40, "min_rtt": 31, "mean_rtt": 34, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.039944, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000143, "seconds": 10.000143, "bytes": 34302756924, "bits_per_second": 27441813121.272366, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.039944, "seconds": 10.039944, "bytes": 34302756924, "bits_per_second": 27333026498.155766, "sender": true}, "cpu_utilization_percent": {"host_total": 84.72291319227105, "host_user": 0.5304700943978504, "host_system": 84.19243318754582, "remote_total": 37.30641845607046, "remote_user": 1.3600734652179878, "remote_system": 35.946344990852474}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 53048, "remote_host": "172.30.187.145", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:35:49 UTC", "timesecs": 1711485349}, "connecting_to": {"host": "172.30.187.145", "port": 5201}, "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000028, "seconds": 1.0000280141830444, "bytes": 4393816392, "bits_per_second": 35149546450.171814, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}], "sum": {"start": 1.000028, "end": 2.000009, "seconds": 0.9999809861183167, "bytes": 4394844160, "bits_per_second": 35159421797.086105, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}], "sum": {"start": 2.000009, "end": 3.000006, "seconds": 0.9999970197677612, "bytes": 4315414528, "bits_per_second": 34523419111.80663, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}], "sum": {"start": 3.000006, "end": 4.000048, "seconds": 1.0000419616699219, "bytes": 4349886464, "bits_per_second": 34797631545.271034, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}], "sum": {"start": 4.000048, "end": 5.000028, "seconds": 0.9999799728393555, "bytes": 4430495744, "bits_per_second": 35444675808.21641, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}], "sum": {"start": 5.000028, "end": 6.000031, "seconds": 1.0000029802322388, "bytes": 4407427072, "bits_per_second": 35259311495.06316, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}], "sum": {"start": 6.000031, "end": 7.000009, "seconds": 0.9999780058860779, "bytes": 4397727744, "bits_per_second": 35182595762.019264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000027, "seconds": 1.0000180006027222, "bytes": 4317599700, "bits_per_second": 34540175856.016464, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}], "sum": {"start": 8.000027, "end": 9.000013, "seconds": 0.9999859929084778, "bytes": 4394844160, "bits_per_second": 35159245758.77319, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}], "sum": {"start": 9.000013, "end": 10.000067, "seconds": 1.0000540018081665, "bytes": 4418043904, "bits_per_second": 35342442676.19047, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040332, "seconds": 10.040332, "bytes": 43821410588, "bits_per_second": 34916304032.97421, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000067, "seconds": 10.000067, "bytes": 43820099868, "bits_per_second": 35055845020.238365, "sender": false}, "cpu_utilization_percent": {"host_total": 91.7129817857671, "host_user": 1.930649372470762, "host_system": 89.782322494473, "remote_total": 44.03409922696862, "remote_user": 0.28095210440615037, "remote_system": 43.75314712256247}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 47342, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:07 UTC", "timesecs": 1711485367}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "snd_cwnd": 841152, "rtt": 194, "rttvar": 62, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000658, "seconds": 1.0006580352783203, "bytes": 1519091984, "bits_per_second": 12144744201.868994, "retransmits": 186, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "snd_cwnd": 831716, "rtt": 212, "rttvar": 24, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000658, "end": 2.00053, "seconds": 0.9998720288276672, "bytes": 1496842240, "bits_per_second": 11976270537.380842, "retransmits": 69, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "snd_cwnd": 849240, "rtt": 240, "rttvar": 28, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.00053, "end": 3.000069, "seconds": 0.9995390176773071, "bytes": 1542717440, "bits_per_second": 12347431467.637243, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "snd_cwnd": 683436, "rtt": 355, "rttvar": 32, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000069, "end": 4.000792, "seconds": 1.0007230043411255, "bytes": 1482424320, "bits_per_second": 11850826361.095003, "retransmits": 21, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "snd_cwnd": 789928, "rtt": 201, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000792, "end": 5.000133, "seconds": 0.9993410110473633, "bytes": 1537474560, "bits_per_second": 12307907254.911064, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "snd_cwnd": 798016, "rtt": 187, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000133, "end": 6.000434, "seconds": 1.0003010034561157, "bytes": 1528299520, "bits_per_second": 12222717079.915821, "retransmits": 22, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "snd_cwnd": 823628, "rtt": 270, "rttvar": 39, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000434, "end": 7.000335, "seconds": 0.9999009966850281, "bytes": 1551892480, "bits_per_second": 12416369101.700983, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "snd_cwnd": 924728, "rtt": 210, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000335, "end": 8.00007, "seconds": 0.9997349977493286, "bytes": 1550581760, "bits_per_second": 12407942212.612543, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "snd_cwnd": 802060, "rtt": 187, "rttvar": 20, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.00007, "end": 9.000638, "seconds": 1.0005680322647095, "bytes": 1545338880, "bits_per_second": 12355692607.945854, "retransmits": 35, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "snd_cwnd": 851936, "rtt": 272, "rttvar": 22, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000638, "end": 10.000796, "seconds": 1.0001579523086548, "bytes": 1542717440, "bits_per_second": 12339790421.61459, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "max_snd_cwnd": 924728, "max_rtt": 355, "min_rtt": 187, "mean_rtt": 232, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040404, "seconds": 10.000796, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000796, "seconds": 10.000796, "bytes": 15297380624, "bits_per_second": 12236930439.537014, "retransmits": 333, "sender": true}, "sum_received": {"start": 0, "end": 10.040404, "seconds": 10.040404, "bytes": 15297378960, "bits_per_second": 12188656121.805456, "sender": true}, "cpu_utilization_percent": {"host_total": 94.61572077164762, "host_user": 0.29949784294138804, "host_system": 94.31623284257061, "remote_total": 24.200736107154952, "remote_user": 0.7375246434410879, "remote_system": 23.463211463713865}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 48142, "remote_host": "172.30.13.191", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:19 UTC", "timesecs": 1711485379}, "connecting_to": {"host": "172.30.13.191", "port": 5201}, "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000003, "seconds": 1.0000029802322388, "bytes": 1743350008, "bits_per_second": 13946758499.420694, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}], "sum": {"start": 1.000003, "end": 2.000012, "seconds": 1.0000089406967163, "bytes": 1755937152, "bits_per_second": 14047371622.71066, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}], "sum": {"start": 2.000012, "end": 3.00001, "seconds": 0.9999979734420776, "bytes": 1733808384, "bits_per_second": 13870495181.361897, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}], "sum": {"start": 3.00001, "end": 4.000018, "seconds": 1.0000079870224, "bytes": 1738644752, "bits_per_second": 13909046924.130655, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}], "sum": {"start": 4.000018, "end": 5.000023, "seconds": 1.0000050067901611, "bytes": 1737561216, "bits_per_second": 13900420131.51325, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}], "sum": {"start": 5.000023, "end": 6.000056, "seconds": 1.0000330209732056, "bytes": 1736454280, "bits_per_second": 13891175539.864704, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}], "sum": {"start": 6.000056, "end": 7.000026, "seconds": 0.999970018863678, "bytes": 1727790912, "bits_per_second": 13822741717.503777, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}], "sum": {"start": 7.000026, "end": 8.000019, "seconds": 0.9999930262565613, "bytes": 1724361600, "bits_per_second": 13794989002.714045, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}], "sum": {"start": 8.000019, "end": 9.000026, "seconds": 1.0000070333480835, "bytes": 1740731712, "bits_per_second": 13925755751.312475, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}], "sum": {"start": 9.000026, "end": 10.000039, "seconds": 1.000012993812561, "bytes": 1729926144, "bits_per_second": 13839229327.648127, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039511, "seconds": 10.039511, "bytes": 17371187600, "bits_per_second": 13842257934.674309, "retransmits": 2068, "sender": false}, "sum_received": {"start": 0, "end": 10.000039, "seconds": 10.000039, "bytes": 17368566160, "bits_per_second": 13894798738.284922, "sender": false}, "cpu_utilization_percent": {"host_total": 44.48791626719862, "host_user": 1.6040884366461445, "host_system": 42.883837750090144, "remote_total": 12.877414932148609, "remote_user": 0.20340289771075803, "remote_system": 12.674021700497715}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39362, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:36 UTC", "timesecs": 1711485396}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "snd_cwnd": 412488, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000203, "seconds": 1.000203013420105, "bytes": 3477340160, "bits_per_second": 27813074852.55055, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "snd_cwnd": 412488, "rtt": 33, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000203, "end": 2.000079, "seconds": 0.9998760223388672, "bytes": 3461611520, "bits_per_second": 27696325885.70528, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "snd_cwnd": 599860, "rtt": 31, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000079, "end": 3.000169, "seconds": 1.0000900030136108, "bytes": 3432745096, "bits_per_second": 27459489331.207977, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "snd_cwnd": 769708, "rtt": 31, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000169, "end": 4.000043, "seconds": 0.9998739957809448, "bytes": 3490447360, "bits_per_second": 27927097812.1503, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "snd_cwnd": 769708, "rtt": 33, "rttvar": 8, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000043, "end": 5.000105, "seconds": 1.0000619888305664, "bytes": 3575644160, "bits_per_second": 28603380189.91178, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 7, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000105, "end": 6.000004, "seconds": 0.9998990297317505, "bytes": 3565158400, "bits_per_second": 28524147290.80354, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000004, "end": 7.000302, "seconds": 1.000298023223877, "bytes": 3586129920, "bits_per_second": 28680491907.339397, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000302, "end": 8.000114, "seconds": 0.9998120069503784, "bytes": 3579576320, "bits_per_second": 28641995055.99782, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 6, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000114, "end": 9.000032, "seconds": 0.9999179840087891, "bytes": 3584819200, "bits_per_second": 28680905892.925636, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "snd_cwnd": 769708, "rtt": 32, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000032, "end": 10.000166, "seconds": 1.000133991241455, "bytes": 3587440640, "bits_per_second": 28695680150.192276, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "max_snd_cwnd": 769708, "max_rtt": 33, "min_rtt": 31, "mean_rtt": 32, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040211, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000166, "seconds": 10.000166, "bytes": 35340912776, "bits_per_second": 28272260901.26904, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.040211, "seconds": 10.040211, "bytes": 35340912776, "bits_per_second": 28159498063.138317, "sender": true}, "cpu_utilization_percent": {"host_total": 98.19888011381254, "host_user": 0.5898692408770353, "host_system": 97.6090108729355, "remote_total": 71.89727658532618, "remote_user": 1.9320023444980647, "remote_system": 69.96528325535468}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 37670, "remote_host": "172.30.206.242", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:36:48 UTC", "timesecs": 1711485408}, "connecting_to": {"host": "172.30.206.242", "port": 5201}, "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000002, "seconds": 1.0000020265579224, "bytes": 3779153100, "bits_per_second": 30233163530.742928, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}], "sum": {"start": 1.000002, "end": 2.000029, "seconds": 1.0000269412994385, "bytes": 3791519744, "bits_per_second": 30331340786.265507, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}], "sum": {"start": 2.000029, "end": 3.000014, "seconds": 0.9999849796295166, "bytes": 3791519744, "bits_per_second": 30332613559.093388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}], "sum": {"start": 3.000014, "end": 4.000004, "seconds": 0.9999899864196777, "bytes": 3793747968, "bits_per_second": 30350287659.043278, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}], "sum": {"start": 4.000004, "end": 5.000013, "seconds": 1.0000089406967163, "bytes": 3797024768, "bits_per_second": 30375926562.05313, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}], "sum": {"start": 5.000013, "end": 6.000018, "seconds": 1.0000050067901611, "bytes": 3796106948, "bits_per_second": 30368703534.273937, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}], "sum": {"start": 6.000018, "end": 7.000009, "seconds": 0.9999909996986389, "bytes": 3778281788, "bits_per_second": 30226526351.846264, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}], "sum": {"start": 7.000009, "end": 8.000013, "seconds": 1.0000040531158447, "bytes": 3812884480, "bits_per_second": 30502952208.001095, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}], "sum": {"start": 8.000013, "end": 9.000017, "seconds": 1.0000040531158447, "bytes": 3806855168, "bits_per_second": 30454717907.5003, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}], "sum": {"start": 9.000017, "end": 10.000014, "seconds": 0.9999970197677612, "bytes": 3791650816, "bits_per_second": 30333296928.269413, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040168, "seconds": 10.040168, "bytes": 37939793100, "bits_per_second": 30230404989.239223, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000014, "seconds": 10.000014, "bytes": 37938744524, "bits_per_second": 30350953127.86562, "sender": false}, "cpu_utilization_percent": {"host_total": 89.35457193175537, "host_user": 2.1531064410889655, "host_system": 87.20146549066642, "remote_total": 96.25175156651449, "remote_user": 0.5483803525296743, "remote_system": 95.70338087979988}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 39876, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:05 UTC", "timesecs": 1711485425}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1011, "rttvar": 17, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000173, "seconds": 1.0001729726791382, "bytes": 2929832972, "bits_per_second": 23434610228.684185, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "snd_cwnd": 3301252, "rtt": 1030, "rttvar": 18, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000173, "end": 2.000056, "seconds": 0.9998829960823059, "bytes": 2926837760, "bits_per_second": 23417442012.457832, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "snd_cwnd": 2109620, "rtt": 718, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000056, "end": 3.000045, "seconds": 0.9999889731407166, "bytes": 2924216320, "bits_per_second": 23393988522.219513, "retransmits": 1071, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "snd_cwnd": 2934596, "rtt": 882, "rttvar": 9, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000045, "end": 4.000057, "seconds": 1.0000120401382446, "bytes": 2926837760, "bits_per_second": 23414420167.144268, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "snd_cwnd": 2067832, "rtt": 699, "rttvar": 11, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000057, "end": 5.000134, "seconds": 1.0000770092010498, "bytes": 2925527040, "bits_per_second": 23402414118.786076, "retransmits": 680, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "snd_cwnd": 2143320, "rtt": 731, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000134, "end": 6.000072, "seconds": 0.9999380111694336, "bytes": 2925527040, "bits_per_second": 23405667209.938972, "retransmits": 576, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "snd_cwnd": 2985820, "rtt": 1004, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000072, "end": 7.000057, "seconds": 0.9999849796295166, "bytes": 2926837760, "bits_per_second": 23415053782.782707, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "snd_cwnd": 3150276, "rtt": 1131, "rttvar": 47, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000057, "end": 8.000151, "seconds": 1.0000940561294556, "bytes": 2928148480, "bits_per_second": 23422984764.712734, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "snd_cwnd": 2446620, "rtt": 816, "rttvar": 5, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000151, "end": 9.00006, "seconds": 0.999908983707428, "bytes": 2926837760, "bits_per_second": 23416833393.35924, "retransmits": 536, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "snd_cwnd": 3163756, "rtt": 1040, "rttvar": 2, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.00006, "end": 10.000062, "seconds": 1.0000020265579224, "bytes": 2928148480, "bits_per_second": 23425140367.596207, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "max_snd_cwnd": 3301252, "max_rtt": 1131, "min_rtt": 699, "mean_rtt": 906, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.040299, "seconds": 10.000062, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 29268751372, "bits_per_second": 23414855925.493263, "retransmits": 2863, "sender": true}, "sum_received": {"start": 0, "end": 10.040299, "seconds": 10.040299, "bytes": 29268042576, "bits_per_second": 23320454959.35928, "sender": true}, "cpu_utilization_percent": {"host_total": 36.61979232353807, "host_user": 0.5177138138716962, "host_system": 36.10208842470637, "remote_total": 63.645622998347704, "remote_user": 2.779808989119691, "remote_system": 60.86582297594884}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "169.254.169.2", "local_port": 49506, "remote_host": "172.30.99.196", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:17 UTC", "timesecs": 1711485437}, "connecting_to": {"host": "172.30.99.196", "port": 5201}, "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00003, "seconds": 1.0000300407409668, "bytes": 2928081096, "bits_per_second": 23423945095.33297, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}], "sum": {"start": 1.00003, "end": 2.00001, "seconds": 0.9999799728393555, "bytes": 2924874236, "bits_per_second": 23399462512.79474, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 2928934064, "bits_per_second": 23431098222.587284, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000006, "seconds": 0.9999799728393555, "bytes": 2927109320, "bits_per_second": 23417343542.901, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}], "sum": {"start": 4.000006, "end": 5.000015, "seconds": 1.0000089406967163, "bytes": 2928650940, "bits_per_second": 23428998048.434082, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}], "sum": {"start": 5.000015, "end": 6.00002, "seconds": 1.0000050067901611, "bytes": 2928599620, "bits_per_second": 23428679657.517204, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}], "sum": {"start": 6.00002, "end": 7.000018, "seconds": 0.9999979734420776, "bytes": 2903162060, "bits_per_second": 23225343547.503967, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}], "sum": {"start": 7.000018, "end": 8.000028, "seconds": 1.0000100135803223, "bytes": 2520932544, "bits_per_second": 20167258405.538074, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}], "sum": {"start": 8.000028, "end": 9.000012, "seconds": 0.9999840259552002, "bytes": 2699663148, "bits_per_second": 21597650185.83164, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}], "sum": {"start": 9.000012, "end": 10.000011, "seconds": 0.9999989867210388, "bytes": 2927449024, "bits_per_second": 23419615922.60409, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}}], "sum_sent": {"start": 0, "end": 10.039579, "seconds": 10.039579, "bytes": 28621053072, "bits_per_second": 22806576309.225716, "retransmits": 2146, "sender": false}, "sum_received": {"start": 0, "end": 10.000011, "seconds": 10.000011, "bytes": 28617456052, "bits_per_second": 22893939658.266373, "sender": false}, "cpu_utilization_percent": {"host_total": 86.71637462053445, "host_user": 2.3097157068484533, "host_system": 84.40665891368599, "remote_total": 20.40828750936386, "remote_user": 0.3775983988088474, "remote_system": 20.030689110555013}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 38034, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:34 UTC", "timesecs": 1711485454}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2566, "rttvar": 70, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000058, "seconds": 1.0000580549240112, "bytes": 1174382536, "bits_per_second": 9394514890.15193, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2504, "rttvar": 111, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 1.000058, "end": 2.000058, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "snd_cwnd": 3298556, "rtt": 2578, "rttvar": 100, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 2.000058, "end": 3.000005, "seconds": 0.9999470114707947, "bytes": 1171783680, "bits_per_second": 9374766195.07232, "retransmits": 13, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2548, "rttvar": 49, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 3.000005, "end": 4.000059, "seconds": 1.0000540018081665, "bytes": 1171783680, "bits_per_second": 9373763239.835724, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2544, "rttvar": 76, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 4.000059, "end": 5.000059, "seconds": 1, "bytes": 1171783680, "bits_per_second": 9374269440, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2626, "rttvar": 71, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000092, "seconds": 1.0000330209732056, "bytes": 1171783680, "bits_per_second": 9373959902.721222, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2637, "rttvar": 87, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 6.000092, "end": 7.000102, "seconds": 1.0000100135803223, "bytes": 1171783680, "bits_per_second": 9374175570.939966, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2584, "rttvar": 65, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 7.000102, "end": 8.000204, "seconds": 1.0001020431518555, "bytes": 1171783680, "bits_per_second": 9373312957.602478, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2646, "rttvar": 50, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 8.000204, "end": 9.000059, "seconds": 0.9998549818992615, "bytes": 1170472960, "bits_per_second": 9365141795.07627, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "snd_cwnd": 3298556, "rtt": 2624, "rttvar": 91, "pmtu": 1400, "omitted": false, "sender": true}], "sum": {"start": 9.000059, "end": 10.000063, "seconds": 1.0000040531158447, "bytes": 1171783680, "bits_per_second": 9374231445.153997, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "max_snd_cwnd": 3298556, "max_rtt": 2646, "min_rtt": 2504, "mean_rtt": 2585, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042436, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000063, "seconds": 10.000063, "bytes": 11719124936, "bits_per_second": 9375240884.782425, "retransmits": 13, "sender": true}, "sum_received": {"start": 0, "end": 10.042436, "seconds": 10.042436, "bytes": 11719124936, "bits_per_second": 9335683044.23349, "sender": true}, "cpu_utilization_percent": {"host_total": 8.581878883067088, "host_user": 0.24757613109832505, "host_system": 8.334302751968762, "remote_total": 17.882794832888134, "remote_user": 0.6213889785332932, "remote_system": 17.261397456752558}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "POD_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "SRIOV", "is_tenant": true, "index": 0}}, "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "10.131.1.196", "local_port": 59786, "remote_host": "10.88.0.5", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:37:44 UTC", "timesecs": 1711485464}, "connecting_to": {"host": "10.88.0.5", "port": 5201}, "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl", "tcp_mss_default": 1348, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.00001, "seconds": 1.0000100135803223, "bytes": 1171526660, "bits_per_second": 9372119431.529282, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}], "sum": {"start": 1.00001, "end": 2.00001, "seconds": 1, "bytes": 1171728636, "bits_per_second": 9373829088, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}], "sum": {"start": 2.00001, "end": 3.000026, "seconds": 1.0000159740447998, "bytes": 1171634728, "bits_per_second": 9372928100.426619, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}], "sum": {"start": 3.000026, "end": 4.000003, "seconds": 0.9999769926071167, "bytes": 1171698712, "bits_per_second": 9373805362.822794, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}], "sum": {"start": 4.000003, "end": 5.000019, "seconds": 1.0000159740447998, "bytes": 1171728612, "bits_per_second": 9373679160.429152, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}], "sum": {"start": 5.000019, "end": 6.000033, "seconds": 1.0000139474868774, "bytes": 1171430044, "bits_per_second": 9371309645.78169, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}], "sum": {"start": 6.000033, "end": 7.000019, "seconds": 0.9999859929084778, "bytes": 1171711552, "bits_per_second": 9373823716.006702, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}], "sum": {"start": 7.000019, "end": 8.000005, "seconds": 0.9999859929084778, "bytes": 1171704164, "bits_per_second": 9373764611.178816, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}], "sum": {"start": 8.000005, "end": 9.000005, "seconds": 1, "bytes": 1171264340, "bits_per_second": 9370114720, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}], "sum": {"start": 9.000005, "end": 10.000025, "seconds": 1.0000200271606445, "bytes": 1171724928, "bits_per_second": 9373611697.172722, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040362, "seconds": 10.040362, "bytes": 11719168912, "bits_per_second": 9337646520.713099, "retransmits": 1, "sender": false}, "sum_received": {"start": 0, "end": 10.000025, "seconds": 10.000025, "bytes": 11716152376, "bits_per_second": 9372898468.553827, "sender": false}, "cpu_utilization_percent": {"host_total": 34.12079215423493, "host_user": 1.449299942928998, "host_system": 32.671502129797744, "remote_total": 9.21759648553234, "remote_user": 0.13056616222089867, "remote_system": 9.087020816528113}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": false, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 42748, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:01 UTC", "timesecs": 1711485481}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 0, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2528, "rttvar": 68, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 0, "end": 1.000059, "seconds": 1.0000590085983276, "bytes": 1180082728, "bits_per_second": 9440104776.649063, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2635, "rttvar": 38, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 1.000059, "end": 2.000103, "seconds": 1.0000439882278442, "bytes": 1177026560, "bits_per_second": 9415798295.719233, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2580, "rttvar": 45, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 2.000103, "end": 3.000059, "seconds": 0.9999560117721558, "bytes": 1175715840, "bits_per_second": 9406140479.450544, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2614, "rttvar": 61, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 3.000059, "end": 4.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2540, "rttvar": 36, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 4.000058, "end": 5.000059, "seconds": 1.0000009536743164, "bytes": 1177026560, "bits_per_second": 9416203500.008564, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2532, "rttvar": 66, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 5.000059, "end": 6.000058, "seconds": 0.9999989867210388, "bytes": 1177026560, "bits_per_second": 9416222021.259668, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2621, "rttvar": 26, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 6.000058, "end": 7.00006, "seconds": 1.0000020265579224, "bytes": 1177026560, "bits_per_second": 9416193397.538671, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2647, "rttvar": 79, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 7.00006, "end": 8.000058, "seconds": 0.9999979734420776, "bytes": 1175715840, "bits_per_second": 9405745781.28863, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2616, "rttvar": 57, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 8.000058, "end": 9.000058, "seconds": 1, "bytes": 1177026560, "bits_per_second": 9416212480, "retransmits": 0, "omitted": false, "sender": true}}, {"streams": [{"socket": 5, "start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "snd_cwnd": 3302888, "rtt": 2608, "rttvar": 75, "pmtu": 1500, "omitted": false, "sender": true}], "sum": {"start": 9.000058, "end": 10.000062, "seconds": 1.0000040531158447, "bytes": 1177026560, "bits_per_second": 9416174315.154686, "retransmits": 0, "omitted": false, "sender": true}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "max_snd_cwnd": 3302888, "max_rtt": 2647, "min_rtt": 2528, "mean_rtt": 2592, "sender": true}, "receiver": {"socket": 5, "start": 0, "end": 10.042832, "seconds": 10.000062, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}}], "sum_sent": {"start": 0, "end": 10.000062, "seconds": 10.000062, "bytes": 11770700328, "bits_per_second": 9416501880.088345, "retransmits": 0, "sender": true}, "sum_received": {"start": 0, "end": 10.042832, "seconds": 10.042832, "bytes": 11770469264, "bits_per_second": 9376215206.228682, "sender": true}, "cpu_utilization_percent": {"host_total": 9.991931328513951, "host_user": 0.30260245650629003, "host_system": 9.689348708938175, "remote_total": 19.41962833866342, "remote_user": 0.6099473016485951, "remote_system": 18.809681037014826}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}, {"flow_test": {"tft_metadata": {"test_case_id": "HOST_TO_EXTERNAL", "test_type": "IPERF_TCP", "reverse": true, "server": {"name": "worker-241", "pod_type": "SRIOV", "is_tenant": true, "index": 0}, "client": {"name": "worker-242", "pod_type": "HOSTBACKED", "is_tenant": true, "index": 0}}, "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R", "result": {"start": {"connected": [{"socket": 5, "local_host": "192.168.122.218", "local_port": 58986, "remote_host": "10.88.0.6", "remote_port": 5201}], "version": "iperf 3.7", "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64", "timestamp": {"time": "Tue, 26 Mar 2024 20:38:11 UTC", "timesecs": 1711485491}, "connecting_to": {"host": "10.88.0.6", "port": 5201}, "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo", "tcp_mss_default": 1448, "sock_bufsize": 0, "sndbuf_actual": 16384, "rcvbuf_actual": 131072, "test_start": {"protocol": "TCP", "num_streams": 1, "blksize": 131072, "omit": 0, "duration": 10, "bytes": 0, "blocks": 0, "reverse": 1, "tos": 0}}, "intervals": [{"streams": [{"socket": 5, "start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}], "sum": {"start": 0, "end": 1.000006, "seconds": 1.0000059604644775, "bytes": 1176615352, "bits_per_second": 9412866710.942337, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}], "sum": {"start": 1.000006, "end": 2.000016, "seconds": 1.0000100135803223, "bytes": 1176524120, "bits_per_second": 9412098711.193554, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}], "sum": {"start": 2.000016, "end": 3.000009, "seconds": 0.9999930262565613, "bytes": 1176810760, "bits_per_second": 9414551734.668388, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}], "sum": {"start": 3.000009, "end": 4.000007, "seconds": 0.9999979734420776, "bytes": 1176810048, "bits_per_second": 9414499463.028471, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}], "sum": {"start": 4.000007, "end": 5.000007, "seconds": 1, "bytes": 1176803976, "bits_per_second": 9414431808, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}], "sum": {"start": 5.000007, "end": 6.000009, "seconds": 1.0000020265579224, "bytes": 1176724064, "bits_per_second": 9413773434.442867, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}], "sum": {"start": 6.000009, "end": 7.000003, "seconds": 0.9999939799308777, "bytes": 1176792016, "bits_per_second": 9414392803.29542, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}], "sum": {"start": 7.000003, "end": 8.000015, "seconds": 1.0000120401382446, "bytes": 1176820328, "bits_per_second": 9414449272.72926, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}], "sum": {"start": 8.000015, "end": 9.000011, "seconds": 0.9999960064888, "bytes": 1176491696, "bits_per_second": 9411971154.81222, "omitted": false, "sender": false}}, {"streams": [{"socket": 5, "start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}], "sum": {"start": 9.000011, "end": 10.000015, "seconds": 1.0000040531158447, "bytes": 1176819760, "bits_per_second": 9414519921.860134, "omitted": false, "sender": false}}], "end": {"streams": [{"sender": {"socket": 5, "start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "max_snd_cwnd": 0, "max_rtt": 0, "min_rtt": 0, "mean_rtt": 0, "sender": false}, "receiver": {"socket": 5, "start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}}], "sum_sent": {"start": 0, "end": 10.040305, "seconds": 10.040305, "bytes": 11770238744, "bits_per_second": 9378391388.707813, "retransmits": 0, "sender": false}, "sum_received": {"start": 0, "end": 10.000015, "seconds": 10.000015, "bytes": 11767212120, "bits_per_second": 9413755575.366638, "sender": false}, "cpu_utilization_percent": {"host_total": 48.724054060084946, "host_user": 3.9110899538590087, "host_system": 44.81297402368786, "remote_total": 7.595950273368541, "remote_user": 0.15972436790366432, "remote_system": 7.436225905464877}, "sender_tcp_congestion": "cubic", "receiver_tcp_congestion": "cubic"}}}, "plugins": []}]}
+{
+  "tft-tests": [
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "invalid_pod_type",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 56762,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:32 UTC",
+              "timesecs": 1711484912
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "tvf3da7t2lviu42da4ngi2frscubyebbo53j",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000191,
+                  "seconds": 1.0001909732818604,
+                  "bytes": 4895539200,
+                  "bits_per_second": 39156835690.5809,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000191,
+                "seconds": 1.0001909732818604,
+                "bytes": 4895539200,
+                "bits_per_second": 39156835690.5809,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000191,
+                  "end": 2.000081,
+                  "seconds": 0.9998900294303894,
+                  "bytes": 4911267840,
+                  "bits_per_second": 39294463954.583626,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000191,
+                "end": 2.000081,
+                "seconds": 0.9998900294303894,
+                "bytes": 4911267840,
+                "bits_per_second": 39294463954.583626,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000081,
+                  "end": 3.000218,
+                  "seconds": 1.0001369714736938,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38781514278.83715,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 27,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000081,
+                "end": 3.000218,
+                "seconds": 1.0001369714736938,
+                "bytes": 4848353280,
+                "bits_per_second": 38781514278.83715,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000218,
+                  "end": 4.000267,
+                  "seconds": 1.0000489950180054,
+                  "bytes": 4840488960,
+                  "bits_per_second": 38722014494.20265,
+                  "retransmits": 0,
+                  "snd_cwnd": 502804,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000218,
+                "end": 4.000267,
+                "seconds": 1.0000489950180054,
+                "bytes": 4840488960,
+                "bits_per_second": 38722014494.20265,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000247,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4881121280,
+                  "bits_per_second": 39049752295.66235,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 29,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000247,
+                "seconds": 0.9999799728393555,
+                "bytes": 4881121280,
+                "bits_per_second": 39049752295.66235,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000247,
+                  "end": 6.00002,
+                  "seconds": 0.9997730255126953,
+                  "bytes": 4856217600,
+                  "bits_per_second": 38858560701.89271,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000247,
+                "end": 6.00002,
+                "seconds": 0.9997730255126953,
+                "bytes": 4856217600,
+                "bits_per_second": 38858560701.89271,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000117,
+                  "seconds": 1.0000970363616943,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38825001843.07837,
+                  "retransmits": 0,
+                  "snd_cwnd": 528416,
+                  "rtt": 30,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000117,
+                "seconds": 1.0000970363616943,
+                "bytes": 4853596160,
+                "bits_per_second": 38825001843.07837,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000117,
+                  "end": 8.000116,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4864081920,
+                  "bits_per_second": 38912694789.414955,
+                  "retransmits": 0,
+                  "snd_cwnd": 591772,
+                  "rtt": 26,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000117,
+                "end": 8.000116,
+                "seconds": 0.9999989867210388,
+                "bytes": 4864081920,
+                "bits_per_second": 38912694789.414955,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000116,
+                  "end": 9.000019,
+                  "seconds": 0.9999030232429504,
+                  "bytes": 4836556800,
+                  "bits_per_second": 38696207032.668144,
+                  "retransmits": 99,
+                  "snd_cwnd": 621428,
+                  "rtt": 27,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000116,
+                "end": 9.000019,
+                "seconds": 0.9999030232429504,
+                "bytes": 4836556800,
+                "bits_per_second": 38696207032.668144,
+                "retransmits": 99,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000019,
+                  "end": 10.000269,
+                  "seconds": 1.000249981880188,
+                  "bytes": 4773642240,
+                  "bits_per_second": 38179593713.378716,
+                  "retransmits": 0,
+                  "snd_cwnd": 621428,
+                  "rtt": 25,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000019,
+                "end": 10.000269,
+                "seconds": 1.000249981880188,
+                "bytes": 4773642240,
+                "bits_per_second": 38179593713.378716,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000269,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38847647222.28973,
+                  "retransmits": 99,
+                  "max_snd_cwnd": 621428,
+                  "max_rtt": 30,
+                  "min_rtt": 25,
+                  "mean_rtt": 26,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040752,
+                  "seconds": 10.000269,
+                  "bytes": 48560865280,
+                  "bits_per_second": 38691018585.06216,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000269,
+              "seconds": 10.000269,
+              "bytes": 48560865280,
+              "bits_per_second": 38847647222.28973,
+              "retransmits": 99,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040752,
+              "seconds": 10.040752,
+              "bytes": 48560865280,
+              "bits_per_second": 38691018585.06216,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.95896032207571,
+              "host_user": 0.46109579260875955,
+              "host_system": 51.4978546106554,
+              "remote_total": 46.34560190202221,
+              "remote_user": 1.2743335369337774,
+              "remote_system": 45.07127657478376
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.131.1.179 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.180",
+                "local_port": 54270,
+                "remote_host": "10.131.1.179",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:28:43 UTC",
+              "timesecs": 1711484923
+            },
+            "connecting_to": {
+              "host": "10.131.1.179",
+              "port": 5201
+            },
+            "cookie": "t2neh5b6fwy3gzqwvawjkoq3y2ab7b2twoeu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000023,
+                  "seconds": 1.0000230073928833,
+                  "bytes": 5267935560,
+                  "bits_per_second": 42142514890.60282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000023,
+                "seconds": 1.0000230073928833,
+                "bytes": 5267935560,
+                "bits_per_second": 42142514890.60282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000023,
+                  "end": 2.000011,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5283380932,
+                  "bits_per_second": 42267553843.84901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000023,
+                "end": 2.000011,
+                "seconds": 0.9999880194664001,
+                "bytes": 5283380932,
+                "bits_per_second": 42267553843.84901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000011,
+                  "end": 3.000025,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5144593776,
+                  "bits_per_second": 41156176182.772766,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000011,
+                "end": 3.000025,
+                "seconds": 1.0000139474868774,
+                "bytes": 5144593776,
+                "bits_per_second": 41156176182.772766,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000025,
+                  "end": 4.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5313921024,
+                  "bits_per_second": 42511454343.92459,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000025,
+                "end": 4.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5313921024,
+                "bits_per_second": 42511454343.92459,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.000026,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 5324144640,
+                  "bits_per_second": 42593030182.8783,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.000026,
+                "seconds": 1.0000029802322388,
+                "bytes": 5324144640,
+                "bits_per_second": 42593030182.8783,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000026,
+                  "end": 6.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 5340397568,
+                  "bits_per_second": 42724036185.13606,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000026,
+                "end": 6.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 5340397568,
+                "bits_per_second": 42724036185.13606,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000006,
+                  "end": 7.000013,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 5317722112,
+                  "bits_per_second": 42541477686.97944,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000006,
+                "end": 7.000013,
+                "seconds": 1.0000070333480835,
+                "bytes": 5317722112,
+                "bits_per_second": 42541477686.97944,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000013,
+                  "end": 8.000023,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 5339086848,
+                  "bits_per_second": 42712267081.28284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000013,
+                "end": 8.000023,
+                "seconds": 1.0000100135803223,
+                "bytes": 5339086848,
+                "bits_per_second": 42712267081.28284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000023,
+                  "end": 9.000043,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5329256448,
+                  "bits_per_second": 42633197762.099625,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000023,
+                "end": 9.000043,
+                "seconds": 1.0000200271606445,
+                "bytes": 5329256448,
+                "bits_per_second": 42633197762.099625,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000043,
+                  "end": 10.000027,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5294784512,
+                  "bits_per_second": 42358952739.80874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000043,
+                "end": 10.000027,
+                "seconds": 0.9999840259552002,
+                "bytes": 5294784512,
+                "bits_per_second": 42358952739.80874,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040745,
+                  "seconds": 10.040745,
+                  "bytes": 52956665212,
+                  "bits_per_second": 42193415099.77596,
+                  "retransmits": 220,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000027,
+                  "seconds": 10.000027,
+                  "bytes": 52955223420,
+                  "bits_per_second": 42364064353.02625,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040745,
+              "seconds": 10.040745,
+              "bytes": 52956665212,
+              "bits_per_second": 42193415099.77596,
+              "retransmits": 220,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000027,
+              "seconds": 10.000027,
+              "bytes": 52955223420,
+              "bits_per_second": 42364064353.02625,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 59.961165048543684,
+              "host_user": 1.7074681645153693,
+              "host_system": 58.25370680355615,
+              "remote_total": 54.92808068462117,
+              "remote_user": 0.35009864909523675,
+              "remote_system": 54.57798203552594
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 43488,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:03 UTC",
+              "timesecs": 1711484943
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "4wg2dea62rklpkpw6lk3u3uluapi3374ouli",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1552629896,
+                  "bits_per_second": 12420331432.172485,
+                  "retransmits": 1162,
+                  "snd_cwnd": 858676,
+                  "rtt": 477,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1552629896,
+                "bits_per_second": 12420331432.172485,
+                "retransmits": 1162,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000057,
+                  "seconds": 1,
+                  "bytes": 1785895104,
+                  "bits_per_second": 14287160832,
+                  "retransmits": 250,
+                  "snd_cwnd": 864068,
+                  "rtt": 582,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000057,
+                "seconds": 1,
+                "bytes": 1785895104,
+                "bits_per_second": 14287160832,
+                "retransmits": 250,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1781226624,
+                  "bits_per_second": 14249799402.332296,
+                  "retransmits": 41,
+                  "snd_cwnd": 897768,
+                  "rtt": 469,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1781226624,
+                "bits_per_second": 14249799402.332296,
+                "retransmits": 41,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000058,
+                  "end": 4.000033,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 1770754368,
+                  "bits_per_second": 14166388740.29625,
+                  "retransmits": 43,
+                  "snd_cwnd": 843848,
+                  "rtt": 459,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000058,
+                "end": 4.000033,
+                "seconds": 0.9999750256538391,
+                "bytes": 1770754368,
+                "bits_per_second": 14166388740.29625,
+                "retransmits": 43,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000033,
+                  "end": 5.00012,
+                  "seconds": 1.000087022781372,
+                  "bytes": 1756157248,
+                  "bits_per_second": 14048035484.879292,
+                  "retransmits": 508,
+                  "snd_cwnd": 931468,
+                  "rtt": 278,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000033,
+                "end": 5.00012,
+                "seconds": 1.000087022781372,
+                "bytes": 1756157248,
+                "bits_per_second": 14048035484.879292,
+                "retransmits": 508,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00012,
+                  "end": 6.000058,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 1776470548,
+                  "bits_per_second": 14212645409.268175,
+                  "retransmits": 774,
+                  "snd_cwnd": 773752,
+                  "rtt": 389,
+                  "rttvar": 21,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.00012,
+                "end": 6.000058,
+                "seconds": 0.9999380111694336,
+                "bytes": 1776470548,
+                "bits_per_second": 14212645409.268175,
+                "retransmits": 774,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000214,
+                  "seconds": 1.000156044960022,
+                  "bytes": 1780520960,
+                  "bits_per_second": 14241945296.215616,
+                  "retransmits": 107,
+                  "snd_cwnd": 706352,
+                  "rtt": 351,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000214,
+                "seconds": 1.000156044960022,
+                "bytes": 1780520960,
+                "bits_per_second": 14241945296.215616,
+                "retransmits": 107,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000214,
+                  "end": 8.000165,
+                  "seconds": 0.9999510049819946,
+                  "bytes": 1782724608,
+                  "bits_per_second": 14262495655.23143,
+                  "retransmits": 103,
+                  "snd_cwnd": 957080,
+                  "rtt": 494,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000214,
+                "end": 8.000165,
+                "seconds": 0.9999510049819946,
+                "bytes": 1782724608,
+                "bits_per_second": 14262495655.23143,
+                "retransmits": 103,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000165,
+                  "end": 9.000061,
+                  "seconds": 0.9998959898948669,
+                  "bytes": 1708298368,
+                  "bits_per_second": 13667808534.202581,
+                  "retransmits": 636,
+                  "snd_cwnd": 668608,
+                  "rtt": 406,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000165,
+                "end": 9.000061,
+                "seconds": 0.9998959898948669,
+                "bytes": 1708298368,
+                "bits_per_second": 13667808534.202581,
+                "retransmits": 636,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000061,
+                  "end": 10.000067,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1711744320,
+                  "bits_per_second": 13693872938.156792,
+                  "retransmits": 37,
+                  "snd_cwnd": 835760,
+                  "rtt": 417,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000061,
+                "end": 10.000067,
+                "seconds": 1.0000059604644775,
+                "bytes": 1711744320,
+                "bits_per_second": 13693872938.156792,
+                "retransmits": 37,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 17406422044,
+                  "bits_per_second": 13925044337.40294,
+                  "retransmits": 3661,
+                  "max_snd_cwnd": 957080,
+                  "max_rtt": 582,
+                  "min_rtt": 278,
+                  "mean_rtt": 432,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040323,
+                  "seconds": 10.000067,
+                  "bytes": 17404804444,
+                  "bits_per_second": 13867923925.554983,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 17406422044,
+              "bits_per_second": 13925044337.40294,
+              "retransmits": 3661,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040323,
+              "seconds": 10.040323,
+              "bytes": 17404804444,
+              "bits_per_second": 13867923925.554983,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.428581942246796,
+              "host_user": 0.18264039451277397,
+              "host_system": 13.245951466295686,
+              "remote_total": 23.0189867907264,
+              "remote_user": 0.650631880001117,
+              "remote_system": 22.368346697024506
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.129.2.18 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.181",
+                "local_port": 52702,
+                "remote_host": "10.129.2.18",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:14 UTC",
+              "timesecs": 1711484954
+            },
+            "connecting_to": {
+              "host": "10.129.2.18",
+              "port": 5201
+            },
+            "cookie": "mgzv7xrfh2x352hkx3zq4b3hzxpzdpaxaswu",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 1769360536,
+                  "bits_per_second": 14154529944.193699,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 1769360536,
+                "bits_per_second": 14154529944.193699,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000056,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 1654294820,
+                  "bits_per_second": 13233948381.508026,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000056,
+                "seconds": 1.0000309944152832,
+                "bytes": 1654294820,
+                "bits_per_second": 13233948381.508026,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000002,
+                  "seconds": 0.9999459981918335,
+                  "bytes": 1693522048,
+                  "bits_per_second": 13548908049.533356,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000002,
+                "seconds": 0.9999459981918335,
+                "bytes": 1693522048,
+                "bits_per_second": 13548908049.533356,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000002,
+                  "end": 4.000058,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1778357520,
+                  "bits_per_second": 14226063096.928802,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000002,
+                "end": 4.000058,
+                "seconds": 1.0000560283660889,
+                "bytes": 1778357520,
+                "bits_per_second": 14226063096.928802,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000058,
+                  "seconds": 1,
+                  "bytes": 1699132892,
+                  "bits_per_second": 13593063136,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000058,
+                "seconds": 1,
+                "bytes": 1699132892,
+                "bits_per_second": 13593063136,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1776734848,
+                  "bits_per_second": 14214631996.442686,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1776734848,
+                "bits_per_second": 14214631996.442686,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000005,
+                  "end": 7.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1770689664,
+                  "bits_per_second": 14165319741.388792,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000005,
+                "end": 7.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 1770689664,
+                "bits_per_second": 14165319741.388792,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.00003,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1596714580,
+                  "bits_per_second": 12773576548.933342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.00003,
+                "seconds": 1.0000109672546387,
+                "bytes": 1596714580,
+                "bits_per_second": 12773576548.933342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000056,
+                  "seconds": 1.000025987625122,
+                  "bytes": 1650146112,
+                  "bits_per_second": 13200825837.886824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000056,
+                "seconds": 1.000025987625122,
+                "bytes": 1650146112,
+                "bits_per_second": 13200825837.886824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000056,
+                  "end": 10.00005,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1544969596,
+                  "bits_per_second": 12359831175.038013,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000056,
+                "end": 10.00005,
+                "seconds": 0.9999939799308777,
+                "bytes": 1544969596,
+                "bits_per_second": 12359831175.038013,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039981,
+                  "seconds": 10.039981,
+                  "bytes": 16936819512,
+                  "bits_per_second": 13495499254.032454,
+                  "retransmits": 2334,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00005,
+                  "seconds": 10.00005,
+                  "bytes": 16933922616,
+                  "bits_per_second": 13547070357.448214,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039981,
+              "seconds": 10.039981,
+              "bytes": 16936819512,
+              "bits_per_second": 13495499254.032454,
+              "retransmits": 2334,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00005,
+              "seconds": 10.00005,
+              "bytes": 16933922616,
+              "bits_per_second": 13547070357.448214,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 27.136162389258295,
+              "host_user": 1.0734065668100488,
+              "host_system": 26.062755822448246,
+              "remote_total": 12.134681085322041,
+              "remote_user": 0.20150770671204546,
+              "remote_system": 11.933173378609997
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 37248,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:34 UTC",
+              "timesecs": 1711484974
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "nkfczfnzgo7jjy53lfovighnk6nlb4ahilk7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000223,
+                  "seconds": 1.0002230405807495,
+                  "bytes": 4827381760,
+                  "bits_per_second": 38610442384.50756,
+                  "retransmits": 0,
+                  "snd_cwnd": 477192,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000223,
+                "seconds": 1.0002230405807495,
+                "bytes": 4827381760,
+                "bits_per_second": 38610442384.50756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000223,
+                  "end": 2.000162,
+                  "seconds": 0.9999390244483948,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38799677831.7579,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000223,
+                "end": 2.000162,
+                "seconds": 0.9999390244483948,
+                "bytes": 4849664000,
+                "bits_per_second": 38799677831.7579,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000162,
+                  "end": 3.000191,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 4826247500,
+                  "bits_per_second": 38608861584.00477,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000162,
+                "end": 3.000191,
+                "seconds": 1.0000289678573608,
+                "bytes": 4826247500,
+                "bits_per_second": 38608861584.00477,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000191,
+                  "end": 4.00012,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4861460480,
+                  "bits_per_second": 38894444922.881874,
+                  "retransmits": 0,
+                  "snd_cwnd": 1035264,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000191,
+                "end": 4.00012,
+                "seconds": 0.9999290108680725,
+                "bytes": 4861460480,
+                "bits_per_second": 38894444922.881874,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00012,
+                  "end": 5.000266,
+                  "seconds": 1.0001460313796997,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38487604562.00447,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.00012,
+                "end": 5.000266,
+                "seconds": 1.0001460313796997,
+                "bytes": 4811653120,
+                "bits_per_second": 38487604562.00447,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000266,
+                  "end": 6.000154,
+                  "seconds": 0.999888002872467,
+                  "bytes": 4818206720,
+                  "bits_per_second": 38549971246.046036,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000266,
+                "end": 6.000154,
+                "seconds": 0.999888002872467,
+                "bytes": 4818206720,
+                "bits_per_second": 38549971246.046036,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000154,
+                  "end": 7.000089,
+                  "seconds": 0.99993497133255,
+                  "bytes": 4853596160,
+                  "bits_per_second": 38831294427.33196,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000154,
+                "end": 7.000089,
+                "seconds": 0.99993497133255,
+                "bytes": 4853596160,
+                "bits_per_second": 38831294427.33196,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000089,
+                  "end": 8.000143,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4870635520,
+                  "bits_per_second": 38962980088.62366,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000089,
+                "end": 8.000143,
+                "seconds": 1.0000540018081665,
+                "bytes": 4870635520,
+                "bits_per_second": 38962980088.62366,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000143,
+                  "end": 9.000159,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4849664000,
+                  "bits_per_second": 38796692259.89976,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000143,
+                "end": 9.000159,
+                "seconds": 1.0000159740447998,
+                "bytes": 4849664000,
+                "bits_per_second": 38796692259.89976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000159,
+                  "end": 10.000248,
+                  "seconds": 1.0000890493392944,
+                  "bytes": 4823449600,
+                  "bits_per_second": 38584160905.964096,
+                  "retransmits": 0,
+                  "snd_cwnd": 1412704,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000159,
+                "end": 10.000248,
+                "seconds": 1.0000890493392944,
+                "bytes": 4823449600,
+                "bits_per_second": 38584160905.964096,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000248,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38712607015.34602,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1412704,
+                  "max_rtt": 24,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040463,
+                  "seconds": 10.000248,
+                  "bytes": 48391958860,
+                  "bits_per_second": 38557551666.69106,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000248,
+              "seconds": 10.000248,
+              "bytes": 48391958860,
+              "bits_per_second": 38712607015.34602,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040463,
+              "seconds": 10.040463,
+              "bytes": 48391958860,
+              "bits_per_second": 38557551666.69106,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.42879332323217,
+              "host_user": 0.48554830964161494,
+              "host_system": 50.94323509492755,
+              "remote_total": 45.16438235241609,
+              "remote_user": 1.4607549345618025,
+              "remote_system": 43.703627417854285
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.76.3 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.183",
+                "local_port": 42348,
+                "remote_host": "172.30.76.3",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:29:45 UTC",
+              "timesecs": 1711484985
+            },
+            "connecting_to": {
+              "host": "172.30.76.3",
+              "port": 5201
+            },
+            "cookie": "qkmoajq543vboergrimgv5n65pbb6enljb2g",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5317084948,
+                  "bits_per_second": 42536086312.49434,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 5317084948,
+                "bits_per_second": 42536086312.49434,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000016,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 5316804608,
+                  "bits_per_second": 42534350665.67468,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000016,
+                "seconds": 1.0000020265579224,
+                "bytes": 5316804608,
+                "bits_per_second": 42534350665.67468,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000013,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5298323456,
+                  "bits_per_second": 42386713970.25147,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000013,
+                "seconds": 0.9999970197677612,
+                "bytes": 5298323456,
+                "bits_per_second": 42386713970.25147,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000013,
+                  "end": 4.000027,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5347213312,
+                  "bits_per_second": 42777109862.82153,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000013,
+                "end": 4.000027,
+                "seconds": 1.0000139474868774,
+                "bytes": 5347213312,
+                "bits_per_second": 42777109862.82153,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000027,
+                  "end": 5.000006,
+                  "seconds": 0.9999790191650391,
+                  "bytes": 5329387520,
+                  "bits_per_second": 42635994698.76817,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000027,
+                "end": 5.000006,
+                "seconds": 0.9999790191650391,
+                "bytes": 5329387520,
+                "bits_per_second": 42635994698.76817,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000006,
+                  "end": 6.000018,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 5332271104,
+                  "bits_per_second": 42657655227.93386,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000006,
+                "end": 6.000018,
+                "seconds": 1.0000120401382446,
+                "bytes": 5332271104,
+                "bits_per_second": 42657655227.93386,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000031,
+                  "seconds": 1.000012993812561,
+                  "bytes": 5274468352,
+                  "bits_per_second": 42195198539.4992,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000031,
+                "seconds": 1.000012993812561,
+                "bytes": 5274468352,
+                "bits_per_second": 42195198539.4992,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000031,
+                  "end": 8.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5300420608,
+                  "bits_per_second": 42404297508.9502,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000031,
+                "end": 8.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 5300420608,
+                "bits_per_second": 42404297508.9502,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000009,
+                  "end": 9.000029,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 5310644224,
+                  "bits_per_second": 42484302952.03991,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000009,
+                "end": 9.000029,
+                "seconds": 1.0000200271606445,
+                "bytes": 5310644224,
+                "bits_per_second": 42484302952.03991,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000028,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5294129152,
+                  "bits_per_second": 42353076131.48099,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000028,
+                "seconds": 0.9999989867210388,
+                "bytes": 5294129152,
+                "bits_per_second": 42353076131.48099,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040317,
+                  "seconds": 10.040317,
+                  "bytes": 53121271572,
+                  "bits_per_second": 42326370031.54382,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 53120747284,
+                  "bits_per_second": 42496478837.05926,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040317,
+              "seconds": 10.040317,
+              "bytes": 53121271572,
+              "bits_per_second": 42326370031.54382,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 53120747284,
+              "bits_per_second": 42496478837.05926,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.9131700562321,
+              "host_user": 1.8313076617106898,
+              "host_system": 57.08186239452141,
+              "remote_total": 54.91579537328721,
+              "remote_user": 0.4710685503353111,
+              "remote_system": 54.44472682295189
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 45258,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:05 UTC",
+              "timesecs": 1711485005
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "ngptlgqn6i3ox2iwnjflcy3yn5vsr43bvd4m",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1756790944,
+                  "bits_per_second": 14053511676.447533,
+                  "retransmits": 563,
+                  "snd_cwnd": 958428,
+                  "rtt": 667,
+                  "rttvar": 176,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1756790944,
+                "bits_per_second": 14053511676.447533,
+                "retransmits": 563,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1762679616,
+                  "bits_per_second": 14101451216.70384,
+                  "retransmits": 117,
+                  "snd_cwnd": 913944,
+                  "rtt": 617,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1762679616,
+                "bits_per_second": 14101451216.70384,
+                "retransmits": 117,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000057,
+                  "seconds": 1,
+                  "bytes": 1743596572,
+                  "bits_per_second": 13948772576,
+                  "retransmits": 76,
+                  "snd_cwnd": 698264,
+                  "rtt": 354,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000057,
+                "seconds": 1,
+                "bytes": 1743596572,
+                "bits_per_second": 13948772576,
+                "retransmits": 76,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1585909824,
+                  "bits_per_second": 12687278592,
+                  "retransmits": 93,
+                  "snd_cwnd": 789928,
+                  "rtt": 504,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1585909824,
+                "bits_per_second": 12687278592,
+                "retransmits": 93,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1719381848,
+                  "bits_per_second": 13755041666.170042,
+                  "retransmits": 79,
+                  "snd_cwnd": 698264,
+                  "rtt": 352,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1719381848,
+                "bits_per_second": 13755041666.170042,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.00008,
+                  "seconds": 1.000022053718567,
+                  "bytes": 1698620928,
+                  "bits_per_second": 13588667743.34589,
+                  "retransmits": 427,
+                  "snd_cwnd": 947644,
+                  "rtt": 487,
+                  "rttvar": 19,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.00008,
+                "seconds": 1.000022053718567,
+                "bytes": 1698620928,
+                "bits_per_second": 13588667743.34589,
+                "retransmits": 427,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00008,
+                  "end": 7.000196,
+                  "seconds": 1.000115990638733,
+                  "bytes": 1755761024,
+                  "bits_per_second": 14044459166.210653,
+                  "retransmits": 62,
+                  "snd_cwnd": 706352,
+                  "rtt": 362,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.00008,
+                "end": 7.000196,
+                "seconds": 1.000115990638733,
+                "bytes": 1755761024,
+                "bits_per_second": 14044459166.210653,
+                "retransmits": 62,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000196,
+                  "end": 8.000057,
+                  "seconds": 0.9998610019683838,
+                  "bytes": 1783120320,
+                  "bits_per_second": 14266945637.36077,
+                  "retransmits": 88,
+                  "snd_cwnd": 684784,
+                  "rtt": 352,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000196,
+                "end": 8.000057,
+                "seconds": 0.9998610019683838,
+                "bytes": 1783120320,
+                "bits_per_second": 14266945637.36077,
+                "retransmits": 88,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000057,
+                  "end": 9.000034,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1733497792,
+                  "bits_per_second": 13868301409.459152,
+                  "retransmits": 177,
+                  "snd_cwnd": 877548,
+                  "rtt": 463,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000057,
+                "end": 9.000034,
+                "seconds": 0.9999769926071167,
+                "bytes": 1733497792,
+                "bits_per_second": 13868301409.459152,
+                "retransmits": 177,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000063,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 1775311360,
+                  "bits_per_second": 14202079476.187506,
+                  "retransmits": 53,
+                  "snd_cwnd": 858676,
+                  "rtt": 461,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000063,
+                "seconds": 1.0000289678573608,
+                "bytes": 1775311360,
+                "bits_per_second": 14202079476.187506,
+                "retransmits": 53,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17314670228,
+                  "bits_per_second": 13851648917.011822,
+                  "retransmits": 1735,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 667,
+                  "min_rtt": 352,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039933,
+                  "seconds": 10.000063,
+                  "bytes": 17312453588,
+                  "bits_per_second": 13794875792.896229,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17314670228,
+              "bits_per_second": 13851648917.011822,
+              "retransmits": 1735,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039933,
+              "seconds": 10.039933,
+              "bytes": 17312453588,
+              "bits_per_second": 13794875792.896229,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 12.965573157783645,
+              "host_user": 0.2766736708792456,
+              "host_system": 12.688899486904399,
+              "remote_total": 23.378925135581515,
+              "remote_user": 0.7967034489409502,
+              "remote_system": 22.582213415818792
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.243.134 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.185",
+                "local_port": 46944,
+                "remote_host": "172.30.243.134",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:16 UTC",
+              "timesecs": 1711485016
+            },
+            "connecting_to": {
+              "host": "172.30.243.134",
+              "port": 5201
+            },
+            "cookie": "jv7dtr4iwkqnqi4nabxbzrrrdmp5ffv7dzpz",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000056,
+                  "seconds": 1.0000560283660889,
+                  "bytes": 1588301472,
+                  "bits_per_second": 12705699896.394789,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000056,
+                "seconds": 1.0000560283660889,
+                "bytes": 1588301472,
+                "bits_per_second": 12705699896.394789,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000056,
+                  "end": 2.000025,
+                  "seconds": 0.9999690055847168,
+                  "bytes": 1717632384,
+                  "bits_per_second": 13741484981.292118,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000056,
+                "end": 2.000025,
+                "seconds": 0.9999690055847168,
+                "bytes": 1717632384,
+                "bits_per_second": 13741484981.292118,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000025,
+                  "end": 3.000046,
+                  "seconds": 1.000020980834961,
+                  "bytes": 1637153304,
+                  "bits_per_second": 13096951647.019003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000025,
+                "end": 3.000046,
+                "seconds": 1.000020980834961,
+                "bytes": 1637153304,
+                "bits_per_second": 13096951647.019003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000057,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 1548560832,
+                  "bits_per_second": 12388350789.802336,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000057,
+                "seconds": 1.0000109672546387,
+                "bytes": 1548560832,
+                "bits_per_second": 12388350789.802336,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000057,
+                  "seconds": 1,
+                  "bytes": 1661339904,
+                  "bits_per_second": 13290719232,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000057,
+                "seconds": 1,
+                "bytes": 1661339904,
+                "bits_per_second": 13290719232,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000057,
+                  "seconds": 1,
+                  "bytes": 1734958228,
+                  "bits_per_second": 13879665824,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000057,
+                "seconds": 1,
+                "bytes": 1734958228,
+                "bits_per_second": 13879665824,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000024,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 1733693804,
+                  "bits_per_second": 13870008433.176832,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000024,
+                "seconds": 0.9999669790267944,
+                "bytes": 1733693804,
+                "bits_per_second": 13870008433.176832,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000056,
+                  "seconds": 1.0000319480895996,
+                  "bytes": 1624242608,
+                  "bits_per_second": 12993525745.675262,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000056,
+                "seconds": 1.0000319480895996,
+                "bytes": 1624242608,
+                "bits_per_second": 12993525745.675262,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000056,
+                  "end": 9.000015,
+                  "seconds": 0.9999589920043945,
+                  "bytes": 1732061376,
+                  "bits_per_second": 13857059258.225166,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000056,
+                "end": 9.000015,
+                "seconds": 0.9999589920043945,
+                "bytes": 1732061376,
+                "bits_per_second": 13857059258.225166,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000015,
+                  "end": 10.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1706050368,
+                  "bits_per_second": 13648225601.514744,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000015,
+                "end": 10.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1706050368,
+                "bits_per_second": 13648225601.514744,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03969,
+                  "seconds": 10.03969,
+                  "bytes": 16687168488,
+                  "bits_per_second": 13296959159.49596,
+                  "retransmits": 2081,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000028,
+                  "seconds": 10.000028,
+                  "bytes": 16683994280,
+                  "bits_per_second": 13347158051.957455,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03969,
+              "seconds": 10.03969,
+              "bytes": 16687168488,
+              "bits_per_second": 13296959159.49596,
+              "retransmits": 2081,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000028,
+              "seconds": 10.000028,
+              "bytes": 16683994280,
+              "bits_per_second": 13347158051.957455,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.49645360241422,
+              "host_user": 1.0953846141637273,
+              "host_system": 25.40107890796627,
+              "remote_total": 12.308727742765743,
+              "remote_user": 0.1856302180705536,
+              "remote_system": 12.12309752469519
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 39718,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:35 UTC",
+              "timesecs": 1711485035
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "yixxxtdw5flcdkp6h4gqjv4rmqhgbldllv6f",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000101,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 4825423936,
+                  "bits_per_second": 38599494086.72777,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 31,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000101,
+                "seconds": 1.0001009702682495,
+                "bytes": 4825423936,
+                "bits_per_second": 38599494086.72777,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000101,
+                  "end": 2.000064,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38452705227.057976,
+                  "retransmits": 0,
+                  "snd_cwnd": 551332,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000101,
+                "end": 2.000064,
+                "seconds": 0.9999629855155945,
+                "bytes": 4806410240,
+                "bits_per_second": 38452705227.057976,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000064,
+                  "end": 3.000036,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 4803788800,
+                  "bits_per_second": 38431387023.910736,
+                  "retransmits": 0,
+                  "snd_cwnd": 707700,
+                  "rtt": 27,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000064,
+                "end": 3.000036,
+                "seconds": 0.9999719858169556,
+                "bytes": 4803788800,
+                "bits_per_second": 38431387023.910736,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000036,
+                  "end": 4.000268,
+                  "seconds": 1.0002319812774658,
+                  "bytes": 4790681600,
+                  "bits_per_second": 38316564074.51789,
+                  "retransmits": 78,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000036,
+                "end": 4.000268,
+                "seconds": 1.0002319812774658,
+                "bytes": 4790681600,
+                "bits_per_second": 38316564074.51789,
+                "retransmits": 78,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000268,
+                  "end": 5.000265,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4696309760,
+                  "bits_per_second": 37570590049.083694,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 30,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000268,
+                "end": 5.000265,
+                "seconds": 0.9999970197677612,
+                "bytes": 4696309760,
+                "bits_per_second": 37570590049.083694,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000265,
+                  "end": 6.000018,
+                  "seconds": 0.9997529983520508,
+                  "bytes": 4778885120,
+                  "bits_per_second": 38240526433.04741,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000265,
+                "end": 6.000018,
+                "seconds": 0.9997529983520508,
+                "bytes": 4778885120,
+                "bits_per_second": 38240526433.04741,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000112,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38112152918.41128,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 28,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000112,
+                "seconds": 1.0000940561294556,
+                "bytes": 4764467200,
+                "bits_per_second": 38112152918.41128,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000112,
+                  "end": 8.000259,
+                  "seconds": 1.0001469850540161,
+                  "bytes": 4839178240,
+                  "bits_per_second": 38707736461.265396,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 26,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000112,
+                "end": 8.000259,
+                "seconds": 1.0001469850540161,
+                "bytes": 4839178240,
+                "bits_per_second": 38707736461.265396,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000259,
+                  "end": 9.000227,
+                  "seconds": 0.9999679923057556,
+                  "bytes": 4712038400,
+                  "bits_per_second": 37697513810.49582,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000259,
+                "end": 9.000227,
+                "seconds": 0.9999679923057556,
+                "bytes": 4712038400,
+                "bits_per_second": 37697513810.49582,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000227,
+                  "end": 10.000156,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 4784128000,
+                  "bits_per_second": 38275741161.63895,
+                  "retransmits": 0,
+                  "snd_cwnd": 808800,
+                  "rtt": 29,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000227,
+                "end": 10.000156,
+                "seconds": 0.9999290108680725,
+                "bytes": 4784128000,
+                "bits_per_second": 38275741161.63895,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000156,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38240452485.74122,
+                  "retransmits": 78,
+                  "max_snd_cwnd": 808800,
+                  "max_rtt": 31,
+                  "min_rtt": 26,
+                  "mean_rtt": 28,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000156,
+                  "bytes": 47801311296,
+                  "bits_per_second": 38087381686.64706,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000156,
+              "seconds": 10.000156,
+              "bytes": 47801311296,
+              "bits_per_second": 38240452485.74122,
+              "retransmits": 78,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 47801311296,
+              "bits_per_second": 38087381686.64706,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 50.79991850744037,
+              "host_user": 0.5093780915545499,
+              "host_system": 50.29054041588581,
+              "remote_total": 69.18971718930246,
+              "remote_user": 1.6048329699753412,
+              "remote_system": 67.58487595116893
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.74.186 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.186",
+                "local_port": 45210,
+                "remote_host": "172.30.74.186",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:30:46 UTC",
+              "timesecs": 1711485046
+            },
+            "connecting_to": {
+              "host": "172.30.74.186",
+              "port": 5201
+            },
+            "cookie": "l2ly54k3ajimerhoxf75kst6fctwl2tmlcp4",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000004,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 4517548360,
+                  "bits_per_second": 36140240399.41901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000004,
+                "seconds": 1.0000040531158447,
+                "bytes": 4517548360,
+                "bits_per_second": 36140240399.41901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000004,
+                  "end": 2.000005,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4473749504,
+                  "bits_per_second": 35789961900.03255,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000004,
+                "end": 2.000005,
+                "seconds": 1.0000009536743164,
+                "bytes": 4473749504,
+                "bits_per_second": 35789961900.03255,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000019,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4472438784,
+                  "bits_per_second": 35779011244.710175,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000019,
+                "seconds": 1.0000139474868774,
+                "bytes": 4472438784,
+                "bits_per_second": 35779011244.710175,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000014,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 4757520384,
+                  "bits_per_second": 38060353632.204094,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000014,
+                "seconds": 0.9999949932098389,
+                "bytes": 4757520384,
+                "bits_per_second": 38060353632.204094,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000014,
+                  "end": 5.000022,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4763942596,
+                  "bits_per_second": 38111236372.7014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000014,
+                "end": 5.000022,
+                "seconds": 1.0000079870224,
+                "bytes": 4763942596,
+                "bits_per_second": 38111236372.7014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000022,
+                  "end": 6.000016,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4744937788,
+                  "bits_per_second": 37959730824.20342,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000022,
+                "end": 6.000016,
+                "seconds": 0.9999939799308777,
+                "bytes": 4744937788,
+                "bits_per_second": 37959730824.20342,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000016,
+                  "end": 7.000004,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 4736604700,
+                  "bits_per_second": 37893291581.853004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000016,
+                "end": 7.000004,
+                "seconds": 0.9999880194664001,
+                "bytes": 4736604700,
+                "bits_per_second": 37893291581.853004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000004,
+                  "end": 8.000015,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 4758175744,
+                  "bits_per_second": 38064988483.57848,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000004,
+                "end": 8.000015,
+                "seconds": 1.0000109672546387,
+                "bytes": 4758175744,
+                "bits_per_second": 38064988483.57848,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000031,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4740612096,
+                  "bits_per_second": 37924290963.67715,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000031,
+                "seconds": 1.0000159740447998,
+                "bytes": 4740612096,
+                "bits_per_second": 37924290963.67715,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000031,
+                  "end": 10.000012,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4774428672,
+                  "bits_per_second": 38196155633.18397,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000031,
+                "end": 10.000012,
+                "seconds": 0.9999809861183167,
+                "bytes": 4774428672,
+                "bits_per_second": 38196155633.18397,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040275,
+                  "seconds": 10.040275,
+                  "bytes": 46740351844,
+                  "bits_per_second": 37242288159.63706,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000012,
+                  "seconds": 10.000012,
+                  "bytes": 46739958628,
+                  "bits_per_second": 37391922032.09356,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040275,
+              "seconds": 10.040275,
+              "bytes": 46740351844,
+              "bits_per_second": 37242288159.63706,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000012,
+              "seconds": 10.000012,
+              "bytes": 46739958628,
+              "bits_per_second": 37391922032.09356,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 53.87293306289964,
+              "host_user": 1.9549507299646565,
+              "host_system": 51.91798233293498,
+              "remote_total": 84.71007116240497,
+              "remote_user": 0.4765840963192183,
+              "remote_system": 84.23349673055752
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 42424,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:05 UTC",
+              "timesecs": 1711485065
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "qad3354ioql7sj66mehvnucjbyf2wgnqvfze",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00002,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 2929396644,
+                  "bits_per_second": 23434703821.421913,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 397,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00002,
+                "seconds": 1.0000200271606445,
+                "bytes": 2929396644,
+                "bits_per_second": 23434703821.421913,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00002,
+                  "end": 2.000058,
+                  "seconds": 1.0000380277633667,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23424297066.37413,
+                  "retransmits": 0,
+                  "snd_cwnd": 1763184,
+                  "rtt": 398,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.00002,
+                "end": 2.000058,
+                "seconds": 1.0000380277633667,
+                "bytes": 2928148480,
+                "bits_per_second": 23424297066.37413,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393683151.346077,
+                  "retransmits": 655,
+                  "snd_cwnd": 760272,
+                  "rtt": 242,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 2924216320,
+                "bits_per_second": 23393683151.346077,
+                "retransmits": 655,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00006,
+                  "end": 4.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425235312.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 1517848,
+                  "rtt": 400,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00006,
+                "end": 4.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 2928148480,
+                "bits_per_second": 23425235312.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425211576.27405,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 393,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 2928148480,
+                "bits_per_second": 23425211576.27405,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000057,
+                  "end": 6.000027,
+                  "seconds": 0.999970018863678,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425890174.806797,
+                  "retransmits": 0,
+                  "snd_cwnd": 1565028,
+                  "rtt": 373,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000057,
+                "end": 6.000027,
+                "seconds": 0.999970018863678,
+                "bytes": 2928148480,
+                "bits_per_second": 23425890174.806797,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000027,
+                  "end": 7.000129,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422797703.897022,
+                  "retransmits": 152,
+                  "snd_cwnd": 1442360,
+                  "rtt": 379,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000027,
+                "end": 7.000129,
+                "seconds": 1.0001020431518555,
+                "bytes": 2928148480,
+                "bits_per_second": 23422797703.897022,
+                "retransmits": 152,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000129,
+                  "end": 8.000058,
+                  "seconds": 0.9999290108680725,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416364387.380756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1544808,
+                  "rtt": 397,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000129,
+                "end": 8.000058,
+                "seconds": 0.9999290108680725,
+                "bytes": 2926837760,
+                "bits_per_second": 23416364387.380756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425187840,
+                  "retransmits": 0,
+                  "snd_cwnd": 1569072,
+                  "rtt": 419,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 2928148480,
+                "bits_per_second": 23425187840,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000116,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2921594880,
+                  "bits_per_second": 23371402215.02037,
+                  "retransmits": 0,
+                  "snd_cwnd": 1606816,
+                  "rtt": 410,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000116,
+                "seconds": 1.0000580549240112,
+                "bytes": 2921594880,
+                "bits_per_second": 23371402215.02037,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000116,
+                  "seconds": 10.000116,
+                  "bytes": 29270936484,
+                  "bits_per_second": 23416477556.06035,
+                  "retransmits": 807,
+                  "max_snd_cwnd": 1763184,
+                  "max_rtt": 419,
+                  "min_rtt": 242,
+                  "mean_rtt": 380,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039772,
+                  "seconds": 10.000116,
+                  "bytes": 29268240456,
+                  "bits_per_second": 23321836755.65541,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000116,
+              "seconds": 10.000116,
+              "bytes": 29270936484,
+              "bits_per_second": 23416477556.06035,
+              "retransmits": 807,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039772,
+              "seconds": 10.039772,
+              "bytes": 29268240456,
+              "bits_per_second": 23321836755.65541,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 19.865083177612643,
+              "host_user": 0.41521108861582645,
+              "host_system": 19.449872088996816,
+              "remote_total": 59.10663386005702,
+              "remote_user": 2.4033524078476156,
+              "remote_system": 56.70327318135753
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.139.14 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.187",
+                "local_port": 38322,
+                "remote_host": "172.30.139.14",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:16 UTC",
+              "timesecs": 1711485076
+            },
+            "connecting_to": {
+              "host": "172.30.139.14",
+              "port": 5201
+            },
+            "cookie": "fz4kz76i6cwlffld5wse4nasbjmaqn6a54dh",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000018,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 2577850256,
+                  "bits_per_second": 20622430831.81543,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000018,
+                "seconds": 1.0000180006027222,
+                "bytes": 2577850256,
+                "bits_per_second": 20622430831.81543,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000018,
+                  "end": 2.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 2421676608,
+                  "bits_per_second": 19373587232.123535,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000018,
+                "end": 2.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 2421676608,
+                "bits_per_second": 19373587232.123535,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000009,
+                  "seconds": 1,
+                  "bytes": 2353155072,
+                  "bits_per_second": 18825240576,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000009,
+                "seconds": 1,
+                "bytes": 2353155072,
+                "bits_per_second": 18825240576,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000015,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 2349402240,
+                  "bits_per_second": 18795105892.438976,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000015,
+                "seconds": 1.0000059604644775,
+                "bytes": 2349402240,
+                "bits_per_second": 18795105892.438976,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000015,
+                  "end": 5.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 2327467584,
+                  "bits_per_second": 18619498733.723473,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000015,
+                "end": 5.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 2327467584,
+                "bits_per_second": 18619498733.723473,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000022,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 2343643584,
+                  "bits_per_second": 18749261543.850487,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000022,
+                "seconds": 0.9999939799308777,
+                "bytes": 2343643584,
+                "bits_per_second": 18749261543.850487,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000022,
+                  "end": 7.000011,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2349466944,
+                  "bits_per_second": 18795942812.21649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000022,
+                "end": 7.000011,
+                "seconds": 0.9999889731407166,
+                "bytes": 2349466944,
+                "bits_per_second": 18795942812.21649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000011,
+                  "end": 8.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 2404465344,
+                  "bits_per_second": 19235358159.692505,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000011,
+                "end": 8.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 2404465344,
+                "bits_per_second": 19235358159.692505,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.00003,
+                  "seconds": 1,
+                  "bytes": 2575413312,
+                  "bits_per_second": 20603306496,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.00003,
+                "seconds": 1,
+                "bytes": 2575413312,
+                "bits_per_second": 20603306496,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.000034,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 2567907648,
+                  "bits_per_second": 20543177920.12007,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.000034,
+                "seconds": 1.0000040531158447,
+                "bytes": 2567907648,
+                "bits_per_second": 20543177920.12007,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039536,
+                  "seconds": 10.039536,
+                  "bytes": 24273090960,
+                  "bits_per_second": 19342002227.991413,
+                  "retransmits": 2404,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000034,
+                  "seconds": 10.000034,
+                  "bytes": 24270448592,
+                  "bits_per_second": 19416292858.204285,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039536,
+              "seconds": 10.039536,
+              "bytes": 24273090960,
+              "bits_per_second": 19342002227.991413,
+              "retransmits": 2404,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000034,
+              "seconds": 10.000034,
+              "bytes": 24270448592,
+              "bits_per_second": 19416292858.204285,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 37.45748338542608,
+              "host_user": 1.3319334804012157,
+              "host_system": 36.125549905024855,
+              "remote_total": 15.928314062618693,
+              "remote_user": 0.36963858784471143,
+              "remote_system": 15.558675474773981
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 47958,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:36 UTC",
+              "timesecs": 1711485096
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "culk7bijm5yyvcril6oviau22xid24eqkwyv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000048,
+                  "seconds": 1.000048041343689,
+                  "bytes": 4818672896,
+                  "bits_per_second": 38547531292.800804,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 26,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000048,
+                "seconds": 1.000048041343689,
+                "bytes": 4818672896,
+                "bits_per_second": 38547531292.800804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000048,
+                  "end": 2.000066,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38461075357.46222,
+                  "retransmits": 0,
+                  "snd_cwnd": 579640,
+                  "rtt": 24,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000048,
+                "end": 2.000066,
+                "seconds": 1.0000180006027222,
+                "bytes": 4807720960,
+                "bits_per_second": 38461075357.46222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000066,
+                  "end": 3.000236,
+                  "seconds": 1.0001699924468994,
+                  "bytes": 4804968024,
+                  "bits_per_second": 38433210836.44771,
+                  "retransmits": 0,
+                  "snd_cwnd": 899116,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000066,
+                "end": 3.000236,
+                "seconds": 1.0001699924468994,
+                "bytes": 4804968024,
+                "bits_per_second": 38433210836.44771,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000236,
+                  "end": 4.000147,
+                  "seconds": 0.9999110102653503,
+                  "bytes": 4799728368,
+                  "bits_per_second": 38401244260.536964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000236,
+                "end": 4.000147,
+                "seconds": 0.9999110102653503,
+                "bytes": 4799728368,
+                "bits_per_second": 38401244260.536964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000147,
+                  "end": 5.000114,
+                  "seconds": 0.9999669790267944,
+                  "bytes": 4824760320,
+                  "bits_per_second": 38599357148.33815,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 26,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000147,
+                "end": 5.000114,
+                "seconds": 0.9999669790267944,
+                "bytes": 4824760320,
+                "bits_per_second": 38599357148.33815,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000114,
+                  "end": 6.000145,
+                  "seconds": 1.0000309944152832,
+                  "bytes": 4833935360,
+                  "bits_per_second": 38670284317.14876,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 24,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000114,
+                "end": 6.000145,
+                "seconds": 1.0000309944152832,
+                "bytes": 4833935360,
+                "bits_per_second": 38670284317.14876,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000145,
+                  "end": 7.000159,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38408803173.721756,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000145,
+                "end": 7.000159,
+                "seconds": 1.0000139474868774,
+                "bytes": 4801167360,
+                "bits_per_second": 38408803173.721756,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000159,
+                  "end": 8.00016,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 4820828160,
+                  "bits_per_second": 38566588500.03507,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000159,
+                "end": 8.00016,
+                "seconds": 1.0000009536743164,
+                "bytes": 4820828160,
+                "bits_per_second": 38566588500.03507,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00016,
+                  "end": 9.000032,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38372306389.033714,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00016,
+                "end": 9.000032,
+                "seconds": 0.9998720288276672,
+                "bytes": 4795924480,
+                "bits_per_second": 38372306389.033714,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000128,
+                  "seconds": 1.0000959634780884,
+                  "bytes": 4848353280,
+                  "bits_per_second": 38783104478.40319,
+                  "retransmits": 0,
+                  "snd_cwnd": 1043352,
+                  "rtt": 22,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000128,
+                "seconds": 1.0000959634780884,
+                "bytes": 4848353280,
+                "bits_per_second": 38783104478.40319,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000128,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38524354254.66554,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1043352,
+                  "max_rtt": 26,
+                  "min_rtt": 22,
+                  "mean_rtt": 23,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040386,
+                  "seconds": 10.000128,
+                  "bytes": 48156059208,
+                  "bits_per_second": 38369886741.80455,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000128,
+              "seconds": 10.000128,
+              "bytes": 48156059208,
+              "bits_per_second": 38524354254.66554,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040386,
+              "seconds": 10.040386,
+              "bytes": 48156059208,
+              "bits_per_second": 38369886741.80455,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.71680226694355,
+              "host_user": 0.47637317598252343,
+              "host_system": 51.24043901002937,
+              "remote_total": 45.230156070887375,
+              "remote_user": 1.3387075643093247,
+              "remote_system": 43.891456788045936
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.32.96 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.189",
+                "local_port": 60988,
+                "remote_host": "172.30.32.96",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:31:48 UTC",
+              "timesecs": 1711485108
+            },
+            "connecting_to": {
+              "host": "172.30.32.96",
+              "port": 5201
+            },
+            "cookie": "cmtlcvrdzqev3x5evsjc365knbkfxxurgbj6",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000022,
+                  "seconds": 1.000022053718567,
+                  "bytes": 5308961096,
+                  "bits_per_second": 42470752129.9852,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000022,
+                "seconds": 1.000022053718567,
+                "bytes": 5308961096,
+                "bits_per_second": 42470752129.9852,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000022,
+                  "end": 2.000005,
+                  "seconds": 0.999983012676239,
+                  "bytes": 5317292584,
+                  "bits_per_second": 42539063296.84071,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000022,
+                "end": 2.000005,
+                "seconds": 0.999983012676239,
+                "bytes": 5317292584,
+                "bits_per_second": 42539063296.84071,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000005,
+                  "end": 3.000026,
+                  "seconds": 1.000020980834961,
+                  "bytes": 5243928576,
+                  "bits_per_second": 41950548450.46644,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000005,
+                "end": 3.000026,
+                "seconds": 1.000020980834961,
+                "bytes": 5243928576,
+                "bits_per_second": 41950548450.46644,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000023,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5279918676,
+                  "bits_per_second": 42239475291.446014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000023,
+                "seconds": 0.9999970197677612,
+                "bytes": 5279918676,
+                "bits_per_second": 42239475291.446014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000023,
+                  "end": 5.00002,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 5323227136,
+                  "bits_per_second": 42585944004.00324,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000023,
+                "end": 5.00002,
+                "seconds": 0.9999970197677612,
+                "bytes": 5323227136,
+                "bits_per_second": 42585944004.00324,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.00002,
+                  "end": 6.000004,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 5266341888,
+                  "bits_per_second": 42131408113.00068,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.00002,
+                "end": 6.000004,
+                "seconds": 0.9999840259552002,
+                "bytes": 5266341888,
+                "bits_per_second": 42131408113.00068,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000028,
+                  "seconds": 1.0000239610671997,
+                  "bytes": 5331222528,
+                  "bits_per_second": 42648758314.236046,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000028,
+                "seconds": 1.0000239610671997,
+                "bytes": 5331222528,
+                "bits_per_second": 42648758314.236046,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000028,
+                  "end": 8.000016,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 5229510656,
+                  "bits_per_second": 41836586472.62994,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000028,
+                "end": 8.000016,
+                "seconds": 0.9999880194664001,
+                "bytes": 5229510656,
+                "bits_per_second": 41836586472.62994,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000016,
+                  "end": 9.000006,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 5216403456,
+                  "bits_per_second": 41731645531.18451,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000016,
+                "end": 9.000006,
+                "seconds": 0.9999899864196777,
+                "bytes": 5216403456,
+                "bits_per_second": 41731645531.18451,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000006,
+                  "end": 10.000033,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 5329518592,
+                  "bits_per_second": 42635000093.695915,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000006,
+                "end": 10.000033,
+                "seconds": 1.0000269412994385,
+                "bytes": 5329518592,
+                "bits_per_second": 42635000093.695915,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040391,
+                  "seconds": 10.040391,
+                  "bytes": 52847242692,
+                  "bits_per_second": 42107716874.37273,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000033,
+                  "seconds": 10.000033,
+                  "bytes": 52846325188,
+                  "bits_per_second": 42276920636.5619,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040391,
+              "seconds": 10.040391,
+              "bytes": 52847242692,
+              "bits_per_second": 42107716874.37273,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000033,
+              "seconds": 10.000033,
+              "bytes": 52846325188,
+              "bits_per_second": 42276920636.5619,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72172176163449,
+              "host_user": 1.7632532126911542,
+              "host_system": 56.958468548943344,
+              "remote_total": 54.5440108210963,
+              "remote_user": 0.40678669250280086,
+              "remote_system": 54.137214462757875
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 46580,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:07 UTC",
+              "timesecs": 1711485127
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fdgdvbf3rpcvy52s3xlhtwuo7t4vkwwe6wfq",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1749200440,
+                  "bits_per_second": 13992791169.571945,
+                  "retransmits": 621,
+                  "snd_cwnd": 812844,
+                  "rtt": 417,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1749200440,
+                "bits_per_second": 13992791169.571945,
+                "retransmits": 621,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000151,
+                  "seconds": 1.0000929832458496,
+                  "bytes": 1770835776,
+                  "bits_per_second": 14165369066.005585,
+                  "retransmits": 57,
+                  "snd_cwnd": 912596,
+                  "rtt": 445,
+                  "rttvar": 23,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000151,
+                "seconds": 1.0000929832458496,
+                "bytes": 1770835776,
+                "bits_per_second": 14165369066.005585,
+                "retransmits": 57,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000151,
+                  "end": 3.000227,
+                  "seconds": 1.0000760555267334,
+                  "bytes": 1781066812,
+                  "bits_per_second": 14247450898.617298,
+                  "retransmits": 87,
+                  "snd_cwnd": 669956,
+                  "rtt": 482,
+                  "rttvar": 128,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000151,
+                "end": 3.000227,
+                "seconds": 1.0000760555267334,
+                "bytes": 1781066812,
+                "bits_per_second": 14247450898.617298,
+                "retransmits": 87,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000227,
+                  "end": 4.000645,
+                  "seconds": 1.000417947769165,
+                  "bytes": 1706121192,
+                  "bits_per_second": 13643267362.841578,
+                  "retransmits": 532,
+                  "snd_cwnd": 843848,
+                  "rtt": 461,
+                  "rttvar": 58,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000227,
+                "end": 4.000645,
+                "seconds": 1.000417947769165,
+                "bytes": 1706121192,
+                "bits_per_second": 13643267362.841578,
+                "retransmits": 532,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000645,
+                  "end": 5.000058,
+                  "seconds": 0.999413013458252,
+                  "bytes": 1646996516,
+                  "bits_per_second": 13183710788.803326,
+                  "retransmits": 142,
+                  "snd_cwnd": 838456,
+                  "rtt": 544,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000645,
+                "end": 5.000058,
+                "seconds": 0.999413013458252,
+                "bytes": 1646996516,
+                "bits_per_second": 13183710788.803326,
+                "retransmits": 142,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1782799112,
+                  "bits_per_second": 14262407347.797302,
+                  "retransmits": 132,
+                  "snd_cwnd": 928772,
+                  "rtt": 486,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1782799112,
+                "bits_per_second": 14262407347.797302,
+                "retransmits": 132,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000057,
+                  "end": 7.000161,
+                  "seconds": 1.0001039505004883,
+                  "bytes": 1788102904,
+                  "bits_per_second": 14303336393.023293,
+                  "retransmits": 77,
+                  "snd_cwnd": 831716,
+                  "rtt": 416,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000057,
+                "end": 7.000161,
+                "seconds": 1.0001039505004883,
+                "bytes": 1788102904,
+                "bits_per_second": 14303336393.023293,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000161,
+                  "end": 8.000058,
+                  "seconds": 0.9998970031738281,
+                  "bytes": 1783196620,
+                  "bits_per_second": 14267042420.088129,
+                  "retransmits": 96,
+                  "snd_cwnd": 824976,
+                  "rtt": 580,
+                  "rttvar": 185,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000161,
+                "end": 8.000058,
+                "seconds": 0.9998970031738281,
+                "bytes": 1783196620,
+                "bits_per_second": 14267042420.088129,
+                "retransmits": 96,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000076,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 1775786432,
+                  "bits_per_second": 14206035738.794409,
+                  "retransmits": 301,
+                  "snd_cwnd": 634908,
+                  "rtt": 423,
+                  "rttvar": 97,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000076,
+                "seconds": 1.0000180006027222,
+                "bytes": 1775786432,
+                "bits_per_second": 14206035738.794409,
+                "retransmits": 301,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000076,
+                  "end": 10.000063,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1681309440,
+                  "bits_per_second": 13450650295.22876,
+                  "retransmits": 249,
+                  "snd_cwnd": 676696,
+                  "rtt": 360,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000076,
+                "end": 10.000063,
+                "seconds": 0.999987006187439,
+                "bytes": 1681309440,
+                "bits_per_second": 13450650295.22876,
+                "retransmits": 249,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 17465415244,
+                  "bits_per_second": 13972244170.061728,
+                  "retransmits": 2294,
+                  "max_snd_cwnd": 928772,
+                  "max_rtt": 580,
+                  "min_rtt": 360,
+                  "mean_rtt": 461,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039945,
+                  "seconds": 10.000063,
+                  "bytes": 17463546188,
+                  "bits_per_second": 13915252474.391047,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 17465415244,
+              "bits_per_second": 13972244170.061728,
+              "retransmits": 2294,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039945,
+              "seconds": 10.039945,
+              "bytes": 17463546188,
+              "bits_per_second": 13915252474.391047,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.61059396129923,
+              "host_user": 0.19270043453809127,
+              "host_system": 13.417903445457585,
+              "remote_total": 23.486672814565882,
+              "remote_user": 0.5555645903789477,
+              "remote_system": 22.931108224186932
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.51.52 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.190",
+                "local_port": 50678,
+                "remote_host": "172.30.51.52",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:19 UTC",
+              "timesecs": 1711485139
+            },
+            "connecting_to": {
+              "host": "172.30.51.52",
+              "port": 5201
+            },
+            "cookie": "fhpezft75vq2afa2wz4wlnped7pz35esj5w2",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000045,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731201352,
+                  "bits_per_second": 13848988416.117579,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000045,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731201352,
+                "bits_per_second": 13848988416.117579,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000045,
+                  "end": 2.000008,
+                  "seconds": 0.9999629855155945,
+                  "bytes": 1582543756,
+                  "bits_per_second": 12660818681.675653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000045,
+                "end": 2.000008,
+                "seconds": 0.9999629855155945,
+                "bytes": 1582543756,
+                "bits_per_second": 12660818681.675653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000008,
+                  "end": 3.000015,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1576707072,
+                  "bits_per_second": 12613567860.386663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000008,
+                "end": 3.000015,
+                "seconds": 1.0000070333480835,
+                "bytes": 1576707072,
+                "bits_per_second": 12613567860.386663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1528626392,
+                  "bits_per_second": 12228852236.5862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1528626392,
+                "bits_per_second": 12228852236.5862,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000013,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 1714944660,
+                  "bits_per_second": 13719763355.92855,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000013,
+                "seconds": 0.9999849796295166,
+                "bytes": 1714944660,
+                "bits_per_second": 13719763355.92855,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000043,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 1705468032,
+                  "bits_per_second": 13643334400.125362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000043,
+                "seconds": 1.0000300407409668,
+                "bytes": 1705468032,
+                "bits_per_second": 13643334400.125362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000043,
+                  "end": 7.000024,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1737755328,
+                  "bits_per_second": 13902306960.81968,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000043,
+                "end": 7.000024,
+                "seconds": 0.9999809861183167,
+                "bytes": 1737755328,
+                "bits_per_second": 13902306960.81968,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000024,
+                  "end": 8.000011,
+                  "seconds": 0.999987006187439,
+                  "bytes": 1737625920,
+                  "bits_per_second": 13901187989.43111,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000024,
+                "end": 8.000011,
+                "seconds": 0.999987006187439,
+                "bytes": 1737625920,
+                "bits_per_second": 13901187989.43111,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000011,
+                  "end": 9.00003,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 1625946816,
+                  "bits_per_second": 13007327983.50187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000011,
+                "end": 9.00003,
+                "seconds": 1.0000189542770386,
+                "bytes": 1625946816,
+                "bits_per_second": 13007327983.50187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00003,
+                  "end": 10.00004,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1604133292,
+                  "bits_per_second": 12832937832.346245,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00003,
+                "end": 10.00004,
+                "seconds": 1.0000100135803223,
+                "bytes": 1604133292,
+                "bits_per_second": 12832937832.346245,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039719,
+                  "seconds": 10.039719,
+                  "bytes": 16547546348,
+                  "bits_per_second": 13185664935.841331,
+                  "retransmits": 2136,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00004,
+                  "seconds": 10.00004,
+                  "bytes": 16544952620,
+                  "bits_per_second": 13235909152.36339,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039719,
+              "seconds": 10.039719,
+              "bytes": 16547546348,
+              "bits_per_second": 13185664935.841331,
+              "retransmits": 2136,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00004,
+              "seconds": 10.00004,
+              "bytes": 16544952620,
+              "bits_per_second": 13235909152.36339,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.747516641197084,
+              "host_user": 1.0158505257156165,
+              "host_system": 25.731666115481467,
+              "remote_total": 11.755923477356498,
+              "remote_user": 0.13796182174123386,
+              "remote_system": 11.617971314101807
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 41706,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:38 UTC",
+              "timesecs": 1711485158
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "o4wzpkyseqdxynbegkm26lmf4dul2syf6x6q",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000041,
+                  "seconds": 1.0000410079956055,
+                  "bytes": 4768399360,
+                  "bits_per_second": 38145630604.14782,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 24,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000041,
+                "seconds": 1.0000410079956055,
+                "bytes": 4768399360,
+                "bits_per_second": 38145630604.14782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000041,
+                  "end": 2.000213,
+                  "seconds": 1.0001720190048218,
+                  "bytes": 4806410240,
+                  "bits_per_second": 38444668706.348434,
+                  "retransmits": 0,
+                  "snd_cwnd": 525720,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000041,
+                "end": 2.000213,
+                "seconds": 1.0001720190048218,
+                "bytes": 4806410240,
+                "bits_per_second": 38444668706.348434,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000213,
+                  "end": 3.00012,
+                  "seconds": 0.9999070167541504,
+                  "bytes": 4761203140,
+                  "bits_per_second": 38093167146.32596,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000213,
+                "end": 3.00012,
+                "seconds": 0.9999070167541504,
+                "bytes": 4761203140,
+                "bits_per_second": 38093167146.32596,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00012,
+                  "end": 4.000102,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 4814274560,
+                  "bits_per_second": 38514889771.22966,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.00012,
+                "end": 4.000102,
+                "seconds": 0.9999819993972778,
+                "bytes": 4814274560,
+                "bits_per_second": 38514889771.22966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000102,
+                  "end": 5.000003,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 4811653120,
+                  "bits_per_second": 38497036294.209724,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000102,
+                "end": 5.000003,
+                "seconds": 0.9999009966850281,
+                "bytes": 4811653120,
+                "bits_per_second": 38497036294.209724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000003,
+                  "end": 6.000056,
+                  "seconds": 1.00005304813385,
+                  "bytes": 4795924480,
+                  "bits_per_second": 38365360629.214134,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 23,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000003,
+                "end": 6.000056,
+                "seconds": 1.00005304813385,
+                "bytes": 4795924480,
+                "bits_per_second": 38365360629.214134,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000108,
+                  "seconds": 1.0000519752502441,
+                  "bytes": 4746117120,
+                  "bits_per_second": 37966963617.564964,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 25,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000108,
+                "seconds": 1.0000519752502441,
+                "bytes": 4746117120,
+                "bits_per_second": 37966963617.564964,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000108,
+                  "end": 8.000094,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4801167360,
+                  "bits_per_second": 38409876890.660965,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 37,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000108,
+                "end": 8.000094,
+                "seconds": 0.9999859929084778,
+                "bytes": 4801167360,
+                "bits_per_second": 38409876890.660965,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000094,
+                  "end": 9.000078,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4807720960,
+                  "bits_per_second": 38462382079.81445,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 24,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000094,
+                "end": 9.000078,
+                "seconds": 0.9999840259552002,
+                "bytes": 4807720960,
+                "bits_per_second": 38462382079.81445,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000078,
+                  "end": 10.00019,
+                  "seconds": 1.0001120567321777,
+                  "bytes": 4764467200,
+                  "bits_per_second": 38111466953.55469,
+                  "retransmits": 0,
+                  "snd_cwnd": 1202416,
+                  "rtt": 21,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000078,
+                "end": 10.00019,
+                "seconds": 1.0001120567321777,
+                "bytes": 4764467200,
+                "bits_per_second": 38111466953.55469,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00019,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38301142310.296104,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1202416,
+                  "max_rtt": 37,
+                  "min_rtt": 21,
+                  "mean_rtt": 24,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040372,
+                  "seconds": 10.00019,
+                  "bytes": 47877337540,
+                  "bits_per_second": 38147859493.65223,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00019,
+              "seconds": 10.00019,
+              "bytes": 47877337540,
+              "bits_per_second": 38301142310.296104,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040372,
+              "seconds": 10.040372,
+              "bytes": 47877337540,
+              "bits_per_second": 38147859493.65223,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 51.579098862767125,
+              "host_user": 0.4361726860977011,
+              "host_system": 51.14293609532062,
+              "remote_total": 44.789642459824776,
+              "remote_user": 1.3832780535675204,
+              "remote_system": 43.40635613187544
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.87.166 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.192",
+                "local_port": 57026,
+                "remote_host": "172.30.87.166",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:32:50 UTC",
+              "timesecs": 1711485170
+            },
+            "connecting_to": {
+              "host": "172.30.87.166",
+              "port": 5201
+            },
+            "cookie": "d2br4i7ycdhparaagyg5j2rwxom4sauulld7",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000025,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5283402056,
+                  "bits_per_second": 42266158359.07089,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000025,
+                "seconds": 1.0000250339508057,
+                "bytes": 5283402056,
+                "bits_per_second": 42266158359.07089,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000025,
+                  "end": 2.000023,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5276569800,
+                  "bits_per_second": 42212643946.36801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000025,
+                "end": 2.000023,
+                "seconds": 0.9999979734420776,
+                "bytes": 5276569800,
+                "bits_per_second": 42212643946.36801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000023,
+                  "end": 3.000005,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42418808492.11961,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000023,
+                "end": 3.000005,
+                "seconds": 0.9999819993972778,
+                "bytes": 5302255616,
+                "bits_per_second": 42418808492.11961,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.00003,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5176033280,
+                  "bits_per_second": 41407229653.44986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.00003,
+                "seconds": 1.0000250339508057,
+                "bytes": 5176033280,
+                "bits_per_second": 41407229653.44986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.00003,
+                  "end": 5.000008,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 5233967104,
+                  "bits_per_second": 41872657784.00552,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.00003,
+                "end": 5.000008,
+                "seconds": 0.9999780058860779,
+                "bytes": 5233967104,
+                "bits_per_second": 41872657784.00552,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000008,
+                  "end": 6.000007,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 5299765248,
+                  "bits_per_second": 42398164945.16853,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000008,
+                "end": 6.000007,
+                "seconds": 0.9999989867210388,
+                "bytes": 5299765248,
+                "bits_per_second": 42398164945.16853,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000007,
+                  "end": 7.000021,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5302255616,
+                  "bits_per_second": 42417453311.12657,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000007,
+                "end": 7.000021,
+                "seconds": 1.0000139474868774,
+                "bytes": 5302255616,
+                "bits_per_second": 42417453311.12657,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000021,
+                  "end": 8.000026,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 5336727552,
+                  "bits_per_second": 42693606658.070244,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000021,
+                "end": 8.000026,
+                "seconds": 1.0000050067901611,
+                "bytes": 5336727552,
+                "bits_per_second": 42693606658.070244,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000026,
+                  "end": 9.000032,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 5314183168,
+                  "bits_per_second": 42513211945.510376,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000026,
+                "end": 9.000032,
+                "seconds": 1.0000059604644775,
+                "bytes": 5314183168,
+                "bits_per_second": 42513211945.510376,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000018,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 5215485952,
+                  "bits_per_second": 41724472054.49879,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000018,
+                "seconds": 0.9999859929084778,
+                "bytes": 5215485952,
+                "bits_per_second": 41724472054.49879,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040334,
+                  "seconds": 10.040334,
+                  "bytes": 52741693968,
+                  "bits_per_second": 42023856152.99252,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000018,
+                  "seconds": 10.000018,
+                  "bytes": 52740645392,
+                  "bits_per_second": 42192440367.20734,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040334,
+              "seconds": 10.040334,
+              "bytes": 52741693968,
+              "bits_per_second": 42023856152.99252,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000018,
+              "seconds": 10.000018,
+              "bytes": 52740645392,
+              "bits_per_second": 42192440367.20734,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 58.72825614611755,
+              "host_user": 1.7371177997142697,
+              "host_system": 56.991148265535564,
+              "remote_total": 54.64429253795493,
+              "remote_user": 0.4133314501365237,
+              "remote_system": 54.23096108781841
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 43702,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:09 UTC",
+              "timesecs": 1711485189
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "ej3lg4uz6n42ag2pe7g773ltkpeisr4x4hzj",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1470700168,
+                  "bits_per_second": 11764930954.229,
+                  "retransmits": 1151,
+                  "snd_cwnd": 816888,
+                  "rtt": 591,
+                  "rttvar": 85,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1470700168,
+                "bits_per_second": 11764930954.229,
+                "retransmits": 1151,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1666939764,
+                  "bits_per_second": 13335505394.27101,
+                  "retransmits": 59,
+                  "snd_cwnd": 958428,
+                  "rtt": 636,
+                  "rttvar": 81,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1666939764,
+                "bits_per_second": 13335505394.27101,
+                "retransmits": 59,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000057,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1704166784,
+                  "bits_per_second": 13633348086.384787,
+                  "retransmits": 118,
+                  "snd_cwnd": 688828,
+                  "rtt": 360,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000057,
+                "seconds": 0.9999989867210388,
+                "bytes": 1704166784,
+                "bits_per_second": 13633348086.384787,
+                "retransmits": 118,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000057,
+                  "seconds": 1,
+                  "bytes": 1593611456,
+                  "bits_per_second": 12748891648,
+                  "retransmits": 128,
+                  "snd_cwnd": 804756,
+                  "rtt": 415,
+                  "rttvar": 1,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000057,
+                "seconds": 1,
+                "bytes": 1593611456,
+                "bits_per_second": 12748891648,
+                "retransmits": 128,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000058,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1778151040,
+                  "bits_per_second": 14225194753.797117,
+                  "retransmits": 49,
+                  "snd_cwnd": 953036,
+                  "rtt": 494,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000058,
+                "seconds": 1.0000009536743164,
+                "bytes": 1778151040,
+                "bits_per_second": 14225194753.797117,
+                "retransmits": 49,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000058,
+                  "end": 6.000056,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1775902848,
+                  "bits_per_second": 14207251575.818235,
+                  "retransmits": 79,
+                  "snd_cwnd": 850588,
+                  "rtt": 461,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000058,
+                "end": 6.000056,
+                "seconds": 0.9999979734420776,
+                "bytes": 1775902848,
+                "bits_per_second": 14207251575.818235,
+                "retransmits": 79,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000058,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1780742784,
+                  "bits_per_second": 14245913401.831335,
+                  "retransmits": 108,
+                  "snd_cwnd": 943600,
+                  "rtt": 507,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000058,
+                "seconds": 1.0000020265579224,
+                "bytes": 1780742784,
+                "bits_per_second": 14245913401.831335,
+                "retransmits": 108,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000058,
+                  "end": 8.000058,
+                  "seconds": 1,
+                  "bytes": 1778931136,
+                  "bits_per_second": 14231449088,
+                  "retransmits": 110,
+                  "snd_cwnd": 846544,
+                  "rtt": 461,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000058,
+                "end": 8.000058,
+                "seconds": 1,
+                "bytes": 1778931136,
+                "bits_per_second": 14231449088,
+                "retransmits": 110,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1771323712,
+                  "bits_per_second": 14170589696,
+                  "retransmits": 77,
+                  "snd_cwnd": 830368,
+                  "rtt": 478,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1771323712,
+                "bits_per_second": 14170589696,
+                "retransmits": 77,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000215,
+                  "seconds": 1.0001569986343384,
+                  "bytes": 1773207680,
+                  "bits_per_second": 14183434660.128132,
+                  "retransmits": 120,
+                  "snd_cwnd": 501456,
+                  "rtt": 244,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000215,
+                "seconds": 1.0001569986343384,
+                "bytes": 1773207680,
+                "bits_per_second": 14183434660.128132,
+                "retransmits": 120,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000215,
+                  "seconds": 10.000215,
+                  "bytes": 17093677372,
+                  "bits_per_second": 13674647892.670307,
+                  "retransmits": 1999,
+                  "max_snd_cwnd": 958428,
+                  "max_rtt": 636,
+                  "min_rtt": 244,
+                  "mean_rtt": 464,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039929,
+                  "seconds": 10.000215,
+                  "bytes": 17090819196,
+                  "bits_per_second": 13618278930.85698,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000215,
+              "seconds": 10.000215,
+              "bytes": 17093677372,
+              "bits_per_second": 13674647892.670307,
+              "retransmits": 1999,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039929,
+              "seconds": 10.039929,
+              "bytes": 17090819196,
+              "bits_per_second": 13618278930.85698,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 13.005006946322178,
+              "host_user": 0.19271754050004394,
+              "host_system": 12.812299324888505,
+              "remote_total": 23.26438245505795,
+              "remote_user": 0.8376646905752849,
+              "remote_system": 22.426726025964516
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 172.30.250.34 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.193",
+                "local_port": 57004,
+                "remote_host": "172.30.250.34",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:21 UTC",
+              "timesecs": 1711485201
+            },
+            "connecting_to": {
+              "host": "172.30.250.34",
+              "port": 5201
+            },
+            "cookie": "nck5rinkwkpmeyrrbqgb4qxwnraiomi5wga3",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000057,
+                  "seconds": 1.0000569820404053,
+                  "bytes": 1720841732,
+                  "bits_per_second": 13765949444.112558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000057,
+                "seconds": 1.0000569820404053,
+                "bytes": 1720841732,
+                "bits_per_second": 13765949444.112558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000057,
+                  "end": 2.000017,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 1732854844,
+                  "bits_per_second": 13863393214.483341,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000057,
+                "end": 2.000017,
+                "seconds": 0.9999600052833557,
+                "bytes": 1732854844,
+                "bits_per_second": 13863393214.483341,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000017,
+                  "end": 3.000057,
+                  "seconds": 1.000040054321289,
+                  "bytes": 1691401320,
+                  "bits_per_second": 13530668598.25271,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000017,
+                "end": 3.000057,
+                "seconds": 1.000040054321289,
+                "bytes": 1691401320,
+                "bits_per_second": 13530668598.25271,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000057,
+                  "end": 4.000067,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1568036736,
+                  "bits_per_second": 12544168275.963392,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000057,
+                "end": 4.000067,
+                "seconds": 1.0000100135803223,
+                "bytes": 1568036736,
+                "bits_per_second": 12544168275.963392,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000067,
+                  "end": 5.000031,
+                  "seconds": 0.9999639987945557,
+                  "bytes": 1557489984,
+                  "bits_per_second": 12460368460.284851,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000067,
+                "end": 5.000031,
+                "seconds": 0.9999639987945557,
+                "bytes": 1557489984,
+                "bits_per_second": 12460368460.284851,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000045,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900295853.805986,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000045,
+                "seconds": 1.0000139474868774,
+                "bytes": 1737561216,
+                "bits_per_second": 13900295853.805986,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000045,
+                  "end": 7.000026,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 1735555392,
+                  "bits_per_second": 13884707138.178734,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000045,
+                "end": 7.000026,
+                "seconds": 0.9999809861183167,
+                "bytes": 1735555392,
+                "bits_per_second": 13884707138.178734,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000033,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1590631612,
+                  "bits_per_second": 12724963396.90308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000033,
+                "seconds": 1.0000070333480835,
+                "bytes": 1590631612,
+                "bits_per_second": 12724963396.90308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000033,
+                  "end": 9.000026,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1589841984,
+                  "bits_per_second": 12718824569.819391,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000033,
+                "end": 9.000026,
+                "seconds": 0.9999930262565613,
+                "bytes": 1589841984,
+                "bits_per_second": 12718824569.819391,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000026,
+                  "seconds": 1,
+                  "bytes": 1480498380,
+                  "bits_per_second": 11843987040,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000026,
+                "seconds": 1,
+                "bytes": 1480498380,
+                "bits_per_second": 11843987040,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.03968,
+                  "seconds": 10.03968,
+                  "bytes": 16408142512,
+                  "bits_per_second": 13074633862.43386,
+                  "retransmits": 1734,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000026,
+                  "seconds": 10.000026,
+                  "bytes": 16404713200,
+                  "bits_per_second": 13123736438.285261,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.03968,
+              "seconds": 10.03968,
+              "bytes": 16408142512,
+              "bits_per_second": 13074633862.43386,
+              "retransmits": 1734,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000026,
+              "seconds": 10.000026,
+              "bytes": 16404713200,
+              "bits_per_second": 13123736438.285261,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 26.064632328384384,
+              "host_user": 1.162207899423042,
+              "host_system": 24.902424428961346,
+              "remote_total": 11.69062967191739,
+              "remote_user": 0.12009331046577057,
+              "remote_system": 11.570546012927187
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56708,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:39 UTC",
+              "timesecs": 1711485219
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "lvxzrfd7bbg56vzfpedoyyjvh3cpa2ay3a66",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000229,
+                  "seconds": 1.000229001045227,
+                  "bytes": 3386293120,
+                  "bits_per_second": 27084142663.02109,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000229,
+                "seconds": 1.000229001045227,
+                "bytes": 3386293120,
+                "bits_per_second": 27084142663.02109,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000229,
+                  "end": 2.000133,
+                  "seconds": 0.9999039769172668,
+                  "bytes": 3393454080,
+                  "bits_per_second": 27150239689.71195,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000229,
+                "end": 2.000133,
+                "seconds": 0.9999039769172668,
+                "bytes": 3393454080,
+                "bits_per_second": 27150239689.71195,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000133,
+                  "end": 3.000277,
+                  "seconds": 1.0001440048217773,
+                  "bytes": 3402629120,
+                  "bits_per_second": 27217113564.41186,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000133,
+                "end": 3.000277,
+                "seconds": 1.0001440048217773,
+                "bytes": 3402629120,
+                "bits_per_second": 27217113564.41186,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000277,
+                  "end": 4.000095,
+                  "seconds": 0.9998180270195007,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27309888701.844177,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000277,
+                "end": 4.000095,
+                "seconds": 0.9998180270195007,
+                "bytes": 3413114880,
+                "bits_per_second": 27309888701.844177,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000095,
+                  "end": 5.000135,
+                  "seconds": 1.000040054321289,
+                  "bytes": 3415736320,
+                  "bits_per_second": 27324796083.8385,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000095,
+                "end": 5.000135,
+                "seconds": 1.000040054321289,
+                "bytes": 3415736320,
+                "bits_per_second": 27324796083.8385,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000135,
+                  "end": 6.000236,
+                  "seconds": 1.0001009702682495,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27302162333.34541,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000135,
+                "end": 6.000236,
+                "seconds": 1.0001009702682495,
+                "bytes": 3413114880,
+                "bits_per_second": 27302162333.34541,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000236,
+                  "end": 7.000377,
+                  "seconds": 1.0001410245895386,
+                  "bytes": 3403939840,
+                  "bits_per_second": 27227678947.752304,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000236,
+                "end": 7.000377,
+                "seconds": 1.0001410245895386,
+                "bytes": 3403939840,
+                "bits_per_second": 27227678947.752304,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000377,
+                  "end": 8.000122,
+                  "seconds": 0.9997450113296509,
+                  "bytes": 3405250560,
+                  "bits_per_second": 27248952654.205704,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000377,
+                "end": 8.000122,
+                "seconds": 0.9997450113296509,
+                "bytes": 3405250560,
+                "bits_per_second": 27248952654.205704,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000122,
+                  "end": 9.000175,
+                  "seconds": 1.00005304813385,
+                  "bytes": 3457679360,
+                  "bits_per_second": 27659967570.33804,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 32,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000122,
+                "end": 9.000175,
+                "seconds": 1.00005304813385,
+                "bytes": 3457679360,
+                "bits_per_second": 27659967570.33804,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000175,
+                  "end": 10.000275,
+                  "seconds": 1.000100016593933,
+                  "bytes": 3503554560,
+                  "bits_per_second": 28025633451.599354,
+                  "retransmits": 0,
+                  "snd_cwnd": 798016,
+                  "rtt": 30,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000175,
+                "end": 10.000275,
+                "seconds": 1.000100016593933,
+                "bytes": 3503554560,
+                "bits_per_second": 28025633451.599354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000275,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27355061111.819424,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 798016,
+                  "max_rtt": 35,
+                  "min_rtt": 30,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040107,
+                  "seconds": 10.000275,
+                  "bytes": 34194766720,
+                  "bits_per_second": 27246535695.28691,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000275,
+              "seconds": 10.000275,
+              "bytes": 34194766720,
+              "bits_per_second": 27355061111.819424,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040107,
+              "seconds": 10.040107,
+              "bytes": 34194766720,
+              "bits_per_second": 27246535695.28691,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.44527815243438,
+              "host_user": 0.4874417118707169,
+              "host_system": 83.95785625929561,
+              "remote_total": 37.5809576369255,
+              "remote_user": 1.2945095444412822,
+              "remote_system": 36.286448092484214
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.108.164 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37086,
+                "remote_host": "172.30.108.164",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:33:51 UTC",
+              "timesecs": 1711485231
+            },
+            "connecting_to": {
+              "host": "172.30.108.164",
+              "port": 5201
+            },
+            "cookie": "hjaf5wh6iq6zbyow6d2v3heh672odpq7fvjt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000019,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 4331032904,
+                  "bits_per_second": 34647606511.66746,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000019,
+                "seconds": 1.0000189542770386,
+                "bytes": 4331032904,
+                "bits_per_second": 34647606511.66746,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000019,
+                  "end": 2.000003,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4384751616,
+                  "bits_per_second": 35078573274.701004,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000019,
+                "end": 2.000003,
+                "seconds": 0.9999840259552002,
+                "bytes": 4384751616,
+                "bits_per_second": 35078573274.701004,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000003,
+                  "end": 3.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4398120960,
+                  "bits_per_second": 35184405642.72801,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000003,
+                "end": 3.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 4398120960,
+                "bits_per_second": 35184405642.72801,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000019,
+                  "end": 4.000018,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 4399955968,
+                  "bits_per_second": 35199683411.09864,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000019,
+                "end": 4.000018,
+                "seconds": 0.9999989867210388,
+                "bytes": 4399955968,
+                "bits_per_second": 35199683411.09864,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000002,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 4368367616,
+                  "bits_per_second": 34947499180.91756,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000002,
+                "seconds": 0.9999840259552002,
+                "bytes": 4368367616,
+                "bits_per_second": 34947499180.91756,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000002,
+                  "end": 6.000018,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 4274782208,
+                  "bits_per_second": 34197711388.226234,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000002,
+                "end": 6.000018,
+                "seconds": 1.0000159740447998,
+                "bytes": 4274782208,
+                "bits_per_second": 34197711388.226234,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000016,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 4378853376,
+                  "bits_per_second": 35030898000.14387,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000016,
+                "seconds": 0.9999979734420776,
+                "bytes": 4378853376,
+                "bits_per_second": 35030898000.14387,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000016,
+                  "end": 8.000018,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 4318953472,
+                  "bits_per_second": 34551557755.2669,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000016,
+                "end": 8.000018,
+                "seconds": 1.0000020265579224,
+                "bytes": 4318953472,
+                "bits_per_second": 34551557755.2669,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000018,
+                  "end": 9.000035,
+                  "seconds": 1.0000170469284058,
+                  "bytes": 4416208896,
+                  "bits_per_second": 35329068915.89155,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000018,
+                "end": 9.000035,
+                "seconds": 1.0000170469284058,
+                "bytes": 4416208896,
+                "bits_per_second": 35329068915.89155,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000035,
+                  "end": 10.00001,
+                  "seconds": 0.9999750256538391,
+                  "bytes": 4437573632,
+                  "bits_per_second": 35501475682.14291,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000035,
+                "end": 10.00001,
+                "seconds": 0.9999750256538391,
+                "bytes": 4437573632,
+                "bits_per_second": 35501475682.14291,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040164,
+                  "seconds": 10.040164,
+                  "bytes": 43710042440,
+                  "bits_per_second": 34828150169.65858,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00001,
+                  "seconds": 10.00001,
+                  "bytes": 43708600648,
+                  "bits_per_second": 34966845551.55445,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040164,
+              "seconds": 10.040164,
+              "bytes": 43710042440,
+              "bits_per_second": 34828150169.65858,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.00001,
+              "seconds": 10.00001,
+              "bytes": 43708600648,
+              "bits_per_second": 34966845551.55445,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.26294493237891,
+              "host_user": 1.8116036545309533,
+              "host_system": 89.45135119667133,
+              "remote_total": 44.14246868282316,
+              "remote_user": 0.32552835005268926,
+              "remote_system": 43.816940332770464
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55424,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:09 UTC",
+              "timesecs": 1711485249
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "sk45wjxyccre6ookk5kcdjs6uspriubkoeug",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000296,
+                  "seconds": 1.0002959966659546,
+                  "bytes": 1501175364,
+                  "bits_per_second": 12005849220.658731,
+                  "retransmits": 40,
+                  "snd_cwnd": 641648,
+                  "rtt": 391,
+                  "rttvar": 37,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000296,
+                "seconds": 1.0002959966659546,
+                "bytes": 1501175364,
+                "bits_per_second": 12005849220.658731,
+                "retransmits": 40,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000296,
+                  "end": 2.000231,
+                  "seconds": 0.99993497133255,
+                  "bytes": 1529610240,
+                  "bits_per_second": 12237677719.874805,
+                  "retransmits": 12,
+                  "snd_cwnd": 787232,
+                  "rtt": 223,
+                  "rttvar": 31,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000296,
+                "end": 2.000231,
+                "seconds": 0.99993497133255,
+                "bytes": 1529610240,
+                "bits_per_second": 12237677719.874805,
+                "retransmits": 12,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000231,
+                  "end": 3.000429,
+                  "seconds": 1.0001980066299438,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12286877836.727018,
+                  "retransmits": 13,
+                  "snd_cwnd": 655128,
+                  "rtt": 228,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000231,
+                "end": 3.000429,
+                "seconds": 1.0001980066299438,
+                "bytes": 1536163840,
+                "bits_per_second": 12286877836.727018,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000429,
+                  "end": 4.000044,
+                  "seconds": 0.9996150135993958,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12367472348.664085,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 193,
+                  "rttvar": 25,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000429,
+                "end": 4.000044,
+                "seconds": 0.9996150135993958,
+                "bytes": 1545338880,
+                "bits_per_second": 12367472348.664085,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000044,
+                  "end": 5.000092,
+                  "seconds": 1.000048041343689,
+                  "bytes": 1523056640,
+                  "bits_per_second": 12183867790.62001,
+                  "retransmits": 2,
+                  "snd_cwnd": 936860,
+                  "rtt": 606,
+                  "rttvar": 12,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000044,
+                "end": 5.000092,
+                "seconds": 1.000048041343689,
+                "bytes": 1523056640,
+                "bits_per_second": 12183867790.62001,
+                "retransmits": 2,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000092,
+                  "end": 6.000681,
+                  "seconds": 1.0005890130996704,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12376392702.57152,
+                  "retransmits": 6,
+                  "snd_cwnd": 829020,
+                  "rtt": 197,
+                  "rttvar": 54,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000092,
+                "end": 6.000681,
+                "seconds": 1.0005890130996704,
+                "bytes": 1547960320,
+                "bits_per_second": 12376392702.57152,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000681,
+                  "end": 7.000548,
+                  "seconds": 0.9998670220375061,
+                  "bytes": 1547960320,
+                  "bits_per_second": 12385329535.886497,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 218,
+                  "rttvar": 40,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000681,
+                "end": 7.000548,
+                "seconds": 0.9998670220375061,
+                "bytes": 1547960320,
+                "bits_per_second": 12385329535.886497,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000548,
+                  "end": 8.000077,
+                  "seconds": 0.9995290040969849,
+                  "bytes": 1534853120,
+                  "bits_per_second": 12284610961.43297,
+                  "retransmits": 0,
+                  "snd_cwnd": 917988,
+                  "rtt": 200,
+                  "rttvar": 33,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000548,
+                "end": 8.000077,
+                "seconds": 0.9995290040969849,
+                "bytes": 1534853120,
+                "bits_per_second": 12284610961.43297,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000077,
+                  "end": 9.000416,
+                  "seconds": 1.0003390312194824,
+                  "bytes": 1536163840,
+                  "bits_per_second": 12285145672.081276,
+                  "retransmits": 0,
+                  "snd_cwnd": 934164,
+                  "rtt": 220,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000077,
+                "end": 9.000416,
+                "seconds": 1.0003390312194824,
+                "bytes": 1536163840,
+                "bits_per_second": 12285145672.081276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000416,
+                  "end": 10.00071,
+                  "seconds": 1.0002939701080322,
+                  "bytes": 1544028160,
+                  "bits_per_second": 12348595162.146137,
+                  "retransmits": 50,
+                  "snd_cwnd": 776448,
+                  "rtt": 184,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000416,
+                "end": 10.00071,
+                "seconds": 1.0002939701080322,
+                "bytes": 1544028160,
+                "bits_per_second": 12348595162.146137,
+                "retransmits": 50,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.00071,
+                  "seconds": 10.00071,
+                  "bytes": 15346310724,
+                  "bits_per_second": 12276176970.635086,
+                  "retransmits": 123,
+                  "max_snd_cwnd": 936860,
+                  "max_rtt": 606,
+                  "min_rtt": 184,
+                  "mean_rtt": 266,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040277,
+                  "seconds": 10.00071,
+                  "bytes": 15346244356,
+                  "bits_per_second": 12227745793.069256,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.00071,
+              "seconds": 10.00071,
+              "bytes": 15346310724,
+              "bits_per_second": 12276176970.635086,
+              "retransmits": 123,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040277,
+              "seconds": 10.040277,
+              "bytes": 15346244356,
+              "bits_per_second": 12227745793.069256,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 95.82562437024121,
+              "host_user": 0.2560031758234491,
+              "host_system": 95.56962119441776,
+              "remote_total": 24.102997438800752,
+              "remote_user": 1.0351409018247604,
+              "remote_system": 23.06785653697599
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.85.71 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39456,
+                "remote_host": "172.30.85.71",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:21 UTC",
+              "timesecs": 1711485261
+            },
+            "connecting_to": {
+              "host": "172.30.85.71",
+              "port": 5201
+            },
+            "cookie": "o42kid5a4pbdh32bjbwm7qioyzovzdrbbl7l",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1697801956,
+                  "bits_per_second": 13582334690.976553,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1697801956,
+                "bits_per_second": 13582334690.976553,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000057,
+                  "seconds": 1.0000510215759277,
+                  "bytes": 1744419840,
+                  "bits_per_second": 13954646731.932222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000057,
+                "seconds": 1.0000510215759277,
+                "bytes": 1744419840,
+                "bits_per_second": 13954646731.932222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000057,
+                  "end": 3.000015,
+                  "seconds": 0.9999579787254333,
+                  "bytes": 1748195168,
+                  "bits_per_second": 13986149059.809772,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000057,
+                "end": 3.000015,
+                "seconds": 0.9999579787254333,
+                "bytes": 1748195168,
+                "bits_per_second": 13986149059.809772,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000015,
+                  "end": 4.000028,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1734067200,
+                  "bits_per_second": 13872357345.188877,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000015,
+                "end": 4.000028,
+                "seconds": 1.000012993812561,
+                "bytes": 1734067200,
+                "bits_per_second": 13872357345.188877,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000028,
+                  "end": 5.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1729473216,
+                  "bits_per_second": 13835744494.268211,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000028,
+                "end": 5.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 1729473216,
+                "bits_per_second": 13835744494.268211,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000014,
+                  "seconds": 0.999983012676239,
+                  "bytes": 1727920320,
+                  "bits_per_second": 13823597385.924335,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000014,
+                "seconds": 0.999983012676239,
+                "bytes": 1727920320,
+                "bits_per_second": 13823597385.924335,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000014,
+                  "end": 7.000057,
+                  "seconds": 1.0000430345535278,
+                  "bytes": 1720414656,
+                  "bits_per_second": 13762724975.275362,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000014,
+                "end": 7.000057,
+                "seconds": 1.0000430345535278,
+                "bytes": 1720414656,
+                "bits_per_second": 13762724975.275362,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000012,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 1731396632,
+                  "bits_per_second": 13851796407.710308,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000012,
+                "seconds": 0.9999549984931946,
+                "bytes": 1731396632,
+                "bits_per_second": 13851796407.710308,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000012,
+                  "end": 9.000057,
+                  "seconds": 1.0000449419021606,
+                  "bytes": 1731026112,
+                  "bits_per_second": 13847586559.1197,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000012,
+                "end": 9.000057,
+                "seconds": 1.0000449419021606,
+                "bytes": 1731026112,
+                "bits_per_second": 13847586559.1197,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000057,
+                  "end": 10.000029,
+                  "seconds": 0.9999719858169556,
+                  "bytes": 1741314048,
+                  "bits_per_second": 13930902646.856724,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000057,
+                "end": 10.000029,
+                "seconds": 0.9999719858169556,
+                "bytes": 1741314048,
+                "bits_per_second": 13930902646.856724,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039465,
+                  "seconds": 10.039465,
+                  "bytes": 17308229084,
+                  "bits_per_second": 13792152537.211893,
+                  "retransmits": 2195,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000029,
+                  "seconds": 10.000029,
+                  "bytes": 17306029148,
+                  "bits_per_second": 13844783168.528812,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039465,
+              "seconds": 10.039465,
+              "bytes": 17308229084,
+              "bits_per_second": 13792152537.211893,
+              "retransmits": 2195,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000029,
+              "seconds": 10.000029,
+              "bytes": 17306029148,
+              "bits_per_second": 13844783168.528812,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.47684113065824,
+              "host_user": 1.8968527601361653,
+              "host_system": 42.57999828989936,
+              "remote_total": 12.529305328982618,
+              "remote_user": 0.09332895016906215,
+              "remote_system": 12.435986036196645
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 56016,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:38 UTC",
+              "timesecs": 1711485278
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "ysnlajgt2kv4vtw3vuw5ghlvl2vdvsskzxpr",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000293,
+                  "seconds": 1.0002930164337158,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25745482710.471886,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000293,
+                "seconds": 1.0002930164337158,
+                "bytes": 3219128320,
+                "bits_per_second": 25745482710.471886,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000293,
+                  "end": 2.000138,
+                  "seconds": 0.999845027923584,
+                  "bytes": 3219128320,
+                  "bits_per_second": 25757018178.58942,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 37,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000293,
+                "end": 2.000138,
+                "seconds": 0.999845027923584,
+                "bytes": 3219128320,
+                "bits_per_second": 25757018178.58942,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000138,
+                  "end": 3.000088,
+                  "seconds": 0.9999499917030334,
+                  "bytes": 3282042880,
+                  "bits_per_second": 26257656140.665928,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000138,
+                "end": 3.000088,
+                "seconds": 0.9999499917030334,
+                "bytes": 3282042880,
+                "bits_per_second": 26257656140.665928,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000088,
+                  "end": 4.000243,
+                  "seconds": 1.000154972076416,
+                  "bytes": 3465543680,
+                  "bits_per_second": 27720053605.734356,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000088,
+                "end": 4.000243,
+                "seconds": 1.000154972076416,
+                "bytes": 3465543680,
+                "bits_per_second": 27720053605.734356,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000243,
+                  "end": 5.000101,
+                  "seconds": 0.999858021736145,
+                  "bytes": 3481272320,
+                  "bits_per_second": 27854133241.47881,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000243,
+                "end": 5.000101,
+                "seconds": 0.999858021736145,
+                "bytes": 3481272320,
+                "bits_per_second": 27854133241.47881,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000101,
+                  "end": 6.000015,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 3489136640,
+                  "bits_per_second": 27915494117.75862,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000101,
+                "end": 6.000015,
+                "seconds": 0.9999139904975891,
+                "bytes": 3489136640,
+                "bits_per_second": 27915494117.75862,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000015,
+                  "end": 7.000294,
+                  "seconds": 1.0002789497375488,
+                  "bytes": 3472097280,
+                  "bits_per_second": 27769032075.790474,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 34,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000015,
+                "end": 7.000294,
+                "seconds": 1.0002789497375488,
+                "bytes": 3472097280,
+                "bits_per_second": 27769032075.790474,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000294,
+                  "end": 8.000249,
+                  "seconds": 0.9999549984931946,
+                  "bytes": 3482583040,
+                  "bits_per_second": 27861918148.299164,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000294,
+                "end": 8.000249,
+                "seconds": 0.9999549984931946,
+                "bytes": 3482583040,
+                "bits_per_second": 27861918148.299164,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000249,
+                  "end": 9.000268,
+                  "seconds": 1.0000189542770386,
+                  "bytes": 3388211200,
+                  "bits_per_second": 27105175840.98793,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 35,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000249,
+                "end": 9.000268,
+                "seconds": 1.0000189542770386,
+                "bytes": 3388211200,
+                "bits_per_second": 27105175840.98793,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000268,
+                  "end": 10.000366,
+                  "seconds": 1.0000979900360107,
+                  "bytes": 3389521920,
+                  "bits_per_second": 27113518505.345284,
+                  "retransmits": 0,
+                  "snd_cwnd": 663216,
+                  "rtt": 31,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000268,
+                "end": 10.000366,
+                "seconds": 1.0000979900360107,
+                "bytes": 3389521920,
+                "bits_per_second": 27113518505.345284,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000366,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27109940256.186626,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 663216,
+                  "max_rtt": 37,
+                  "min_rtt": 31,
+                  "mean_rtt": 33,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039647,
+                  "seconds": 10.000366,
+                  "bytes": 33888665600,
+                  "bits_per_second": 27003870235.676613,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000366,
+              "seconds": 10.000366,
+              "bytes": 33888665600,
+              "bits_per_second": 27109940256.186626,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039647,
+              "seconds": 10.039647,
+              "bytes": 33888665600,
+              "bits_per_second": 27003870235.676613,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.6366144037512,
+              "host_user": 0.5079154773387307,
+              "host_system": 98.12868897353042,
+              "remote_total": 69.33475570009895,
+              "remote_user": 1.8358332803622874,
+              "remote_system": 67.4989133777374
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.16.61 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 41272,
+                "remote_host": "172.30.16.61",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:34:50 UTC",
+              "timesecs": 1711485290
+            },
+            "connecting_to": {
+              "host": "172.30.16.61",
+              "port": 5201
+            },
+            "cookie": "5gmodl5epqhfruamszr7f63cdemcm7v7luuw",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000015,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 3679605064,
+                  "bits_per_second": 29436398366.39084,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000015,
+                "seconds": 1.0000150203704834,
+                "bytes": 3679605064,
+                "bits_per_second": 29436398366.39084,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000015,
+                  "end": 2.00001,
+                  "seconds": 0.9999949932098389,
+                  "bytes": 3648388804,
+                  "bits_per_second": 29187256566.469006,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000015,
+                "end": 2.00001,
+                "seconds": 0.9999949932098389,
+                "bytes": 3648388804,
+                "bits_per_second": 29187256566.469006,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000028,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 3632922940,
+                  "bits_per_second": 29062860370.99649,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000028,
+                "seconds": 1.0000180006027222,
+                "bytes": 3632922940,
+                "bits_per_second": 29062860370.99649,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000028,
+                  "end": 4.000024,
+                  "seconds": 0.9999960064888,
+                  "bytes": 3643932672,
+                  "bits_per_second": 29151577793.152412,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000028,
+                "end": 4.000024,
+                "seconds": 0.9999960064888,
+                "bytes": 3643932672,
+                "bits_per_second": 29151577793.152412,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000024,
+                  "end": 5.000031,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 3619028992,
+                  "bits_per_second": 28952028306.307198,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000024,
+                "end": 5.000031,
+                "seconds": 1.0000070333480835,
+                "bytes": 3619028992,
+                "bits_per_second": 28952028306.307198,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000031,
+                  "end": 6.000037,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 3631349760,
+                  "bits_per_second": 29050624924.782085,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000031,
+                "end": 6.000037,
+                "seconds": 1.0000059604644775,
+                "bytes": 3631349760,
+                "bits_per_second": 29050624924.782085,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000037,
+                  "end": 7.000025,
+                  "seconds": 0.9999880194664001,
+                  "bytes": 3610509312,
+                  "bits_per_second": 28884420546.770874,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000037,
+                "end": 7.000025,
+                "seconds": 0.9999880194664001,
+                "bytes": 3610509312,
+                "bits_per_second": 28884420546.770874,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000025,
+                  "end": 8.000022,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3608674304,
+                  "bits_per_second": 28869480469.756413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000025,
+                "end": 8.000022,
+                "seconds": 0.9999970197677612,
+                "bytes": 3608674304,
+                "bits_per_second": 28869480469.756413,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000022,
+                  "end": 9.000038,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 3623223296,
+                  "bits_per_second": 28985323355.146187,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000022,
+                "end": 9.000038,
+                "seconds": 1.0000159740447998,
+                "bytes": 3623223296,
+                "bits_per_second": 28985323355.146187,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000038,
+                  "end": 10.000021,
+                  "seconds": 0.999983012676239,
+                  "bytes": 3621519360,
+                  "bits_per_second": 28972647047.73561,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000038,
+                "end": 10.000021,
+                "seconds": 0.999983012676239,
+                "bytes": 3621519360,
+                "bits_per_second": 28972647047.73561,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039809,
+                  "seconds": 10.039809,
+                  "bytes": 36320203080,
+                  "bits_per_second": 28940951430.45052,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000021,
+                  "seconds": 10.000021,
+                  "bytes": 36319154504,
+                  "bits_per_second": 29055262587.148567,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039809,
+              "seconds": 10.039809,
+              "bytes": 36320203080,
+              "bits_per_second": 28940951430.45052,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000021,
+              "seconds": 10.000021,
+              "bytes": 36319154504,
+              "bits_per_second": 29055262587.148567,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.40432984604324,
+              "host_user": 2.1048623181527053,
+              "host_system": 84.29947744708186,
+              "remote_total": 96.37010529501002,
+              "remote_user": 0.5200516733573617,
+              "remote_system": 95.85006329541284
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 35114,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:07 UTC",
+              "timesecs": 1711485307
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "nzwskjxxz46hf7ecx7s6uvn3nsimlfx6e4fv",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 2927638472,
+                  "bits_per_second": 23419748144.30112,
+                  "retransmits": 368,
+                  "snd_cwnd": 2701392,
+                  "rtt": 911,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 2927638472,
+                "bits_per_second": 23419748144.30112,
+                "retransmits": 368,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000132,
+                  "seconds": 1.000074028968811,
+                  "bytes": 2915041280,
+                  "bits_per_second": 23318603987.79267,
+                  "retransmits": 202,
+                  "snd_cwnd": 2724308,
+                  "rtt": 935,
+                  "rttvar": 42,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000132,
+                "seconds": 1.000074028968811,
+                "bytes": 2915041280,
+                "bits_per_second": 23318603987.79267,
+                "retransmits": 202,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000132,
+                  "end": 3.000059,
+                  "seconds": 0.9999269843101501,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416411845.464706,
+                  "retransmits": 13,
+                  "snd_cwnd": 2744528,
+                  "rtt": 900,
+                  "rttvar": 30,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000132,
+                "end": 3.000059,
+                "seconds": 0.9999269843101501,
+                "bytes": 2926837760,
+                "bits_per_second": 23416411845.464706,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000057,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23404263750.09612,
+                  "retransmits": 6,
+                  "snd_cwnd": 2345520,
+                  "rtt": 798,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000057,
+                "seconds": 0.9999979734420776,
+                "bytes": 2925527040,
+                "bits_per_second": 23404263750.09612,
+                "retransmits": 6,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000144,
+                  "seconds": 1.000087022781372,
+                  "bytes": 2929459200,
+                  "bits_per_second": 23433634339.962082,
+                  "retransmits": 4,
+                  "snd_cwnd": 2325300,
+                  "rtt": 778,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000144,
+                "seconds": 1.000087022781372,
+                "bytes": 2929459200,
+                "bits_per_second": 23433634339.962082,
+                "retransmits": 4,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000144,
+                  "end": 6.000058,
+                  "seconds": 0.9999139904975891,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416716140.103306,
+                  "retransmits": 0,
+                  "snd_cwnd": 3097704,
+                  "rtt": 1023,
+                  "rttvar": 3,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000144,
+                "end": 6.000058,
+                "seconds": 0.9999139904975891,
+                "bytes": 2926837760,
+                "bits_per_second": 23416716140.103306,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.000149,
+                  "seconds": 1.0000909566879272,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23423057356.281742,
+                  "retransmits": 0,
+                  "snd_cwnd": 3165104,
+                  "rtt": 1109,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.000149,
+                "seconds": 1.0000909566879272,
+                "bytes": 2928148480,
+                "bits_per_second": 23423057356.281742,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000149,
+                  "end": 8.000068,
+                  "seconds": 0.9999189972877502,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416598888.021595,
+                  "retransmits": 711,
+                  "snd_cwnd": 2543676,
+                  "rtt": 841,
+                  "rttvar": 14,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000149,
+                "end": 8.000068,
+                "seconds": 0.9999189972877502,
+                "bytes": 2926837760,
+                "bits_per_second": 23416598888.021595,
+                "retransmits": 711,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000068,
+                  "end": 9.000241,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23421136623.249817,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 1059,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000068,
+                "end": 9.000241,
+                "seconds": 1.0001729726791382,
+                "bytes": 2928148480,
+                "bits_per_second": 23421136623.249817,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000241,
+                  "end": 10.000231,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414936547.34786,
+                  "retransmits": 0,
+                  "snd_cwnd": 3157016,
+                  "rtt": 781,
+                  "rttvar": 78,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000241,
+                "end": 10.000231,
+                "seconds": 0.9999899864196777,
+                "bytes": 2926837760,
+                "bits_per_second": 23414936547.34786,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000231,
+                  "seconds": 10.000231,
+                  "bytes": 29261313992,
+                  "bits_per_second": 23408510457.008446,
+                  "retransmits": 1304,
+                  "max_snd_cwnd": 3165104,
+                  "max_rtt": 1109,
+                  "min_rtt": 778,
+                  "mean_rtt": 913,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040346,
+                  "seconds": 10.000231,
+                  "bytes": 29260124328,
+                  "bits_per_second": 23314036650.131382,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000231,
+              "seconds": 10.000231,
+              "bytes": 29261313992,
+              "bits_per_second": 23408510457.008446,
+              "retransmits": 1304,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040346,
+              "seconds": 10.040346,
+              "bytes": 29260124328,
+              "bits_per_second": 23314036650.131382,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.97762289166434,
+              "host_user": 0.5691962216451614,
+              "host_system": 34.40843658477508,
+              "remote_total": 62.9251445256492,
+              "remote_user": 2.6124474135751976,
+              "remote_system": 60.31269711207401
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.148.98 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 55052,
+                "remote_host": "172.30.148.98",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:19 UTC",
+              "timesecs": 1711485319
+            },
+            "connecting_to": {
+              "host": "172.30.148.98",
+              "port": 5201
+            },
+            "cookie": "5oofuvu3qi3r7fkq5kvznrrjjmxzbzw7dgby",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000014,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2924870228,
+                  "bits_per_second": 23398635471.838806,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000014,
+                "seconds": 1.0000139474868774,
+                "bytes": 2924870228,
+                "bits_per_second": 23398635471.838806,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000014,
+                  "end": 2.000028,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 2928633648,
+                  "bits_per_second": 23428742411.922653,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000014,
+                "end": 2.000028,
+                "seconds": 1.0000139474868774,
+                "bytes": 2928633648,
+                "bits_per_second": 23428742411.922653,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000028,
+                  "end": 3.000026,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2912575888,
+                  "bits_per_second": 23300654324.125618,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000028,
+                "end": 3.000026,
+                "seconds": 0.9999979734420776,
+                "bytes": 2912575888,
+                "bits_per_second": 23300654324.125618,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000009,
+                  "seconds": 0.999983012676239,
+                  "bytes": 2928793176,
+                  "bits_per_second": 23430743433.62467,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000009,
+                "seconds": 0.999983012676239,
+                "bytes": 2928793176,
+                "bits_per_second": 23430743433.62467,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000009,
+                  "end": 5.000024,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2927518936,
+                  "bits_per_second": 23419799713.93165,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000009,
+                "end": 5.000024,
+                "seconds": 1.0000150203704834,
+                "bytes": 2927518936,
+                "bits_per_second": 23419799713.93165,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000024,
+                  "end": 6.000039,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 2928627108,
+                  "bits_per_second": 23428664956.77242,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000024,
+                "end": 6.000039,
+                "seconds": 1.0000150203704834,
+                "bytes": 2928627108,
+                "bits_per_second": 23428664956.77242,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000039,
+                  "end": 7.000044,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2924520712,
+                  "bits_per_second": 23396048556.894276,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000039,
+                "end": 7.000044,
+                "seconds": 1.0000050067901611,
+                "bytes": 2924520712,
+                "bits_per_second": 23396048556.894276,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000044,
+                  "end": 8.00003,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 2928023612,
+                  "bits_per_second": 23424517005.353558,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000044,
+                "end": 8.00003,
+                "seconds": 0.9999859929084778,
+                "bytes": 2928023612,
+                "bits_per_second": 23424517005.353558,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00003,
+                  "end": 9.000029,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927982060,
+                  "bits_per_second": 23423880214.92501,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.00003,
+                "end": 9.000029,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927982060,
+                "bits_per_second": 23423880214.92501,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000029,
+                  "end": 10.000013,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2927753088,
+                  "bits_per_second": 23422398854.44862,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000029,
+                "end": 10.000013,
+                "seconds": 0.9999840259552002,
+                "bytes": 2927753088,
+                "bits_per_second": 23422398854.44862,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039882,
+                  "seconds": 10.039882,
+                  "bytes": 29263263664,
+                  "bits_per_second": 23317615616.597885,
+                  "retransmits": 2270,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000013,
+                  "seconds": 10.000013,
+                  "bytes": 29259298456,
+                  "bits_per_second": 23407408335.169167,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039882,
+              "seconds": 10.039882,
+              "bytes": 29263263664,
+              "bits_per_second": 23317615616.597885,
+              "retransmits": 2270,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000013,
+              "seconds": 10.000013,
+              "bytes": 29259298456,
+              "bits_per_second": 23407408335.169167,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 88.6667781634535,
+              "host_user": 2.169277119907057,
+              "host_system": 86.4975109631894,
+              "remote_total": 22.440235970749637,
+              "remote_user": 0.4127789042736779,
+              "remote_system": 22.027466720316273
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 50458,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:37 UTC",
+              "timesecs": 1711485337
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "z5g3vhadeeoamy6eq32u6bsm7e5abmztwhfd",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000278,
+                  "seconds": 1.0002779960632324,
+                  "bytes": 3395979324,
+                  "bits_per_second": 27160284139.932823,
+                  "retransmits": 0,
+                  "snd_cwnd": 884288,
+                  "rtt": 40,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000278,
+                "seconds": 1.0002779960632324,
+                "bytes": 3395979324,
+                "bits_per_second": 27160284139.932823,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000278,
+                  "end": 2.000255,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27473323289.542732,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000278,
+                "end": 2.000255,
+                "seconds": 0.9999769926071167,
+                "bytes": 3434086400,
+                "bits_per_second": 27473323289.542732,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000255,
+                  "end": 3.000046,
+                  "seconds": 0.9997910261154175,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530873233.52556,
+                  "retransmits": 0,
+                  "snd_cwnd": 974604,
+                  "rtt": 35,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000255,
+                "end": 3.000046,
+                "seconds": 0.9997910261154175,
+                "bytes": 3440640000,
+                "bits_per_second": 27530873233.52556,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000046,
+                  "end": 4.000267,
+                  "seconds": 1.0002210140228271,
+                  "bytes": 3413114880,
+                  "bits_per_second": 27298885603.47408,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000046,
+                "end": 4.000267,
+                "seconds": 1.0002210140228271,
+                "bytes": 3413114880,
+                "bits_per_second": 27298885603.47408,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000267,
+                  "end": 5.000044,
+                  "seconds": 0.9997770190238953,
+                  "bytes": 3420979200,
+                  "bits_per_second": 27373937467.296288,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 35,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000267,
+                "end": 5.000044,
+                "seconds": 0.9997770190238953,
+                "bytes": 3420979200,
+                "bits_per_second": 27373937467.296288,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000044,
+                  "end": 6.000099,
+                  "seconds": 1.000054955482483,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27523607426.874187,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000044,
+                "end": 6.000099,
+                "seconds": 1.000054955482483,
+                "bytes": 3440640000,
+                "bits_per_second": 27523607426.874187,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000099,
+                  "end": 7.000285,
+                  "seconds": 1.0001859664916992,
+                  "bytes": 3441950720,
+                  "bits_per_second": 27530486012.101555,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000099,
+                "end": 7.000285,
+                "seconds": 1.0001859664916992,
+                "bytes": 3441950720,
+                "bits_per_second": 27530486012.101555,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000285,
+                  "end": 8.000245,
+                  "seconds": 0.9999600052833557,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27526220903.40532,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 34,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000285,
+                "end": 8.000245,
+                "seconds": 0.9999600052833557,
+                "bytes": 3440640000,
+                "bits_per_second": 27526220903.40532,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000245,
+                  "end": 9.000034,
+                  "seconds": 0.9997889995574951,
+                  "bytes": 3440640000,
+                  "bits_per_second": 27530929038.209633,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 33,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000245,
+                "end": 9.000034,
+                "seconds": 0.9997889995574951,
+                "bytes": 3440640000,
+                "bits_per_second": 27530929038.209633,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000034,
+                  "end": 10.000143,
+                  "seconds": 1.0001089572906494,
+                  "bytes": 3434086400,
+                  "bits_per_second": 27469698176.111774,
+                  "retransmits": 0,
+                  "snd_cwnd": 1074356,
+                  "rtt": 31,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000034,
+                "end": 10.000143,
+                "seconds": 1.0001089572906494,
+                "bytes": 3434086400,
+                "bits_per_second": 27469698176.111774,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000143,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27441813121.272366,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 1074356,
+                  "max_rtt": 40,
+                  "min_rtt": 31,
+                  "mean_rtt": 34,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039944,
+                  "seconds": 10.000143,
+                  "bytes": 34302756924,
+                  "bits_per_second": 27333026498.155766,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000143,
+              "seconds": 10.000143,
+              "bytes": 34302756924,
+              "bits_per_second": 27441813121.272366,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.039944,
+              "seconds": 10.039944,
+              "bytes": 34302756924,
+              "bits_per_second": 27333026498.155766,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 84.72291319227105,
+              "host_user": 0.5304700943978504,
+              "host_system": 84.19243318754582,
+              "remote_total": 37.30641845607046,
+              "remote_user": 1.3600734652179878,
+              "remote_system": 35.946344990852474
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.187.145 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 53048,
+                "remote_host": "172.30.187.145",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:35:49 UTC",
+              "timesecs": 1711485349
+            },
+            "connecting_to": {
+              "host": "172.30.187.145",
+              "port": 5201
+            },
+            "cookie": "pflklkxtl3va2b7jnnwfck2oaqw6oaesemei",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000028,
+                  "seconds": 1.0000280141830444,
+                  "bytes": 4393816392,
+                  "bits_per_second": 35149546450.171814,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000028,
+                "seconds": 1.0000280141830444,
+                "bytes": 4393816392,
+                "bits_per_second": 35149546450.171814,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000028,
+                  "end": 2.000009,
+                  "seconds": 0.9999809861183167,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159421797.086105,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000028,
+                "end": 2.000009,
+                "seconds": 0.9999809861183167,
+                "bytes": 4394844160,
+                "bits_per_second": 35159421797.086105,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000009,
+                  "end": 3.000006,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 4315414528,
+                  "bits_per_second": 34523419111.80663,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000009,
+                "end": 3.000006,
+                "seconds": 0.9999970197677612,
+                "bytes": 4315414528,
+                "bits_per_second": 34523419111.80663,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000006,
+                  "end": 4.000048,
+                  "seconds": 1.0000419616699219,
+                  "bytes": 4349886464,
+                  "bits_per_second": 34797631545.271034,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000006,
+                "end": 4.000048,
+                "seconds": 1.0000419616699219,
+                "bytes": 4349886464,
+                "bits_per_second": 34797631545.271034,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000048,
+                  "end": 5.000028,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 4430495744,
+                  "bits_per_second": 35444675808.21641,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000048,
+                "end": 5.000028,
+                "seconds": 0.9999799728393555,
+                "bytes": 4430495744,
+                "bits_per_second": 35444675808.21641,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000028,
+                  "end": 6.000031,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 4407427072,
+                  "bits_per_second": 35259311495.06316,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000028,
+                "end": 6.000031,
+                "seconds": 1.0000029802322388,
+                "bytes": 4407427072,
+                "bits_per_second": 35259311495.06316,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000031,
+                  "end": 7.000009,
+                  "seconds": 0.9999780058860779,
+                  "bytes": 4397727744,
+                  "bits_per_second": 35182595762.019264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000031,
+                "end": 7.000009,
+                "seconds": 0.9999780058860779,
+                "bytes": 4397727744,
+                "bits_per_second": 35182595762.019264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000027,
+                  "seconds": 1.0000180006027222,
+                  "bytes": 4317599700,
+                  "bits_per_second": 34540175856.016464,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000027,
+                "seconds": 1.0000180006027222,
+                "bytes": 4317599700,
+                "bits_per_second": 34540175856.016464,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000027,
+                  "end": 9.000013,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 4394844160,
+                  "bits_per_second": 35159245758.77319,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000027,
+                "end": 9.000013,
+                "seconds": 0.9999859929084778,
+                "bytes": 4394844160,
+                "bits_per_second": 35159245758.77319,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000013,
+                  "end": 10.000067,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 4418043904,
+                  "bits_per_second": 35342442676.19047,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000013,
+                "end": 10.000067,
+                "seconds": 1.0000540018081665,
+                "bytes": 4418043904,
+                "bits_per_second": 35342442676.19047,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040332,
+                  "seconds": 10.040332,
+                  "bytes": 43821410588,
+                  "bits_per_second": 34916304032.97421,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000067,
+                  "seconds": 10.000067,
+                  "bytes": 43820099868,
+                  "bits_per_second": 35055845020.238365,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040332,
+              "seconds": 10.040332,
+              "bytes": 43821410588,
+              "bits_per_second": 34916304032.97421,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000067,
+              "seconds": 10.000067,
+              "bytes": 43820099868,
+              "bits_per_second": 35055845020.238365,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 91.7129817857671,
+              "host_user": 1.930649372470762,
+              "host_system": 89.782322494473,
+              "remote_total": 44.03409922696862,
+              "remote_user": 0.28095210440615037,
+              "remote_system": 43.75314712256247
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 47342,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:07 UTC",
+              "timesecs": 1711485367
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "63e3frv2vx5jfxwcijcn6v6cpcxbxu3kzsnt",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000658,
+                  "seconds": 1.0006580352783203,
+                  "bytes": 1519091984,
+                  "bits_per_second": 12144744201.868994,
+                  "retransmits": 186,
+                  "snd_cwnd": 841152,
+                  "rtt": 194,
+                  "rttvar": 62,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000658,
+                "seconds": 1.0006580352783203,
+                "bytes": 1519091984,
+                "bits_per_second": 12144744201.868994,
+                "retransmits": 186,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000658,
+                  "end": 2.00053,
+                  "seconds": 0.9998720288276672,
+                  "bytes": 1496842240,
+                  "bits_per_second": 11976270537.380842,
+                  "retransmits": 69,
+                  "snd_cwnd": 831716,
+                  "rtt": 212,
+                  "rttvar": 24,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000658,
+                "end": 2.00053,
+                "seconds": 0.9998720288276672,
+                "bytes": 1496842240,
+                "bits_per_second": 11976270537.380842,
+                "retransmits": 69,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00053,
+                  "end": 3.000069,
+                  "seconds": 0.9995390176773071,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12347431467.637243,
+                  "retransmits": 0,
+                  "snd_cwnd": 849240,
+                  "rtt": 240,
+                  "rttvar": 28,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.00053,
+                "end": 3.000069,
+                "seconds": 0.9995390176773071,
+                "bytes": 1542717440,
+                "bits_per_second": 12347431467.637243,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000069,
+                  "end": 4.000792,
+                  "seconds": 1.0007230043411255,
+                  "bytes": 1482424320,
+                  "bits_per_second": 11850826361.095003,
+                  "retransmits": 21,
+                  "snd_cwnd": 683436,
+                  "rtt": 355,
+                  "rttvar": 32,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000069,
+                "end": 4.000792,
+                "seconds": 1.0007230043411255,
+                "bytes": 1482424320,
+                "bits_per_second": 11850826361.095003,
+                "retransmits": 21,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000792,
+                  "end": 5.000133,
+                  "seconds": 0.9993410110473633,
+                  "bytes": 1537474560,
+                  "bits_per_second": 12307907254.911064,
+                  "retransmits": 0,
+                  "snd_cwnd": 789928,
+                  "rtt": 201,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000792,
+                "end": 5.000133,
+                "seconds": 0.9993410110473633,
+                "bytes": 1537474560,
+                "bits_per_second": 12307907254.911064,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000133,
+                  "end": 6.000434,
+                  "seconds": 1.0003010034561157,
+                  "bytes": 1528299520,
+                  "bits_per_second": 12222717079.915821,
+                  "retransmits": 22,
+                  "snd_cwnd": 798016,
+                  "rtt": 187,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000133,
+                "end": 6.000434,
+                "seconds": 1.0003010034561157,
+                "bytes": 1528299520,
+                "bits_per_second": 12222717079.915821,
+                "retransmits": 22,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000434,
+                  "end": 7.000335,
+                  "seconds": 0.9999009966850281,
+                  "bytes": 1551892480,
+                  "bits_per_second": 12416369101.700983,
+                  "retransmits": 0,
+                  "snd_cwnd": 823628,
+                  "rtt": 270,
+                  "rttvar": 39,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000434,
+                "end": 7.000335,
+                "seconds": 0.9999009966850281,
+                "bytes": 1551892480,
+                "bits_per_second": 12416369101.700983,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000335,
+                  "end": 8.00007,
+                  "seconds": 0.9997349977493286,
+                  "bytes": 1550581760,
+                  "bits_per_second": 12407942212.612543,
+                  "retransmits": 0,
+                  "snd_cwnd": 924728,
+                  "rtt": 210,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000335,
+                "end": 8.00007,
+                "seconds": 0.9997349977493286,
+                "bytes": 1550581760,
+                "bits_per_second": 12407942212.612543,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.00007,
+                  "end": 9.000638,
+                  "seconds": 1.0005680322647095,
+                  "bytes": 1545338880,
+                  "bits_per_second": 12355692607.945854,
+                  "retransmits": 35,
+                  "snd_cwnd": 802060,
+                  "rtt": 187,
+                  "rttvar": 20,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.00007,
+                "end": 9.000638,
+                "seconds": 1.0005680322647095,
+                "bytes": 1545338880,
+                "bits_per_second": 12355692607.945854,
+                "retransmits": 35,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000638,
+                  "end": 10.000796,
+                  "seconds": 1.0001579523086548,
+                  "bytes": 1542717440,
+                  "bits_per_second": 12339790421.61459,
+                  "retransmits": 0,
+                  "snd_cwnd": 851936,
+                  "rtt": 272,
+                  "rttvar": 22,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000638,
+                "end": 10.000796,
+                "seconds": 1.0001579523086548,
+                "bytes": 1542717440,
+                "bits_per_second": 12339790421.61459,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000796,
+                  "seconds": 10.000796,
+                  "bytes": 15297380624,
+                  "bits_per_second": 12236930439.537014,
+                  "retransmits": 333,
+                  "max_snd_cwnd": 924728,
+                  "max_rtt": 355,
+                  "min_rtt": 187,
+                  "mean_rtt": 232,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040404,
+                  "seconds": 10.000796,
+                  "bytes": 15297378960,
+                  "bits_per_second": 12188656121.805456,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000796,
+              "seconds": 10.000796,
+              "bytes": 15297380624,
+              "bits_per_second": 12236930439.537014,
+              "retransmits": 333,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040404,
+              "seconds": 10.040404,
+              "bytes": 15297378960,
+              "bits_per_second": 12188656121.805456,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 94.61572077164762,
+              "host_user": 0.29949784294138804,
+              "host_system": 94.31623284257061,
+              "remote_total": 24.200736107154952,
+              "remote_user": 0.7375246434410879,
+              "remote_system": 23.463211463713865
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.13.191 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 48142,
+                "remote_host": "172.30.13.191",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:19 UTC",
+              "timesecs": 1711485379
+            },
+            "connecting_to": {
+              "host": "172.30.13.191",
+              "port": 5201
+            },
+            "cookie": "h7lv3xaoxtkoxlgcjlr2bydfkluc57y2bj3i",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000003,
+                  "seconds": 1.0000029802322388,
+                  "bytes": 1743350008,
+                  "bits_per_second": 13946758499.420694,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000003,
+                "seconds": 1.0000029802322388,
+                "bytes": 1743350008,
+                "bits_per_second": 13946758499.420694,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000003,
+                  "end": 2.000012,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 1755937152,
+                  "bits_per_second": 14047371622.71066,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000003,
+                "end": 2.000012,
+                "seconds": 1.0000089406967163,
+                "bytes": 1755937152,
+                "bits_per_second": 14047371622.71066,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000012,
+                  "end": 3.00001,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1733808384,
+                  "bits_per_second": 13870495181.361897,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000012,
+                "end": 3.00001,
+                "seconds": 0.9999979734420776,
+                "bytes": 1733808384,
+                "bits_per_second": 13870495181.361897,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.00001,
+                  "end": 4.000018,
+                  "seconds": 1.0000079870224,
+                  "bytes": 1738644752,
+                  "bits_per_second": 13909046924.130655,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.00001,
+                "end": 4.000018,
+                "seconds": 1.0000079870224,
+                "bytes": 1738644752,
+                "bits_per_second": 13909046924.130655,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000018,
+                  "end": 5.000023,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 1737561216,
+                  "bits_per_second": 13900420131.51325,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000018,
+                "end": 5.000023,
+                "seconds": 1.0000050067901611,
+                "bytes": 1737561216,
+                "bits_per_second": 13900420131.51325,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000023,
+                  "end": 6.000056,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1736454280,
+                  "bits_per_second": 13891175539.864704,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000023,
+                "end": 6.000056,
+                "seconds": 1.0000330209732056,
+                "bytes": 1736454280,
+                "bits_per_second": 13891175539.864704,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000056,
+                  "end": 7.000026,
+                  "seconds": 0.999970018863678,
+                  "bytes": 1727790912,
+                  "bits_per_second": 13822741717.503777,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000056,
+                "end": 7.000026,
+                "seconds": 0.999970018863678,
+                "bytes": 1727790912,
+                "bits_per_second": 13822741717.503777,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000026,
+                  "end": 8.000019,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1724361600,
+                  "bits_per_second": 13794989002.714045,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000026,
+                "end": 8.000019,
+                "seconds": 0.9999930262565613,
+                "bytes": 1724361600,
+                "bits_per_second": 13794989002.714045,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000019,
+                  "end": 9.000026,
+                  "seconds": 1.0000070333480835,
+                  "bytes": 1740731712,
+                  "bits_per_second": 13925755751.312475,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000019,
+                "end": 9.000026,
+                "seconds": 1.0000070333480835,
+                "bytes": 1740731712,
+                "bits_per_second": 13925755751.312475,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000026,
+                  "end": 10.000039,
+                  "seconds": 1.000012993812561,
+                  "bytes": 1729926144,
+                  "bits_per_second": 13839229327.648127,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000026,
+                "end": 10.000039,
+                "seconds": 1.000012993812561,
+                "bytes": 1729926144,
+                "bits_per_second": 13839229327.648127,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039511,
+                  "seconds": 10.039511,
+                  "bytes": 17371187600,
+                  "bits_per_second": 13842257934.674309,
+                  "retransmits": 2068,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000039,
+                  "seconds": 10.000039,
+                  "bytes": 17368566160,
+                  "bits_per_second": 13894798738.284922,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039511,
+              "seconds": 10.039511,
+              "bytes": 17371187600,
+              "bits_per_second": 13842257934.674309,
+              "retransmits": 2068,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000039,
+              "seconds": 10.000039,
+              "bytes": 17368566160,
+              "bits_per_second": 13894798738.284922,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 44.48791626719862,
+              "host_user": 1.6040884366461445,
+              "host_system": 42.883837750090144,
+              "remote_total": 12.877414932148609,
+              "remote_user": 0.20340289771075803,
+              "remote_system": 12.674021700497715
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39362,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:36 UTC",
+              "timesecs": 1711485396
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "irbwkjbsalrfgbopx5e5dzkfyfpkqel4sxkk",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000203,
+                  "seconds": 1.000203013420105,
+                  "bytes": 3477340160,
+                  "bits_per_second": 27813074852.55055,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000203,
+                "seconds": 1.000203013420105,
+                "bytes": 3477340160,
+                "bits_per_second": 27813074852.55055,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000203,
+                  "end": 2.000079,
+                  "seconds": 0.9998760223388672,
+                  "bytes": 3461611520,
+                  "bits_per_second": 27696325885.70528,
+                  "retransmits": 0,
+                  "snd_cwnd": 412488,
+                  "rtt": 33,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000203,
+                "end": 2.000079,
+                "seconds": 0.9998760223388672,
+                "bytes": 3461611520,
+                "bits_per_second": 27696325885.70528,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000079,
+                  "end": 3.000169,
+                  "seconds": 1.0000900030136108,
+                  "bytes": 3432745096,
+                  "bits_per_second": 27459489331.207977,
+                  "retransmits": 0,
+                  "snd_cwnd": 599860,
+                  "rtt": 31,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000079,
+                "end": 3.000169,
+                "seconds": 1.0000900030136108,
+                "bytes": 3432745096,
+                "bits_per_second": 27459489331.207977,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000169,
+                  "end": 4.000043,
+                  "seconds": 0.9998739957809448,
+                  "bytes": 3490447360,
+                  "bits_per_second": 27927097812.1503,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 31,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000169,
+                "end": 4.000043,
+                "seconds": 0.9998739957809448,
+                "bytes": 3490447360,
+                "bits_per_second": 27927097812.1503,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000043,
+                  "end": 5.000105,
+                  "seconds": 1.0000619888305664,
+                  "bytes": 3575644160,
+                  "bits_per_second": 28603380189.91178,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 33,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000043,
+                "end": 5.000105,
+                "seconds": 1.0000619888305664,
+                "bytes": 3575644160,
+                "bits_per_second": 28603380189.91178,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000105,
+                  "end": 6.000004,
+                  "seconds": 0.9998990297317505,
+                  "bytes": 3565158400,
+                  "bits_per_second": 28524147290.80354,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000105,
+                "end": 6.000004,
+                "seconds": 0.9998990297317505,
+                "bytes": 3565158400,
+                "bits_per_second": 28524147290.80354,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000004,
+                  "end": 7.000302,
+                  "seconds": 1.000298023223877,
+                  "bytes": 3586129920,
+                  "bits_per_second": 28680491907.339397,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000004,
+                "end": 7.000302,
+                "seconds": 1.000298023223877,
+                "bytes": 3586129920,
+                "bits_per_second": 28680491907.339397,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000302,
+                  "end": 8.000114,
+                  "seconds": 0.9998120069503784,
+                  "bytes": 3579576320,
+                  "bits_per_second": 28641995055.99782,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000302,
+                "end": 8.000114,
+                "seconds": 0.9998120069503784,
+                "bytes": 3579576320,
+                "bits_per_second": 28641995055.99782,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000114,
+                  "end": 9.000032,
+                  "seconds": 0.9999179840087891,
+                  "bytes": 3584819200,
+                  "bits_per_second": 28680905892.925636,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000114,
+                "end": 9.000032,
+                "seconds": 0.9999179840087891,
+                "bytes": 3584819200,
+                "bits_per_second": 28680905892.925636,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000032,
+                  "end": 10.000166,
+                  "seconds": 1.000133991241455,
+                  "bytes": 3587440640,
+                  "bits_per_second": 28695680150.192276,
+                  "retransmits": 0,
+                  "snd_cwnd": 769708,
+                  "rtt": 32,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000032,
+                "end": 10.000166,
+                "seconds": 1.000133991241455,
+                "bytes": 3587440640,
+                "bits_per_second": 28695680150.192276,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000166,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28272260901.26904,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 769708,
+                  "max_rtt": 33,
+                  "min_rtt": 31,
+                  "mean_rtt": 32,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040211,
+                  "seconds": 10.000166,
+                  "bytes": 35340912776,
+                  "bits_per_second": 28159498063.138317,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000166,
+              "seconds": 10.000166,
+              "bytes": 35340912776,
+              "bits_per_second": 28272260901.26904,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040211,
+              "seconds": 10.040211,
+              "bytes": 35340912776,
+              "bits_per_second": 28159498063.138317,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 98.19888011381254,
+              "host_user": 0.5898692408770353,
+              "host_system": 97.6090108729355,
+              "remote_total": 71.89727658532618,
+              "remote_user": 1.9320023444980647,
+              "remote_system": 69.96528325535468
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.206.242 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 37670,
+                "remote_host": "172.30.206.242",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:36:48 UTC",
+              "timesecs": 1711485408
+            },
+            "connecting_to": {
+              "host": "172.30.206.242",
+              "port": 5201
+            },
+            "cookie": "xqzwnziqs6osgz5fpot34e32g24jewc75lec",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000002,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 3779153100,
+                  "bits_per_second": 30233163530.742928,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000002,
+                "seconds": 1.0000020265579224,
+                "bytes": 3779153100,
+                "bits_per_second": 30233163530.742928,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000002,
+                  "end": 2.000029,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30331340786.265507,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000002,
+                "end": 2.000029,
+                "seconds": 1.0000269412994385,
+                "bytes": 3791519744,
+                "bits_per_second": 30331340786.265507,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000029,
+                  "end": 3.000014,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 3791519744,
+                  "bits_per_second": 30332613559.093388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000029,
+                "end": 3.000014,
+                "seconds": 0.9999849796295166,
+                "bytes": 3791519744,
+                "bits_per_second": 30332613559.093388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000014,
+                  "end": 4.000004,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 3793747968,
+                  "bits_per_second": 30350287659.043278,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000014,
+                "end": 4.000004,
+                "seconds": 0.9999899864196777,
+                "bytes": 3793747968,
+                "bits_per_second": 30350287659.043278,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000004,
+                  "end": 5.000013,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 3797024768,
+                  "bits_per_second": 30375926562.05313,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000004,
+                "end": 5.000013,
+                "seconds": 1.0000089406967163,
+                "bytes": 3797024768,
+                "bits_per_second": 30375926562.05313,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000013,
+                  "end": 6.000018,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 3796106948,
+                  "bits_per_second": 30368703534.273937,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000013,
+                "end": 6.000018,
+                "seconds": 1.0000050067901611,
+                "bytes": 3796106948,
+                "bits_per_second": 30368703534.273937,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000018,
+                  "end": 7.000009,
+                  "seconds": 0.9999909996986389,
+                  "bytes": 3778281788,
+                  "bits_per_second": 30226526351.846264,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000018,
+                "end": 7.000009,
+                "seconds": 0.9999909996986389,
+                "bytes": 3778281788,
+                "bits_per_second": 30226526351.846264,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000009,
+                  "end": 8.000013,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3812884480,
+                  "bits_per_second": 30502952208.001095,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000009,
+                "end": 8.000013,
+                "seconds": 1.0000040531158447,
+                "bytes": 3812884480,
+                "bits_per_second": 30502952208.001095,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000013,
+                  "end": 9.000017,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 3806855168,
+                  "bits_per_second": 30454717907.5003,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000013,
+                "end": 9.000017,
+                "seconds": 1.0000040531158447,
+                "bytes": 3806855168,
+                "bits_per_second": 30454717907.5003,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000017,
+                  "end": 10.000014,
+                  "seconds": 0.9999970197677612,
+                  "bytes": 3791650816,
+                  "bits_per_second": 30333296928.269413,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000017,
+                "end": 10.000014,
+                "seconds": 0.9999970197677612,
+                "bytes": 3791650816,
+                "bits_per_second": 30333296928.269413,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040168,
+                  "seconds": 10.040168,
+                  "bytes": 37939793100,
+                  "bits_per_second": 30230404989.239223,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000014,
+                  "seconds": 10.000014,
+                  "bytes": 37938744524,
+                  "bits_per_second": 30350953127.86562,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040168,
+              "seconds": 10.040168,
+              "bytes": 37939793100,
+              "bits_per_second": 30230404989.239223,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000014,
+              "seconds": 10.000014,
+              "bytes": 37938744524,
+              "bits_per_second": 30350953127.86562,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 89.35457193175537,
+              "host_user": 2.1531064410889655,
+              "host_system": 87.20146549066642,
+              "remote_total": 96.25175156651449,
+              "remote_user": 0.5483803525296743,
+              "remote_system": 95.70338087979988
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 39876,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:05 UTC",
+              "timesecs": 1711485425
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "wcg7ufm75we3klbul43osuxf3pio4dpyftyl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000173,
+                  "seconds": 1.0001729726791382,
+                  "bytes": 2929832972,
+                  "bits_per_second": 23434610228.684185,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1011,
+                  "rttvar": 17,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000173,
+                "seconds": 1.0001729726791382,
+                "bytes": 2929832972,
+                "bits_per_second": 23434610228.684185,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000173,
+                  "end": 2.000056,
+                  "seconds": 0.9998829960823059,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23417442012.457832,
+                  "retransmits": 0,
+                  "snd_cwnd": 3301252,
+                  "rtt": 1030,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000173,
+                "end": 2.000056,
+                "seconds": 0.9998829960823059,
+                "bytes": 2926837760,
+                "bits_per_second": 23417442012.457832,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000056,
+                  "end": 3.000045,
+                  "seconds": 0.9999889731407166,
+                  "bytes": 2924216320,
+                  "bits_per_second": 23393988522.219513,
+                  "retransmits": 1071,
+                  "snd_cwnd": 2109620,
+                  "rtt": 718,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000056,
+                "end": 3.000045,
+                "seconds": 0.9999889731407166,
+                "bytes": 2924216320,
+                "bits_per_second": 23393988522.219513,
+                "retransmits": 1071,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000045,
+                  "end": 4.000057,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23414420167.144268,
+                  "retransmits": 0,
+                  "snd_cwnd": 2934596,
+                  "rtt": 882,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000045,
+                "end": 4.000057,
+                "seconds": 1.0000120401382446,
+                "bytes": 2926837760,
+                "bits_per_second": 23414420167.144268,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000057,
+                  "end": 5.000134,
+                  "seconds": 1.0000770092010498,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23402414118.786076,
+                  "retransmits": 680,
+                  "snd_cwnd": 2067832,
+                  "rtt": 699,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000057,
+                "end": 5.000134,
+                "seconds": 1.0000770092010498,
+                "bytes": 2925527040,
+                "bits_per_second": 23402414118.786076,
+                "retransmits": 680,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000134,
+                  "end": 6.000072,
+                  "seconds": 0.9999380111694336,
+                  "bytes": 2925527040,
+                  "bits_per_second": 23405667209.938972,
+                  "retransmits": 576,
+                  "snd_cwnd": 2143320,
+                  "rtt": 731,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000134,
+                "end": 6.000072,
+                "seconds": 0.9999380111694336,
+                "bytes": 2925527040,
+                "bits_per_second": 23405667209.938972,
+                "retransmits": 576,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000072,
+                  "end": 7.000057,
+                  "seconds": 0.9999849796295166,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23415053782.782707,
+                  "retransmits": 0,
+                  "snd_cwnd": 2985820,
+                  "rtt": 1004,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000072,
+                "end": 7.000057,
+                "seconds": 0.9999849796295166,
+                "bytes": 2926837760,
+                "bits_per_second": 23415053782.782707,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000057,
+                  "end": 8.000151,
+                  "seconds": 1.0000940561294556,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23422984764.712734,
+                  "retransmits": 0,
+                  "snd_cwnd": 3150276,
+                  "rtt": 1131,
+                  "rttvar": 47,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000057,
+                "end": 8.000151,
+                "seconds": 1.0000940561294556,
+                "bytes": 2928148480,
+                "bits_per_second": 23422984764.712734,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000151,
+                  "end": 9.00006,
+                  "seconds": 0.999908983707428,
+                  "bytes": 2926837760,
+                  "bits_per_second": 23416833393.35924,
+                  "retransmits": 536,
+                  "snd_cwnd": 2446620,
+                  "rtt": 816,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000151,
+                "end": 9.00006,
+                "seconds": 0.999908983707428,
+                "bytes": 2926837760,
+                "bits_per_second": 23416833393.35924,
+                "retransmits": 536,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00006,
+                  "end": 10.000062,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 2928148480,
+                  "bits_per_second": 23425140367.596207,
+                  "retransmits": 0,
+                  "snd_cwnd": 3163756,
+                  "rtt": 1040,
+                  "rttvar": 2,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.00006,
+                "end": 10.000062,
+                "seconds": 1.0000020265579224,
+                "bytes": 2928148480,
+                "bits_per_second": 23425140367.596207,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 29268751372,
+                  "bits_per_second": 23414855925.493263,
+                  "retransmits": 2863,
+                  "max_snd_cwnd": 3301252,
+                  "max_rtt": 1131,
+                  "min_rtt": 699,
+                  "mean_rtt": 906,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040299,
+                  "seconds": 10.000062,
+                  "bytes": 29268042576,
+                  "bits_per_second": 23320454959.35928,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 29268751372,
+              "bits_per_second": 23414855925.493263,
+              "retransmits": 2863,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.040299,
+              "seconds": 10.040299,
+              "bytes": 29268042576,
+              "bits_per_second": 23320454959.35928,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 36.61979232353807,
+              "host_user": 0.5177138138716962,
+              "host_system": 36.10208842470637,
+              "remote_total": 63.645622998347704,
+              "remote_user": 2.779808989119691,
+              "remote_system": 60.86582297594884
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 172.30.99.196 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "169.254.169.2",
+                "local_port": 49506,
+                "remote_host": "172.30.99.196",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:17 UTC",
+              "timesecs": 1711485437
+            },
+            "connecting_to": {
+              "host": "172.30.99.196",
+              "port": 5201
+            },
+            "cookie": "rltue6sce2m2unqis3pm47l4nvjtkc745u4y",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00003,
+                  "seconds": 1.0000300407409668,
+                  "bytes": 2928081096,
+                  "bits_per_second": 23423945095.33297,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00003,
+                "seconds": 1.0000300407409668,
+                "bytes": 2928081096,
+                "bits_per_second": 23423945095.33297,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00003,
+                  "end": 2.00001,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2924874236,
+                  "bits_per_second": 23399462512.79474,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00003,
+                "end": 2.00001,
+                "seconds": 0.9999799728393555,
+                "bytes": 2924874236,
+                "bits_per_second": 23399462512.79474,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 2928934064,
+                  "bits_per_second": 23431098222.587284,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 2928934064,
+                "bits_per_second": 23431098222.587284,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000006,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 2927109320,
+                  "bits_per_second": 23417343542.901,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000006,
+                "seconds": 0.9999799728393555,
+                "bytes": 2927109320,
+                "bits_per_second": 23417343542.901,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000006,
+                  "end": 5.000015,
+                  "seconds": 1.0000089406967163,
+                  "bytes": 2928650940,
+                  "bits_per_second": 23428998048.434082,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000006,
+                "end": 5.000015,
+                "seconds": 1.0000089406967163,
+                "bytes": 2928650940,
+                "bits_per_second": 23428998048.434082,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000015,
+                  "end": 6.00002,
+                  "seconds": 1.0000050067901611,
+                  "bytes": 2928599620,
+                  "bits_per_second": 23428679657.517204,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000015,
+                "end": 6.00002,
+                "seconds": 1.0000050067901611,
+                "bytes": 2928599620,
+                "bits_per_second": 23428679657.517204,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.00002,
+                  "end": 7.000018,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 2903162060,
+                  "bits_per_second": 23225343547.503967,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.00002,
+                "end": 7.000018,
+                "seconds": 0.9999979734420776,
+                "bytes": 2903162060,
+                "bits_per_second": 23225343547.503967,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000018,
+                  "end": 8.000028,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 2520932544,
+                  "bits_per_second": 20167258405.538074,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000018,
+                "end": 8.000028,
+                "seconds": 1.0000100135803223,
+                "bytes": 2520932544,
+                "bits_per_second": 20167258405.538074,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000028,
+                  "end": 9.000012,
+                  "seconds": 0.9999840259552002,
+                  "bytes": 2699663148,
+                  "bits_per_second": 21597650185.83164,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000028,
+                "end": 9.000012,
+                "seconds": 0.9999840259552002,
+                "bytes": 2699663148,
+                "bits_per_second": 21597650185.83164,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000012,
+                  "end": 10.000011,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 2927449024,
+                  "bits_per_second": 23419615922.60409,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000012,
+                "end": 10.000011,
+                "seconds": 0.9999989867210388,
+                "bytes": 2927449024,
+                "bits_per_second": 23419615922.60409,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.039579,
+                  "seconds": 10.039579,
+                  "bytes": 28621053072,
+                  "bits_per_second": 22806576309.225716,
+                  "retransmits": 2146,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000011,
+                  "seconds": 10.000011,
+                  "bytes": 28617456052,
+                  "bits_per_second": 22893939658.266373,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.039579,
+              "seconds": 10.039579,
+              "bytes": 28621053072,
+              "bits_per_second": 22806576309.225716,
+              "retransmits": 2146,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000011,
+              "seconds": 10.000011,
+              "bytes": 28617456052,
+              "bits_per_second": 22893939658.266373,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 86.71637462053445,
+              "host_user": 2.3097157068484533,
+              "host_system": 84.40665891368599,
+              "remote_total": 20.40828750936386,
+              "remote_user": 0.3775983988088474,
+              "remote_system": 20.030689110555013
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 38034,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:34 UTC",
+              "timesecs": 1711485454
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "mk3vi3ohefugakv22qljqy5och5vq6sohsaf",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000058,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 1174382536,
+                  "bits_per_second": 9394514890.15193,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2566,
+                  "rttvar": 70,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000058,
+                "seconds": 1.0000580549240112,
+                "bytes": 1174382536,
+                "bits_per_second": 9394514890.15193,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000058,
+                  "end": 2.000058,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2504,
+                  "rttvar": 111,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000058,
+                "end": 2.000058,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000005,
+                  "seconds": 0.9999470114707947,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374766195.07232,
+                  "retransmits": 13,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2578,
+                  "rttvar": 100,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000005,
+                "seconds": 0.9999470114707947,
+                "bytes": 1171783680,
+                "bits_per_second": 9374766195.07232,
+                "retransmits": 13,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000005,
+                  "end": 4.000059,
+                  "seconds": 1.0000540018081665,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373763239.835724,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2548,
+                  "rttvar": 49,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000005,
+                "end": 4.000059,
+                "seconds": 1.0000540018081665,
+                "bytes": 1171783680,
+                "bits_per_second": 9373763239.835724,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000059,
+                  "end": 5.000059,
+                  "seconds": 1,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374269440,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2544,
+                  "rttvar": 76,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000059,
+                "end": 5.000059,
+                "seconds": 1,
+                "bytes": 1171783680,
+                "bits_per_second": 9374269440,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000092,
+                  "seconds": 1.0000330209732056,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373959902.721222,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2626,
+                  "rttvar": 71,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000092,
+                "seconds": 1.0000330209732056,
+                "bytes": 1171783680,
+                "bits_per_second": 9373959902.721222,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000092,
+                  "end": 7.000102,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374175570.939966,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2637,
+                  "rttvar": 87,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000092,
+                "end": 7.000102,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171783680,
+                "bits_per_second": 9374175570.939966,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000102,
+                  "end": 8.000204,
+                  "seconds": 1.0001020431518555,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9373312957.602478,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2584,
+                  "rttvar": 65,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000102,
+                "end": 8.000204,
+                "seconds": 1.0001020431518555,
+                "bytes": 1171783680,
+                "bits_per_second": 9373312957.602478,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000204,
+                  "end": 9.000059,
+                  "seconds": 0.9998549818992615,
+                  "bytes": 1170472960,
+                  "bits_per_second": 9365141795.07627,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2646,
+                  "rttvar": 50,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000204,
+                "end": 9.000059,
+                "seconds": 0.9998549818992615,
+                "bytes": 1170472960,
+                "bits_per_second": 9365141795.07627,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000059,
+                  "end": 10.000063,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1171783680,
+                  "bits_per_second": 9374231445.153997,
+                  "retransmits": 0,
+                  "snd_cwnd": 3298556,
+                  "rtt": 2624,
+                  "rttvar": 91,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000059,
+                "end": 10.000063,
+                "seconds": 1.0000040531158447,
+                "bytes": 1171783680,
+                "bits_per_second": 9374231445.153997,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000063,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9375240884.782425,
+                  "retransmits": 13,
+                  "max_snd_cwnd": 3298556,
+                  "max_rtt": 2646,
+                  "min_rtt": 2504,
+                  "mean_rtt": 2585,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042436,
+                  "seconds": 10.000063,
+                  "bytes": 11719124936,
+                  "bits_per_second": 9335683044.23349,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000063,
+              "seconds": 10.000063,
+              "bytes": 11719124936,
+              "bits_per_second": 9375240884.782425,
+              "retransmits": 13,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042436,
+              "seconds": 10.042436,
+              "bytes": 11719124936,
+              "bits_per_second": 9335683044.23349,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 8.581878883067088,
+              "host_user": 0.24757613109832505,
+              "host_system": 8.334302751968762,
+              "remote_total": 17.882794832888134,
+              "remote_user": 0.6213889785332932,
+              "remote_system": 17.261397456752558
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "POD_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t sriov-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.5 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.1.196",
+                "local_port": 59786,
+                "remote_host": "10.88.0.5",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux sriov-pod-worker-242-client-5201 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:37:44 UTC",
+              "timesecs": 1711485464
+            },
+            "connecting_to": {
+              "host": "10.88.0.5",
+              "port": 5201
+            },
+            "cookie": "r347nkiuc7n5n3bwbae242ggznelnjrdnlvl",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.00001,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1171526660,
+                  "bits_per_second": 9372119431.529282,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.00001,
+                "seconds": 1.0000100135803223,
+                "bytes": 1171526660,
+                "bits_per_second": 9372119431.529282,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.00001,
+                  "end": 2.00001,
+                  "seconds": 1,
+                  "bytes": 1171728636,
+                  "bits_per_second": 9373829088,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.00001,
+                "end": 2.00001,
+                "seconds": 1,
+                "bytes": 1171728636,
+                "bits_per_second": 9373829088,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.00001,
+                  "end": 3.000026,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171634728,
+                  "bits_per_second": 9372928100.426619,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.00001,
+                "end": 3.000026,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171634728,
+                "bits_per_second": 9372928100.426619,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000026,
+                  "end": 4.000003,
+                  "seconds": 0.9999769926071167,
+                  "bytes": 1171698712,
+                  "bits_per_second": 9373805362.822794,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000026,
+                "end": 4.000003,
+                "seconds": 0.9999769926071167,
+                "bytes": 1171698712,
+                "bits_per_second": 9373805362.822794,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000003,
+                  "end": 5.000019,
+                  "seconds": 1.0000159740447998,
+                  "bytes": 1171728612,
+                  "bits_per_second": 9373679160.429152,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000003,
+                "end": 5.000019,
+                "seconds": 1.0000159740447998,
+                "bytes": 1171728612,
+                "bits_per_second": 9373679160.429152,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000019,
+                  "end": 6.000033,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 1171430044,
+                  "bits_per_second": 9371309645.78169,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000019,
+                "end": 6.000033,
+                "seconds": 1.0000139474868774,
+                "bytes": 1171430044,
+                "bits_per_second": 9371309645.78169,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000033,
+                  "end": 7.000019,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171711552,
+                  "bits_per_second": 9373823716.006702,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000033,
+                "end": 7.000019,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171711552,
+                "bits_per_second": 9373823716.006702,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000019,
+                  "end": 8.000005,
+                  "seconds": 0.9999859929084778,
+                  "bytes": 1171704164,
+                  "bits_per_second": 9373764611.178816,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000019,
+                "end": 8.000005,
+                "seconds": 0.9999859929084778,
+                "bytes": 1171704164,
+                "bits_per_second": 9373764611.178816,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000005,
+                  "end": 9.000005,
+                  "seconds": 1,
+                  "bytes": 1171264340,
+                  "bits_per_second": 9370114720,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000005,
+                "end": 9.000005,
+                "seconds": 1,
+                "bytes": 1171264340,
+                "bits_per_second": 9370114720,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000005,
+                  "end": 10.000025,
+                  "seconds": 1.0000200271606445,
+                  "bytes": 1171724928,
+                  "bits_per_second": 9373611697.172722,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000005,
+                "end": 10.000025,
+                "seconds": 1.0000200271606445,
+                "bytes": 1171724928,
+                "bits_per_second": 9373611697.172722,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040362,
+                  "seconds": 10.040362,
+                  "bytes": 11719168912,
+                  "bits_per_second": 9337646520.713099,
+                  "retransmits": 1,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000025,
+                  "seconds": 10.000025,
+                  "bytes": 11716152376,
+                  "bits_per_second": 9372898468.553827,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040362,
+              "seconds": 10.040362,
+              "bytes": 11719168912,
+              "bits_per_second": 9337646520.713099,
+              "retransmits": 1,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000025,
+              "seconds": 10.000025,
+              "bytes": 11716152376,
+              "bits_per_second": 9372898468.553827,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 34.12079215423493,
+              "host_user": 1.449299942928998,
+              "host_system": 32.671502129797744,
+              "remote_total": 9.21759648553234,
+              "remote_user": 0.13056616222089867,
+              "remote_system": 9.087020816528113
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": false,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": "exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 42748,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:01 UTC",
+              "timesecs": 1711485481
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "gufqojpr3dpevqkupzhux5v5vlruvqn2zo2v",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000059,
+                  "seconds": 1.0000590085983276,
+                  "bytes": 1180082728,
+                  "bits_per_second": 9440104776.649063,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2528,
+                  "rttvar": 68,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000059,
+                "seconds": 1.0000590085983276,
+                "bytes": 1180082728,
+                "bits_per_second": 9440104776.649063,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000059,
+                  "end": 2.000103,
+                  "seconds": 1.0000439882278442,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9415798295.719233,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2635,
+                  "rttvar": 38,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000059,
+                "end": 2.000103,
+                "seconds": 1.0000439882278442,
+                "bytes": 1177026560,
+                "bits_per_second": 9415798295.719233,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000103,
+                  "end": 3.000059,
+                  "seconds": 0.9999560117721558,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9406140479.450544,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2580,
+                  "rttvar": 45,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000103,
+                "end": 3.000059,
+                "seconds": 0.9999560117721558,
+                "bytes": 1175715840,
+                "bits_per_second": 9406140479.450544,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000059,
+                  "end": 4.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2614,
+                  "rttvar": 61,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000059,
+                "end": 4.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000059,
+                  "seconds": 1.0000009536743164,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416203500.008564,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2540,
+                  "rttvar": 36,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000059,
+                "seconds": 1.0000009536743164,
+                "bytes": 1177026560,
+                "bits_per_second": 9416203500.008564,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000059,
+                  "end": 6.000058,
+                  "seconds": 0.9999989867210388,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416222021.259668,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2532,
+                  "rttvar": 66,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000059,
+                "end": 6.000058,
+                "seconds": 0.9999989867210388,
+                "bytes": 1177026560,
+                "bits_per_second": 9416222021.259668,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000058,
+                  "end": 7.00006,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416193397.538671,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2621,
+                  "rttvar": 26,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000058,
+                "end": 7.00006,
+                "seconds": 1.0000020265579224,
+                "bytes": 1177026560,
+                "bits_per_second": 9416193397.538671,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.00006,
+                  "end": 8.000058,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1175715840,
+                  "bits_per_second": 9405745781.28863,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2647,
+                  "rttvar": 79,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.00006,
+                "end": 8.000058,
+                "seconds": 0.9999979734420776,
+                "bytes": 1175715840,
+                "bits_per_second": 9405745781.28863,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000058,
+                  "end": 9.000058,
+                  "seconds": 1,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416212480,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2616,
+                  "rttvar": 57,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000058,
+                "end": 9.000058,
+                "seconds": 1,
+                "bytes": 1177026560,
+                "bits_per_second": 9416212480,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000058,
+                  "end": 10.000062,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1177026560,
+                  "bits_per_second": 9416174315.154686,
+                  "retransmits": 0,
+                  "snd_cwnd": 3302888,
+                  "rtt": 2608,
+                  "rttvar": 75,
+                  "pmtu": 1500,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000058,
+                "end": 10.000062,
+                "seconds": 1.0000040531158447,
+                "bytes": 1177026560,
+                "bits_per_second": 9416174315.154686,
+                "retransmits": 0,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000062,
+                  "seconds": 10.000062,
+                  "bytes": 11770700328,
+                  "bits_per_second": 9416501880.088345,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 3302888,
+                  "max_rtt": 2647,
+                  "min_rtt": 2528,
+                  "mean_rtt": 2592,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.042832,
+                  "seconds": 10.000062,
+                  "bytes": 11770469264,
+                  "bits_per_second": 9376215206.228682,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.000062,
+              "seconds": 10.000062,
+              "bytes": 11770700328,
+              "bits_per_second": 9416501880.088345,
+              "retransmits": 0,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.042832,
+              "seconds": 10.042832,
+              "bytes": 11770469264,
+              "bits_per_second": 9376215206.228682,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 9.991931328513951,
+              "host_user": 0.30260245650629003,
+              "host_system": 9.689348708938175,
+              "remote_total": 19.41962833866342,
+              "remote_user": 0.6099473016485951,
+              "remote_system": 18.809681037014826
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    },
+    {
+      "flow_test": {
+        "tft_metadata": {
+          "test_case_id": "HOST_TO_EXTERNAL",
+          "test_type": "IPERF_TCP",
+          "reverse": true,
+          "server": {
+            "name": "worker-241",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-242",
+            "pod_type": "HOSTBACKED",
+            "is_tenant": true,
+            "index": 0
+          }
+        },
+        "command": " exec -t host-pod-worker-242-client-5201 -- iperf3 -c 10.88.0.6 -p 5201 --json -t 10 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "192.168.122.218",
+                "local_port": 58986,
+                "remote_host": "10.88.0.6",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.7",
+            "system_info": "Linux worker-242 5.14.0-284.57.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 1 09:45:44 EST 2024 x86_64",
+            "timestamp": {
+              "time": "Tue, 26 Mar 2024 20:38:11 UTC",
+              "timesecs": 1711485491
+            },
+            "connecting_to": {
+              "host": "10.88.0.6",
+              "port": 5201
+            },
+            "cookie": "tjf36i4hqqtmz6o6vlwtqomydxbh5uzw3zgo",
+            "tcp_mss_default": 1448,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 10,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000006,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 1176615352,
+                  "bits_per_second": 9412866710.942337,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000006,
+                "seconds": 1.0000059604644775,
+                "bytes": 1176615352,
+                "bits_per_second": 9412866710.942337,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000006,
+                  "end": 2.000016,
+                  "seconds": 1.0000100135803223,
+                  "bytes": 1176524120,
+                  "bits_per_second": 9412098711.193554,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000006,
+                "end": 2.000016,
+                "seconds": 1.0000100135803223,
+                "bytes": 1176524120,
+                "bits_per_second": 9412098711.193554,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000016,
+                  "end": 3.000009,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 1176810760,
+                  "bits_per_second": 9414551734.668388,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000016,
+                "end": 3.000009,
+                "seconds": 0.9999930262565613,
+                "bytes": 1176810760,
+                "bits_per_second": 9414551734.668388,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000009,
+                  "end": 4.000007,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 1176810048,
+                  "bits_per_second": 9414499463.028471,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000009,
+                "end": 4.000007,
+                "seconds": 0.9999979734420776,
+                "bytes": 1176810048,
+                "bits_per_second": 9414499463.028471,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000007,
+                  "end": 5.000007,
+                  "seconds": 1,
+                  "bytes": 1176803976,
+                  "bits_per_second": 9414431808,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000007,
+                "end": 5.000007,
+                "seconds": 1,
+                "bytes": 1176803976,
+                "bits_per_second": 9414431808,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000007,
+                  "end": 6.000009,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 1176724064,
+                  "bits_per_second": 9413773434.442867,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000007,
+                "end": 6.000009,
+                "seconds": 1.0000020265579224,
+                "bytes": 1176724064,
+                "bits_per_second": 9413773434.442867,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000009,
+                  "end": 7.000003,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 1176792016,
+                  "bits_per_second": 9414392803.29542,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000009,
+                "end": 7.000003,
+                "seconds": 0.9999939799308777,
+                "bytes": 1176792016,
+                "bits_per_second": 9414392803.29542,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000003,
+                  "end": 8.000015,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 1176820328,
+                  "bits_per_second": 9414449272.72926,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000003,
+                "end": 8.000015,
+                "seconds": 1.0000120401382446,
+                "bytes": 1176820328,
+                "bits_per_second": 9414449272.72926,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000015,
+                  "end": 9.000011,
+                  "seconds": 0.9999960064888,
+                  "bytes": 1176491696,
+                  "bits_per_second": 9411971154.81222,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000015,
+                "end": 9.000011,
+                "seconds": 0.9999960064888,
+                "bytes": 1176491696,
+                "bits_per_second": 9411971154.81222,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000011,
+                  "end": 10.000015,
+                  "seconds": 1.0000040531158447,
+                  "bytes": 1176819760,
+                  "bits_per_second": 9414519921.860134,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.000011,
+                "end": 10.000015,
+                "seconds": 1.0000040531158447,
+                "bytes": 1176819760,
+                "bits_per_second": 9414519921.860134,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.040305,
+                  "seconds": 10.040305,
+                  "bytes": 11770238744,
+                  "bits_per_second": 9378391388.707813,
+                  "retransmits": 0,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 10.000015,
+                  "seconds": 10.000015,
+                  "bytes": 11767212120,
+                  "bits_per_second": 9413755575.366638,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 10.040305,
+              "seconds": 10.040305,
+              "bytes": 11770238744,
+              "bits_per_second": 9378391388.707813,
+              "retransmits": 0,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 10.000015,
+              "seconds": 10.000015,
+              "bytes": 11767212120,
+              "bits_per_second": 9413755575.366638,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 48.724054060084946,
+              "host_user": 3.9110899538590087,
+              "host_system": 44.81297402368786,
+              "remote_total": 7.595950273368541,
+              "remote_user": 0.15972436790366432,
+              "remote_system": 7.436225905464877
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        }
+      },
+      "plugins": []
+    }
+  ]
+}


### PR DESCRIPTION
The format will change, and so will need to adjust those files. As they currently are one huge line, the diff becomes not reviewable.

Instead, prettify the files with `jq`.

This is no longer the original style that was written by the test. But as we don't need to test the JSON parser itself, this is equivalent.