### PR TITLE
[th/dataclasses-kw-only] tftbase: make result/output dataclasses kw_only

### DIFF
--- a/common.py
+++ b/common.py
@@ -476,7 +476,7 @@ def structparse_check_and_pop_name_required(
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class StructParseBase(abc.ABC):
     yamlpath: str
     yamlidx: int
@@ -490,7 +490,7 @@ class StructParseBase(abc.ABC):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class StructParseBaseNamed(StructParseBase, abc.ABC):
     name: str
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -26,7 +26,7 @@ from tftbase import TestType
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PassFailStatus:
     """Pass/Fail ratio and result from evaluating a full tft Flow Test result
 
@@ -43,7 +43,7 @@ class PassFailStatus:
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TestResult:
     """Result of a single test case run
 

--- a/perf.py
+++ b/perf.py
@@ -102,7 +102,7 @@ class PerfServer(Task):
         pass
 
     def generate_output(self, data: str) -> tftbase.BaseOutput:
-        return tftbase.BaseOutput("", {})
+        return tftbase.BaseOutput(command="", result={})
 
 
 class PerfClient(Task):

--- a/task.py
+++ b/task.py
@@ -187,7 +187,7 @@ class Task(ABC):
             self._output = self.generate_output(data=r.out)
         else:
             logger.error(f"Thread {class_name} did not return a result")
-            self._output = tftbase.BaseOutput("", {})
+            self._output = tftbase.BaseOutput(command="", result={})
 
     """
     output() should be called to store the results of this task in a PluginOutput class object, and return this by appending the instance to the

--- a/testConfig.py
+++ b/testConfig.py
@@ -49,7 +49,7 @@ T2 = TypeVar("T2", bound="ConfServer | ConfClient")
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class _ConfBaseClientServer(StructParseBaseNamed, abc.ABC):
     sriov: bool
     pod_type: PodType
@@ -115,7 +115,7 @@ class _ConfBaseClientServer(StructParseBaseNamed, abc.ABC):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfPlugin(StructParseBaseNamed):
     plugin: Plugin
 
@@ -146,7 +146,7 @@ class ConfPlugin(StructParseBaseNamed):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfServer(_ConfBaseClientServer):
     persistent: bool
 
@@ -162,7 +162,7 @@ class ConfServer(_ConfBaseClientServer):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfClient(_ConfBaseClientServer):
     @staticmethod
     def parse(yamlidx: int, yamlpath: str, arg: Any) -> "ConfClient":
@@ -170,7 +170,7 @@ class ConfClient(_ConfBaseClientServer):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfConnection(StructParseBaseNamed):
     test_type: TestType
     instances: int
@@ -272,7 +272,7 @@ class ConfConnection(StructParseBaseNamed):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfTest(StructParseBaseNamed):
     namespace: str
     test_cases: tuple[TestCaseType, ...]
@@ -370,7 +370,7 @@ class ConfTest(StructParseBaseNamed):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ConfConfig(StructParseBase):
     tft: tuple[ConfTest, ...]
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -75,7 +75,7 @@ class NodeLocation(Enum):
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Bitrate:
     tx: Optional[float]
     rx: Optional[float]
@@ -126,7 +126,7 @@ Bitrate.NA = Bitrate()
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PodInfo:
     name: str
     pod_type: PodType
@@ -135,7 +135,7 @@ class PodInfo:
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PluginResult:
     """Result of a single plugin from a given run
 
@@ -153,7 +153,7 @@ class PluginResult:
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TestMetadata:
     reverse: bool
     test_case_id: TestCaseType
@@ -163,27 +163,27 @@ class TestMetadata:
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class BaseOutput:
     command: str
     result: dict[str, Any]
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IperfOutput(BaseOutput):
     tft_metadata: TestMetadata
 
 
 @strict_dataclass
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PluginOutput(BaseOutput):
     plugin_metadata: dict[str, str]
     name: str
 
 
 @strict_dataclass
-@dataclass
+@dataclass(kw_only=True)
 class TftAggregateOutput:
     """Aggregated output of a single tft run. A single run of a trafficFlowTests._run_tests() will
     pass a reference to an instance of TftAggregateOutput to each task to which the task will append


### PR DESCRIPTION
The dataclasses are immutable, and thus the constructors have a larger number of arguments. For readability, callers should use keyword arguments. Set kw_only=True to force that.