### PR TITLE
[th/http-test] http: implement test_type=HTTP for fetching a small file via HTTP

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -6,4 +6,6 @@ RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download
 
 RUN INSTALL_PKGS="vim wget jq python3 git cri-tools net-tools iptables iproute pciutils ethtool httpd iperf3 tcpdump sysstat ipmitool util-linux netperf nc iputils" && yum install -y ${INSTALL_PKGS}
 
+RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
+
 CMD ["/bin/bash"]

--- a/testType.py
+++ b/testType.py
@@ -54,6 +54,10 @@ class TestTypeHandler(ABC):
             if test_type == TestType.NETPERF_TCP_STREAM:
                 return testTypeNetPerf.test_type_handler_netperf_tcp_stream
             return testTypeNetPerf.test_type_handler_netperf_tcp_rr
+        if test_type == TestType.HTTP:
+            import testTypeHttp
+
+            return testTypeHttp.test_type_handler_http
         raise ValueError(f"Unsupported test type {test_type}")
 
 

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -1,0 +1,98 @@
+import json
+import shlex
+
+from dataclasses import dataclass
+
+import common
+import perf
+import tftbase
+
+from logger import logger
+from perf import PerfClient
+from perf import PerfServer
+from task import TaskOperation
+from testSettings import TestSettings
+from testType import TestTypeHandler
+from tftbase import BaseOutput
+from tftbase import IperfOutput
+from tftbase import TestType
+
+
+@dataclass(frozen=True)
+class TestTypeHandlerHttp(TestTypeHandler):
+    def __init__(self) -> None:
+        super().__init__(TestType.HTTP)
+
+    def _create_server_client(self, ts: TestSettings) -> tuple[PerfServer, PerfClient]:
+        s = HttpServer(ts=ts)
+        c = HttpClient(ts=ts, server=s)
+        return (s, c)
+
+
+test_type_handler_http = TestTypeHandlerHttp()
+
+
+class HttpServer(perf.PerfServer):
+    def cmd_line_args(self) -> list[str]:
+        return [
+            "-m",
+            "http.server",
+            "-d",
+            "/etc/ocp-traffic-flow-tests",
+            f"{self.port}",
+        ]
+
+    def get_template_args(self) -> dict[str, str]:
+
+        extra_args: dict[str, str] = {}
+        if self.exec_persistent:
+            extra_args["command"] = "python3"
+            extra_args["args"] = json.dumps(self.cmd_line_args())
+
+        return {
+            **super().get_template_args(),
+            **extra_args,
+        }
+
+    def _create_setup_operation_get_thread_action_cmd(self) -> str:
+        return f"python3 {shlex.join(self.cmd_line_args())}"
+
+    def _create_setup_operation_get_cancel_action_cmd(self) -> str:
+        return "killall python3"
+
+
+class HttpClient(perf.PerfClient):
+    def _create_task_operation(self) -> TaskOperation:
+        server_ip = self.get_target_ip()
+        cmd = f"exec {self.pod_name} -- curl --fail -s http://{server_ip}:{self.port}/data"
+
+        def _thread_action() -> BaseOutput:
+            self.ts.clmo_barrier.wait()
+            r = self.run_oc(cmd)
+            self.ts.event_client_finished.set()
+
+            return IperfOutput(
+                success=(
+                    r.success and r.out == "ocp-traffic-flow-tests\n" and r.err == ""
+                ),
+                tft_metadata=self.ts.get_test_metadata(),
+                command=cmd,
+                result={
+                    "result": common.dataclass_to_dict(r),
+                },
+            )
+
+        return TaskOperation(
+            log_name=self.log_name,
+            thread_action=_thread_action,
+        )
+
+    def _aggregate_output(
+        self,
+        result: tftbase.AggregatableOutput,
+        out: tftbase.TftAggregateOutput,
+    ) -> None:
+        assert isinstance(result, IperfOutput)
+
+        logger.info(f"Results of {self.ts.get_test_str()}")
+        out.flow_test = result

--- a/tests/test_testType.py
+++ b/tests/test_testType.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import sys
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -10,10 +9,6 @@ import tftbase  # noqa: E402
 
 def test_handlers() -> None:
     for test_type in tftbase.TestType:
-        if test_type == tftbase.TestType.HTTP:
-            with pytest.raises(ValueError):
-                testType.TestTypeHandler.get(test_type)
-            continue
         h = testType.TestTypeHandler.get(test_type)
         assert isinstance(h, testType.TestTypeHandler)
         assert h.test_type == test_type


### PR DESCRIPTION
Inspired by ovn-kuber-traffic-flow-tests (client: [1], server: [2]).

[1] https://github.com/Billy99/ovn-kuber-traffic-flow-tests/blob/17369edc2875b18c1c9df96683518cbc76600fe8/process-cmds.sh#L38
[2] https://github.com/Billy99/ovn-kuber-traffic-flow-tests/blob/17369edc2875b18c1c9df96683518cbc76600fe8/manifests/http-server-pod-v4.yaml.j2#L36

https://issues.redhat.com/browse/NHE-711