### PR TITLE
[th/eval-config] add EvalConfig and make Evaluator stateless

### DIFF
--- a/evalConfig.py
+++ b/evalConfig.py
@@ -1,0 +1,166 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import common
+import testType
+
+from common import StructParseBase
+from common import strict_dataclass
+from common import structparse_check_empty_dict
+from common import structparse_check_strdict
+from tftbase import TestCaseType
+from tftbase import TestType
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class TestItem(StructParseBase):
+    threshold: float
+
+    @staticmethod
+    def parse(yamlidx: int, yamlpath: str, arg: Any) -> "TestItem":
+        vdict = structparse_check_strdict(arg, yamlpath)
+
+        v = vdict.pop("threshold", None)
+        try:
+            threshold = float(v)
+        except ValueError:
+            raise ValueError(f"{yamlpath}.threshold: expected a number but got {v}")
+
+        structparse_check_empty_dict(vdict, yamlpath)
+
+        return TestItem(
+            yamlidx=yamlidx,
+            yamlpath=yamlpath,
+            threshold=threshold,
+        )
+
+    def serialize(self) -> dict[str, Any]:
+        return {"threshold": self.threshold}
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class TestCaseData(StructParseBase):
+    test_case_type: TestCaseType
+    normal: TestItem
+    reverse: TestItem
+
+    def get_threshold(self, *, is_reverse: bool) -> float:
+        if is_reverse:
+            return self.reverse.threshold
+        return self.normal.threshold
+
+    @staticmethod
+    def parse(yamlidx: int, yamlpath: str, arg: Any) -> "TestCaseData":
+        vdict = structparse_check_strdict(arg, yamlpath)
+
+        v = vdict.pop("id", None)
+        try:
+            test_case_type = common.enum_convert(TestCaseType, v)
+        except ValueError:
+            raise ValueError(f'{yamlpath}.id: invalid value "{v}"')
+
+        normal = TestItem.parse(0, f"{yamlpath}.Normal", vdict.pop("Normal", None))
+        reverse = TestItem.parse(0, f"{yamlpath}.Reverse", vdict.pop("Reverse", None))
+
+        structparse_check_empty_dict(vdict, yamlpath)
+
+        return TestCaseData(
+            yamlidx=yamlidx,
+            yamlpath=yamlpath,
+            test_case_type=test_case_type,
+            normal=normal,
+            reverse=reverse,
+        )
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "id": self.test_case_type.name,
+            "Normal": self.normal.serialize(),
+            "Reverse": self.reverse.serialize(),
+        }
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class TestTypeData(StructParseBase):
+    test_type: TestType
+    test_cases: Mapping[TestCaseType, TestCaseData]
+    test_type_handler: testType.TestTypeHandler
+
+    @staticmethod
+    def parse(yamlidx: int, yamlpath_base: str, key: Any, arg: Any) -> "TestTypeData":
+        try:
+            test_type = common.enum_convert(TestType, key)
+        except Exception:
+            raise ValueError(
+                f"{yamlpath_base}.[{yamlidx}].: expects a test type as key like iperf-tcp but got {key}"
+            )
+
+        yamlpath = f"{yamlpath_base}.{test_type.name}"
+
+        try:
+            test_type_handler = testType.TestTypeHandler.get(test_type)
+        except Exception:
+            raise ValueError(
+                f'{yamlpath}: test type "{test_type}" has no handler implementation'
+            )
+
+        if not isinstance(arg, list):
+            raise ValueError(f'"{yamlpath}": expects a list of test cases')
+        test_cases = {}
+        for yamlidx2, arg in enumerate(arg):
+            c = TestCaseData.parse(yamlidx2, f"{yamlpath}[{yamlidx}]", arg)
+            if c.test_case_type in test_cases:
+                raise ValueError(
+                    f"{yamlpath}[{yamlidx2}]: duplicate key {c.test_case_type.name}"
+                )
+            test_cases[c.test_case_type] = c
+
+        return TestTypeData(
+            yamlidx=yamlidx,
+            yamlpath=yamlpath,
+            test_type=test_type,
+            test_type_handler=test_type_handler,
+            test_cases=test_cases,
+        )
+
+    def serialize(self) -> list[Any]:
+        return [v.serialize() for k, v in self.test_cases.items()]
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class Config(StructParseBase):
+    configs: Mapping[TestType, TestTypeData]
+
+    @staticmethod
+    def parse(arg: Any) -> "Config":
+        yamlpath = ""
+        vdict = structparse_check_strdict(arg, yamlpath)
+
+        configs = {}
+
+        for yamlidx2, key in enumerate(vdict):
+            c = TestTypeData.parse(
+                yamlidx=yamlidx2,
+                yamlpath_base=yamlpath,
+                key=key,
+                arg=vdict[key],
+            )
+            if c.test_type in configs:
+                raise ValueError(
+                    f"{yamlpath}.[{yamlidx2}]: duplicate key {c.test_type.name}"
+                )
+            configs[c.test_type] = c
+
+        return Config(
+            yamlidx=0,
+            yamlpath=yamlpath,
+            configs=configs,
+        )
+
+    def serialize(self) -> dict[str, Any]:
+        return {k.name: v.serialize() for k, v in self.configs.items()}

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,16 +1,30 @@
 import filecmp
