### PR TITLE
[th/oc-exec] pass namespace to kubectl/oc and minor cleanups

### DIFF
--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,6 +1,7 @@
 import kubernetes  # type: ignore
 import logging
 import shlex
+import typing
 import yaml
 
 import host
@@ -31,9 +32,13 @@ class K8sClient:
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
     ) -> host.Result:
+        namespace_args: tuple[str, ...] = ()
+        if namespace:
+            namespace_args = ("-n", namespace)
         return host.local.run(
-            ["kubectl", "--kubeconfig", self._kc, *shlex.split(cmd)],
+            ["kubectl", "--kubeconfig", self._kc, *namespace_args, *shlex.split(cmd)],
             die_on_error=die_on_error,
             log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
         )

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -128,7 +128,7 @@ class TaskValidateOffload(PluginTask):
             logger.info("There is no VF on an external server")
             return "external"
 
-        self.get_vf_rep_cmd = f'exec -n default {self.pod_name} -- /bin/sh -c "crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json "'
+        self.get_vf_rep_cmd = f'exec {self.pod_name} -- /bin/sh -c "crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json "'
         r = self.run_oc(self.get_vf_rep_cmd)
 
         if r.returncode != 0:
@@ -179,7 +179,7 @@ class TaskValidateOffload(PluginTask):
             SyncManager.wait_on_barrier()
             vf_rep = self.extract_vf_rep()
             self.ethtool_cmd = (
-                f'exec -n default {self.pod_name} -- /bin/sh -c "ethtool -S {vf_rep}"'
+                f'exec {self.pod_name} -- /bin/sh -c "ethtool -S {vf_rep}"'
             )
             if vf_rep == "ovn-k8s-mp0":
                 return Result(out="Hostbacked pod", err="", returncode=0)

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -128,7 +128,7 @@ class TaskValidateOffload(PluginTask):
             logger.info("There is no VF on an external server")
             return "external"
 
-        self.get_vf_rep_cmd = f'exec {self.pod_name} -- /bin/sh -c "crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json "'
+        self.get_vf_rep_cmd = f"exec {self.pod_name} -- crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json"
         r = self.run_oc(self.get_vf_rep_cmd)
 
         if r.returncode != 0:
@@ -178,9 +178,7 @@ class TaskValidateOffload(PluginTask):
         def stat(self: TaskValidateOffload, duration: int) -> Result:
             SyncManager.wait_on_barrier()
             vf_rep = self.extract_vf_rep()
-            self.ethtool_cmd = (
-                f'exec {self.pod_name} -- /bin/sh -c "ethtool -S {vf_rep}"'
-            )
+            self.ethtool_cmd = f"exec {self.pod_name} -- ethtool -S {vf_rep}"
             if vf_rep == "ovn-k8s-mp0":
                 return Result(out="Hostbacked pod", err="", returncode=0)
             if vf_rep == "external":

--- a/task.py
+++ b/task.py
@@ -35,9 +35,12 @@ class Task(ABC):
         if not self.tenant and self.tc.mode == ClusterMode.SINGLE:
             raise ValueError("Cannot have non-tenant Task when cluster mode is single")
 
+    def get_namespace(self) -> str:
+        return self.ts.cfg_descr.get_tft().namespace
+
     def get_template_args(self) -> dict[str, str]:
         return {
-            "name_space": self.ts.cfg_descr.get_tft().namespace,
+            "name_space": self.get_namespace(),
             "test_image": tftbase.TFT_TOOLS_IMG,
             "command": "/sbin/init",
             "args": "",
@@ -72,11 +75,17 @@ class Task(ABC):
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
+        namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
     ) -> host.Result:
+        if isinstance(namespace, common._MISSING_TYPE):
+            # By default, set use self.get_namespace(). You can select another
+            # namespace or no namespace (by setting to None).
+            namespace = self.get_namespace()
         return self.tc.client(tenant=self.tenant).oc(
             cmd,
             may_fail=may_fail,
             die_on_error=die_on_error,
+            namespace=namespace,
         )
 
     def get_pod_ip(self) -> str:

--- a/task.py
+++ b/task.py
@@ -1,9 +1,11 @@
+import shlex
 import sys
 import typing
 import yaml
 
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Iterable
 from typing import Optional
 
 import common
@@ -83,6 +85,25 @@ class Task(ABC):
             namespace = self.get_namespace()
         return self.tc.client(tenant=self.tenant).oc(
             cmd,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+    def run_oc_exec(
+        self,
+        cmd: str | Iterable[str],
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
+    ) -> host.Result:
+        if isinstance(cmd, str):
+            argv = shlex.split(cmd)
+        else:
+            argv = list(cmd)
+        return self.run_oc(
+            f"exec {shlex.quote(self.pod_name)} -- {shlex.join(argv)}",
             may_fail=may_fail,
             die_on_error=die_on_error,
             namespace=namespace,


### PR DESCRIPTION
- task: pass "-n namespace" to kubectl commands in Task
- task: add Task.run_oc_exec() helper
- pluginValidateOffload: fix specifying namespace in kubectl command of TaskValidateOffload
- pluginValidateOffload: don't call oc exec command with "sh -c"
