### PR TITLE
[th/configure-test-image] allow selecting another test container image for testing

### DIFF
--- a/manifests/host-pod.yaml.j2
+++ b/manifests/host-pod.yaml.j2
@@ -17,7 +17,7 @@ spec:
     command:
       - "{{ command }}"
     args: {{ args }}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {{ image_pull_policy }}
     securityContext:
       capabilities:
         add: ["NET_ADMIN","NET_RAW"]

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -15,4 +15,4 @@ spec:
     command:
       - "{{ command }}"
     args: {{ args }}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {{ image_pull_policy }}

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -17,4 +17,4 @@ spec:
     command:
       - "{{ command }}"
     args: {{ args }}
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {{ image_pull_policy }}

--- a/manifests/tools-pod.yaml.j2
+++ b/manifests/tools-pod.yaml.j2
@@ -15,7 +15,7 @@ spec:
     command:
       - "{{ command }}"
     args: ["{{ args }}"]
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: {{ image_pull_policy }}
     securityContext:
       privileged: true
       runAsUser: 0

--- a/perf.py
+++ b/perf.py
@@ -115,7 +115,7 @@ class PerfServer(Task, abc.ABC):
         th_cmd = self._create_setup_operation_get_thread_action_cmd()
 
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
-            cmd = f"podman run -it --init --replace --rm -p {self.port} --name={self.pod_name} {tftbase.TFT_TOOLS_IMG} {th_cmd}"
+            cmd = f"podman run -it --init --replace --rm -p {self.port} --name={self.pod_name} {tftbase.get_tft_test_image()} {th_cmd}"
             cancel_cmd = f"podman rm --force {self.pod_name}"
         else:
             self.setup_pod()

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -13,7 +13,6 @@ from task import TaskOperation
 from testSettings import TestSettings
 from tftbase import BaseOutput
 from tftbase import PluginOutput
-from tftbase import TFT_TOOLS_IMG
 
 
 class PluginMeasureCpu(pluginbase.Plugin):