+import json
 import os
 import pytest
 import subprocess
+import sys
+import yaml
 
 from pathlib import Path
 from typing import Any
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import evalConfig  # noqa: E402
+import evaluator  # noqa: E402
+import tftbase  # noqa: E402
+
+Evaluator = evaluator.Evaluator
+TestType = tftbase.TestType
+TestCaseType = tftbase.TestCaseType
 
 
 current_dir = os.path.dirname(__file__)
 parent_dir = os.path.dirname(current_dir)
 
 config_path = os.path.join(parent_dir, "eval-config.yaml")
+config_path2 = os.path.join(parent_dir, "updated-eval-config.yaml")
 evaluator_file = os.path.join(parent_dir, "evaluator.py")
 
 COMMON_COMMAND = ["python", evaluator_file, config_path]
@@ -73,3 +87,59 @@ def test_evaluator_invalid_pod_type() -> None:
             [log_path],
             check=True,
         )
+
+
+def test_eval_config() -> None:
+    def _check(filename: str) -> None:
+        assert os.path.exists(filename)
+
+        with open(filename, encoding="utf-8") as file:
+            conf_dict = yaml.safe_load(file)
+
+        c = evalConfig.Config.parse(conf_dict)
+
+        assert (
+            c.configs[TestType.IPERF_UDP]
+            .test_cases[TestCaseType.HOST_TO_NODE_PORT_TO_HOST_SAME_NODE]
+            .normal.threshold
+            == 5
+        )
+
+        for test_type in TestType:
+            if test_type not in c.configs:
+                continue
+
+            assert test_type in (
+                TestType.IPERF_UDP,
+                TestType.IPERF_TCP,
+            )
+
+            d = c.configs[test_type].test_cases
+
+            for test_case_type in TestCaseType:
+                assert test_case_type in d
+
+        dump = c.serialize()
+        assert c == evalConfig.Config.parse(dump)
+
+        c2 = c.configs[TestType.IPERF_UDP]
+        assert c2.test_type == TestType.IPERF_UDP
+        assert isinstance(c2.serialize(), list)
+        assert c2 == evalConfig.TestTypeData.parse(
+            1, "", TestType.IPERF_UDP, c2.serialize()
+        )
+
+        c3 = c2.test_cases[TestCaseType.POD_TO_HOST_DIFF_NODE]
+        assert c3.test_case_type == TestCaseType.POD_TO_HOST_DIFF_NODE
+        assert c3.serialize_json() == json.dumps(
+            {
+                "id": "POD_TO_HOST_DIFF_NODE",
+                "Normal": {"threshold": 5.0},
+                "Reverse": {"threshold": 5.0},
+            }
+        )
+        assert c3.yamlpath == ".IPERF_UDP[1]"
+        assert c3.normal.yamlpath == ".IPERF_UDP[1].Normal"
+
+    _check(config_path)
+    _check(config_path2)

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -87,16 +87,16 @@ class TrafficFlowTests:
         logger.info(f"Evaluating results of tests {log_file}")
         results_path = log_file.parent / (str(log_file.stem) + "-RESULTS")
 
-        evaluator.eval_log(log_file)
+        test_results, plugin_results = evaluator.eval_log(log_file)
 
         # Generate Resulting Json
         logger.info(f"Dumping results to {results_path}")
-        data = evaluator.dump_to_json()
+        data = evaluator.dump_to_json(test_results, plugin_results)
         with open(results_path, "w") as file:
             file.write(data)
 
         # Return PassFailStatus
-        res = evaluator.evaluate_pass_fail_status()
+        res = evaluator.evaluate_pass_fail_status(test_results, plugin_results)
         logger.info(f"RESULT: Success = {res.result}.")
         logger.info(
             f"  FlowTest results: Passed {res.num_tft_passed}/{res.num_tft_passed + res.num_tft_failed}"


### PR DESCRIPTION
- don't let the Evaluator object keep state. Instead, the few functions that are there take function arguments and return the result. The caller has to pass them around. Stateless objects are nice, because you don't need to think about their state. In particular, you see where an input argument comes from (from the caller) and you see what we do with the result (return it).

- add `evalConfig.Config` for parsing the `eval-config.yaml`. The benefit is tight validation of the configuration file and a strongly typed object that we can use. Currently the config  only contains the threshold. This will be more useful, if the configuration gets more complex (https://issues.redhat.com/browse/NHE-774)

- use `evalConfig.Config`.