### PR TITLE
[th/dataclass-to-json] common: add common.dataclass_to_json() helper

### DIFF
--- a/common.py
+++ b/common.py
@@ -249,6 +249,11 @@ def dataclass_to_dict(obj: "DataclassInstance") -> dict[str, Any]:
     return typing.cast(dict[str, Any], serialize_enum(d))
 
 
+def dataclass_to_json(obj: "DataclassInstance") -> str:
+    d = dataclass_to_dict(obj)
+    return json.dumps(d)
+
+
 # Takes a dataclass and the dict you want to convert from
 # If your dataclass has a dataclass member, it handles that recursively
 def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:


### PR DESCRIPTION
This is useful for a quick way to serialize a class to string, for example to print a logging message.

Logging an object in JSON  can be more useful than str(obj), because the result can be deserialized (first with json.loads() and then common.dataclass_from_dict()).