@@ -57,7 +56,7 @@ class TaskMeasureCPU(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": TFT_TOOLS_IMG,
+            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -12,7 +12,6 @@ from task import TaskOperation
 from testSettings import TestSettings
 from tftbase import BaseOutput
 from tftbase import PluginOutput
-from tftbase import TFT_TOOLS_IMG
 
 
 class PluginMeasurePower(pluginbase.Plugin):
@@ -66,7 +65,7 @@ class TaskMeasurePower(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": TFT_TOOLS_IMG,
+            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -15,8 +15,8 @@ from tftbase import BaseOutput
 from tftbase import PluginOutput
 from tftbase import PluginResult
 from tftbase import PodType
-from tftbase import TFT_TOOLS_IMG
 from tftbase import TestMetadata
+
 
 VF_REP_TRAFFIC_THRESHOLD = 1000
 
@@ -111,7 +111,7 @@ class TaskValidateOffload(PluginTask):
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,
-            "test_image": TFT_TOOLS_IMG,
+            "test_image": tftbase.get_tft_test_image(),
         }
 
     def initialize(self) -> None:

--- a/task.py
+++ b/task.py
@@ -255,6 +255,7 @@ class Task(ABC):
         return {
             "name_space": self.get_namespace(),
             "test_image": tftbase.get_tft_test_image(),
+            "image_pull_policy": tftbase.get_tft_image_pull_policy(),
             "command": "/sbin/init",
             "args": "",
             "index": f"{self.index}",

--- a/task.py
+++ b/task.py
@@ -254,7 +254,7 @@ class Task(ABC):
     def get_template_args(self) -> dict[str, str]:
         return {
             "name_space": self.get_namespace(),
-            "test_image": tftbase.TFT_TOOLS_IMG,
+            "test_image": tftbase.get_tft_test_image(),
             "command": "/sbin/init",
             "args": "",
             "index": f"{self.index}",

--- a/tftbase.py
+++ b/tftbase.py
@@ -1,5 +1,8 @@
 import dataclasses
+import functools
 import math
+import os
+import shlex
 import typing
 
 from dataclasses import dataclass
@@ -10,9 +13,27 @@ from typing import Optional
 import host
 
 from common import strict_dataclass
+from logger import logger
 
 
-TFT_TOOLS_IMG = "quay.io/wizhao/tft-tools:latest"
+ENV_TFT_TEST_IMAGE = "TFT_TEST_IMAGE"
+
+ENV_TFT_TEST_IMAGE_DEFAULT = "quay.io/wizhao/tft-tools:latest"
+
+
+def get_environ(name: str) -> Optional[str]:
+    # Some environment variables are honored as configuration.
+    # Which ones? Run `git grep -w get_environ`!
+    return os.environ.get(name, None)
+
+
+@functools.cache
+def get_tft_test_image() -> str:
+    s = get_environ(ENV_TFT_TEST_IMAGE) or ENV_TFT_TEST_IMAGE_DEFAULT
+    logger.info(f"env: {ENV_TFT_TEST_IMAGE}={shlex.quote(s)}")
+    return s
+
+
 TFT_TESTS = "tft-tests"
 
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -17,6 +17,7 @@ from logger import logger
 
 
 ENV_TFT_TEST_IMAGE = "TFT_TEST_IMAGE"
+ENV_TFT_IMAGE_PULL_POLICY = "TFT_IMAGE_PULL_POLICY"
 
 ENV_TFT_TEST_IMAGE_DEFAULT = "quay.io/wizhao/tft-tools:latest"
 
@@ -31,6 +32,30 @@ def get_environ(name: str) -> Optional[str]:
 def get_tft_test_image() -> str:
     s = get_environ(ENV_TFT_TEST_IMAGE) or ENV_TFT_TEST_IMAGE_DEFAULT
     logger.info(f"env: {ENV_TFT_TEST_IMAGE}={shlex.quote(s)}")
+    return s
+
+
+@functools.cache
+def get_tft_image_pull_policy() -> str:
+    s: Optional[str] = None
+    s_env = get_environ(ENV_TFT_IMAGE_PULL_POLICY)
+    if s_env is not None:
+        s0 = s_env.strip().lower()
+        if s0 == "always":
+            s = "Always"
+        if s0 == "ifnotpresent":
+            s = "IfNotPresent"
+        if s0 == "never":
+            s = "Never"
+        logger.error(
+            f'env: invalid environment variable in {ENV_TFT_IMAGE_PULL_POLICY}="{shlex.quote(s_env)}". Set to one of "IfNotPresent", "Always", "Never"'
+        )
+    if s is None:
+        if get_environ(ENV_TFT_TEST_IMAGE):
+            s = "Always"
+        else:
+            s = "IfNotPresent"
+    logger.info(f"env: {ENV_TFT_IMAGE_PULL_POLICY}={shlex.quote(s)}")
     return s
 
 


### PR DESCRIPTION
The tests pull `tftbase.TFT_TOOLS_IMG`, which is set to `quay.io/wizhao/tft-tools:latest`. This image gets automatically rebuild on every push to `main` branch.

However, if you are testing a WIP branch that requires an update test image, it is cumbersome.

Allow overriding the test image by setting `TFT_TEST_IMAGE` environment variable. Also, allow overwriting the ImagePullPolicy by setting `TFT_IMAGE_PULL_POLICY` environment variable.

An alternative would be to make those settings part of the TestConfig. However, this option is only useful for testing/developing the flow tests, as such it seems more cumbersome to do it via the TestConfig. Also, you might think if those settings were part of the config YAML, then it would be well known which test image was used by looking at the config. However, we tend to use `:latest`, so a week after you rant the test, you also don't know anymore which test image was used. If you want to record which image was used when running the test a week ago, preserve the log output.