### PR TITLE
[th/flake-w291-trailing-whitespace] flake8: ignore "W291 trailing whitespace" warning

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 extend-ignore =
     E203
     E501
+    W291
 extend-exclude =
     *venv/
 filename =


### PR DESCRIPTION
We use python-black for formatting the code. We cannot have trailing white space in the source code.

However, we can have white space inside a (multiline) string. In that case, the space is intentional. Suppress the warning, it doesn't seem useful.