### PR TITLE
[th/serialize-output] add methods for serializing/parsing the TftAggregateOutput

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -3,7 +3,6 @@ import json
 import sys
 import yaml
 
-from dataclasses import asdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -12,7 +11,7 @@ import evalConfig
 import pluginbase
 import tftbase
 
-from common import serialize_enum
+from common import dataclass_to_dict
 from common import strict_dataclass
 from logger import logger
 from testType import TestTypeHandler
@@ -123,19 +122,17 @@ class Evaluator:
         test_results: list[TestResult],
         plugin_results: list[tftbase.PluginResult],
     ) -> str:
-        passing = [asdict(result) for result in test_results if result.success]
-        failing = [asdict(result) for result in test_results if not result.success]
-        plugin_passing = [asdict(result) for result in plugin_results if result.success]
-        plugin_failing = [
-            asdict(result) for result in plugin_results if not result.success
-        ]
+        passing = [dataclass_to_dict(r) for r in test_results if r.success]
+        failing = [dataclass_to_dict(r) for r in test_results if not r.success]
+        plugin_passing = [dataclass_to_dict(r) for r in plugin_results if r.success]
+        plugin_failing = [dataclass_to_dict(r) for r in plugin_results if not r.success]
 
         return json.dumps(
             {
-                "passing": serialize_enum(passing),
-                "failing": serialize_enum(failing),
-                "plugin_passing": serialize_enum(plugin_passing),
-                "plugin_failing": serialize_enum(plugin_failing),
+                "passing": passing,
+                "failing": failing,
+                "plugin_passing": plugin_passing,
+                "plugin_failing": plugin_failing,
             }
         )
 

--- a/tests/input5.json
+++ b/tests/input5.json
@@ -1,0 +1,1970 @@
+{
+  "tft-tests": [
+    {
+      "flow_test": {
+        "success": true,
+        "msg": null,
+        "command": "exec sriov-pod-worker-247-client-5201 -- iperf3 -c 10.131.0.106 -p 5201 --json -t 30",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.0.107",
+                "local_port": 45296,
+                "remote_host": "10.131.0.106",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.9",
+            "system_info": "Linux sriov-pod-worker-247-client-5201 5.14.0-284.69.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri May 31 14:47:07 EDT 2024 x86_64",
+            "timestamp": {
+              "time": "Mon, 17 Jun 2024 19:28:22 GMT",
+              "timesecs": 1718652502
+            },
+            "connecting_to": {
+              "host": "10.131.0.106",
+              "port": 5201
+            },
+            "cookie": "ia7addh24s6chhcuemxjpbxcvoaa4qafhn6r",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 30,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 0,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000065,
+                  "seconds": 1.0000649690628052,
+                  "bytes": 4984471176,
+                  "bits_per_second": 39873178884.93678,
+                  "retransmits": 2672,
+                  "snd_cwnd": 891028,
+                  "rtt": 206,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000065,
+                "seconds": 1.0000649690628052,
+                "bytes": 4984471176,
+                "bits_per_second": 39873178884.93678,
+                "retransmits": 2672,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000065,
+                  "end": 2.000058,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 5210112000,
+                  "bits_per_second": 41681186673.902084,
+                  "retransmits": 1036,
+                  "snd_cwnd": 1023132,
+                  "rtt": 257,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 1.000065,
+                "end": 2.000058,
+                "seconds": 0.9999930262565613,
+                "bytes": 5210112000,
+                "bits_per_second": 41681186673.902084,
+                "retransmits": 1036,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000058,
+                  "end": 3.000056,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 4820828160,
+                  "bits_per_second": 38566703437.6584,
+                  "retransmits": 1369,
+                  "snd_cwnd": 1260380,
+                  "rtt": 247,
+                  "rttvar": 4,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 2.000058,
+                "end": 3.000056,
+                "seconds": 0.9999979734420776,
+                "bytes": 4820828160,
+                "bits_per_second": 38566703437.6584,
+                "retransmits": 1369,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000056,
+                  "end": 4.000058,
+                  "seconds": 1.0000020265579224,
+                  "bytes": 5223219200,
+                  "bits_per_second": 41785668918.9216,
+                  "retransmits": 1413,
+                  "snd_cwnd": 1028524,
+                  "rtt": 210,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 3.000056,
+                "end": 4.000058,
+                "seconds": 1.0000020265579224,
+                "bytes": 5223219200,
+                "bits_per_second": 41785668918.9216,
+                "retransmits": 1413,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000058,
+                  "end": 5.000041,
+                  "seconds": 0.999983012676239,
+                  "bytes": 4636016640,
+                  "bits_per_second": 37088763158.827675,
+                  "retransmits": 1272,
+                  "snd_cwnd": 853284,
+                  "rtt": 93,
+                  "rttvar": 15,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 4.000058,
+                "end": 5.000041,
+                "seconds": 0.999983012676239,
+                "bytes": 4636016640,
+                "bits_per_second": 37088763158.827675,
+                "retransmits": 1272,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000041,
+                  "end": 6.000155,
+                  "seconds": 1.0001139640808105,
+                  "bytes": 5051514880,
+                  "bits_per_second": 40407514034.80518,
+                  "retransmits": 1474,
+                  "snd_cwnd": 908552,
+                  "rtt": 133,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 5.000041,
+                "end": 6.000155,
+                "seconds": 1.0001139640808105,
+                "bytes": 5051514880,
+                "bits_per_second": 40407514034.80518,
+                "retransmits": 1474,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000155,
+                  "end": 7.000012,
+                  "seconds": 0.999857008457184,
+                  "bytes": 5316280320,
+                  "bits_per_second": 42536324894.72243,
+                  "retransmits": 1197,
+                  "snd_cwnd": 773752,
+                  "rtt": 113,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 6.000155,
+                "end": 7.000012,
+                "seconds": 0.999857008457184,
+                "bytes": 5316280320,
+                "bits_per_second": 42536324894.72243,
+                "retransmits": 1197,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000012,
+                  "end": 8.000049,
+                  "seconds": 1.0000369548797607,
+                  "bytes": 5248122880,
+                  "bits_per_second": 41983431547.33523,
+                  "retransmits": 1813,
+                  "snd_cwnd": 771056,
+                  "rtt": 120,
+                  "rttvar": 16,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 7.000012,
+                "end": 8.000049,
+                "seconds": 1.0000369548797607,
+                "bytes": 5248122880,
+                "bits_per_second": 41983431547.33523,
+                "retransmits": 1813,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000049,
+                  "end": 9.000107,
+                  "seconds": 1.0000580549240112,
+                  "bytes": 4843110400,
+                  "bits_per_second": 38742633999.32717,
+                  "retransmits": 1325,
+                  "snd_cwnd": 807452,
+                  "rtt": 170,
+                  "rttvar": 27,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 8.000049,
+                "end": 9.000107,
+                "seconds": 1.0000580549240112,
+                "bytes": 4843110400,
+                "bits_per_second": 38742633999.32717,
+                "retransmits": 1325,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.000107,
+                  "end": 10.000058,
+                  "seconds": 0.9999510049819946,
+                  "bytes": 5352980480,
+                  "bits_per_second": 42825942097.80418,
+                  "retransmits": 1059,
+                  "snd_cwnd": 541896,
+                  "rtt": 140,
+                  "rttvar": 26,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 9.000107,
+                "end": 10.000058,
+                "seconds": 0.9999510049819946,
+                "bytes": 5352980480,
+                "bits_per_second": 42825942097.80418,
+                "retransmits": 1059,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 10.000058,
+                  "end": 11.000079,
+                  "seconds": 1.000020980834961,
+                  "bytes": 4756602880,
+                  "bits_per_second": 38052024676.75033,
+                  "retransmits": 1641,
+                  "snd_cwnd": 1467972,
+                  "rtt": 294,
+                  "rttvar": 13,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 10.000058,
+                "end": 11.000079,
+                "seconds": 1.000020980834961,
+                "bytes": 4756602880,
+                "bits_per_second": 38052024676.75033,
+                "retransmits": 1641,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 11.000079,
+                  "end": 12.000057,
+                  "seconds": 0.999978005886078,
+                  "bytes": 4692377600,
+                  "bits_per_second": 37539846455.65956,
+                  "retransmits": 1193,
+                  "snd_cwnd": 671304,
+                  "rtt": 157,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 11.000079,
+                "end": 12.000057,
+                "seconds": 0.999978005886078,
+                "bytes": 4692377600,
+                "bits_per_second": 37539846455.65956,
+                "retransmits": 1193,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 12.000057,
+                  "end": 13.000025,
+                  "seconds": 0.9999679923057556,
+                  "bytes": 4965007360,
+                  "bits_per_second": 39721330268.1942,
+                  "retransmits": 1476,
+                  "snd_cwnd": 710396,
+                  "rtt": 105,
+                  "rttvar": 8,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 12.000057,
+                "end": 13.000025,
+                "seconds": 0.9999679923057556,
+                "bytes": 4965007360,
+                "bits_per_second": 39721330268.1942,
+                "retransmits": 1476,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 13.000025,
+                  "end": 14.000062,
+                  "seconds": 1.0000369548797607,
+                  "bytes": 5284823040,
+                  "bits_per_second": 42277021977.73617,
+                  "retransmits": 1327,
+                  "snd_cwnd": 772404,
+                  "rtt": 282,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 13.000025,
+                "end": 14.000062,
+                "seconds": 1.0000369548797607,
+                "bytes": 5284823040,
+                "bits_per_second": 42277021977.73617,
+                "retransmits": 1327,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 14.000062,
+                  "end": 15.000083,
+                  "seconds": 1.000020980834961,
+                  "bytes": 5279580160,
+                  "bits_per_second": 42235755138.59199,
+                  "retransmits": 1520,
+                  "snd_cwnd": 889680,
+                  "rtt": 132,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 14.000062,
+                "end": 15.000083,
+                "seconds": 1.000020980834961,
+                "bytes": 5279580160,
+                "bits_per_second": 42235755138.59199,
+                "retransmits": 1520,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 15.000083,
+                  "end": 16.000057,
+                  "seconds": 0.999974012374878,
+                  "bytes": 4962385920,
+                  "bits_per_second": 39700119071.81174,
+                  "retransmits": 1523,
+                  "snd_cwnd": 652432,
+                  "rtt": 101,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 15.000083,
+                "end": 16.000057,
+                "seconds": 0.999974012374878,
+                "bytes": 4962385920,
+                "bits_per_second": 39700119071.81174,
+                "retransmits": 1523,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 16.000057,
+                  "end": 17.000188,
+                  "seconds": 1.0001310110092163,
+                  "bytes": 5440798720,
+                  "bits_per_second": 43520688070.73406,
+                  "retransmits": 2231,
+                  "snd_cwnd": 853284,
+                  "rtt": 131,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 16.000057,
+                "end": 17.000188,
+                "seconds": 1.0001310110092163,
+                "bytes": 5440798720,
+                "bits_per_second": 43520688070.73406,
+                "retransmits": 2231,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 17.000188,
+                  "end": 18.000046,
+                  "seconds": 0.999858021736145,
+                  "bytes": 5262540800,
+                  "bits_per_second": 42106304580.02162,
+                  "retransmits": 1616,
+                  "snd_cwnd": 855980,
+                  "rtt": 120,
+                  "rttvar": 25,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 17.000188,
+                "end": 18.000046,
+                "seconds": 0.999858021736145,
+                "bytes": 5262540800,
+                "bits_per_second": 42106304580.02162,
+                "retransmits": 1616,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 18.000046,
+                  "end": 19.000101,
+                  "seconds": 1.000054955482483,
+                  "bytes": 5288755200,
+                  "bits_per_second": 42307716559.02375,
+                  "retransmits": 1577,
+                  "snd_cwnd": 544592,
+                  "rtt": 149,
+                  "rttvar": 11,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 18.000046,
+                "end": 19.000101,
+                "seconds": 1.000054955482483,
+                "bytes": 5288755200,
+                "bits_per_second": 42307716559.02375,
+                "retransmits": 1577,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 19.000101,
+                  "end": 20.000066,
+                  "seconds": 0.999965012073517,
+                  "bytes": 5464391680,
+                  "bits_per_second": 43716662995.39097,
+                  "retransmits": 1740,
+                  "snd_cwnd": 1017740,
+                  "rtt": 212,
+                  "rttvar": 18,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 19.000101,
+                "end": 20.000066,
+                "seconds": 0.999965012073517,
+                "bytes": 5464391680,
+                "bits_per_second": 43716662995.39097,
+                "retransmits": 1740,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 20.000066,
+                  "end": 21.00003,
+                  "seconds": 0.9999639987945557,
+                  "bytes": 4617666560,
+                  "bits_per_second": 36942662460.3809,
+                  "retransmits": 1629,
+                  "snd_cwnd": 686132,
+                  "rtt": 130,
+                  "rttvar": 28,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 20.000066,
+                "end": 21.00003,
+                "seconds": 0.9999639987945557,
+                "bytes": 4617666560,
+                "bits_per_second": 36942662460.3809,
+                "retransmits": 1629,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 21.00003,
+                  "end": 22.000057,
+                  "seconds": 1.0000269412994385,
+                  "bytes": 5535170560,
+                  "bits_per_second": 44280171514.64004,
+                  "retransmits": 2300,
+                  "snd_cwnd": 834412,
+                  "rtt": 126,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 21.00003,
+                "end": 22.000057,
+                "seconds": 1.0000269412994385,
+                "bytes": 5535170560,
+                "bits_per_second": 44280171514.64004,
+                "retransmits": 2300,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 22.000057,
+                  "end": 23.000057,
+                  "seconds": 1,
+                  "bytes": 5676728320,
+                  "bits_per_second": 45413826560,
+                  "retransmits": 1758,
+                  "snd_cwnd": 892376,
+                  "rtt": 132,
+                  "rttvar": 6,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 22.000057,
+                "end": 23.000057,
+                "seconds": 1,
+                "bytes": 5676728320,
+                "bits_per_second": 45413826560,
+                "retransmits": 1758,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 23.000057,
+                  "end": 24.000048,
+                  "seconds": 0.999990999698639,
+                  "bytes": 5457838080,
+                  "bits_per_second": 43663097621.03695,
+                  "retransmits": 1787,
+                  "snd_cwnd": 869460,
+                  "rtt": 183,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 23.000057,
+                "end": 24.000048,
+                "seconds": 0.999990999698639,
+                "bytes": 5457838080,
+                "bits_per_second": 43663097621.03695,
+                "retransmits": 1787,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 24.000048,
+                  "end": 25.00001,
+                  "seconds": 0.9999619722366333,
+                  "bytes": 5062000640,
+                  "bits_per_second": 40497545151.063934,
+                  "retransmits": 1946,
+                  "snd_cwnd": 841152,
+                  "rtt": 194,
+                  "rttvar": 156,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 24.000048,
+                "end": 25.00001,
+                "seconds": 0.9999619722366333,
+                "bytes": 5062000640,
+                "bits_per_second": 40497545151.063934,
+                "retransmits": 1946,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 25.00001,
+                  "end": 26.000057,
+                  "seconds": 1.000046968460083,
+                  "bytes": 5259919360,
+                  "bits_per_second": 42077378570.32422,
+                  "retransmits": 2093,
+                  "snd_cwnd": 977300,
+                  "rtt": 168,
+                  "rttvar": 10,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 25.00001,
+                "end": 26.000057,
+                "seconds": 1.000046968460083,
+                "bytes": 5259919360,
+                "bits_per_second": 42077378570.32422,
+                "retransmits": 2093,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 26.000057,
+                  "end": 27.000071,
+                  "seconds": 1.0000139474868774,
+                  "bytes": 5102632960,
+                  "bits_per_second": 40820494336.6909,
+                  "retransmits": 1819,
+                  "snd_cwnd": 1369568,
+                  "rtt": 285,
+                  "rttvar": 5,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 26.000057,
+                "end": 27.000071,
+                "seconds": 1.0000139474868774,
+                "bytes": 5102632960,
+                "bits_per_second": 40820494336.6909,
+                "retransmits": 1819,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 27.000071,
+                  "end": 28.000058,
+                  "seconds": 0.999987006187439,
+                  "bytes": 5030543360,
+                  "bits_per_second": 40244869814.2949,
+                  "retransmits": 366,
+                  "snd_cwnd": 788580,
+                  "rtt": 174,
+                  "rttvar": 9,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 27.000071,
+                "end": 28.000058,
+                "seconds": 0.999987006187439,
+                "bytes": 5030543360,
+                "bits_per_second": 40244869814.2949,
+                "retransmits": 366,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 28.000058,
+                  "end": 29.000087,
+                  "seconds": 1.0000289678573608,
+                  "bytes": 5406720000,
+                  "bits_per_second": 43252507067.54477,
+                  "retransmits": 1649,
+                  "snd_cwnd": 649736,
+                  "rtt": 108,
+                  "rttvar": 7,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 28.000058,
+                "end": 29.000087,
+                "seconds": 1.0000289678573608,
+                "bytes": 5406720000,
+                "bits_per_second": 43252507067.54477,
+                "retransmits": 1649,
+                "omitted": false,
+                "sender": true
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 29.000087,
+                  "end": 30.000077,
+                  "seconds": 0.9999899864196777,
+                  "bytes": 4933550080,
+                  "bits_per_second": 39468795863.9576,
+                  "retransmits": 1517,
+                  "snd_cwnd": 974604,
+                  "rtt": 175,
+                  "rttvar": 24,
+                  "pmtu": 1400,
+                  "omitted": false,
+                  "sender": true
+                }
+              ],
+              "sum": {
+                "start": 29.000087,
+                "end": 30.000077,
+                "seconds": 0.9999899864196777,
+                "bytes": 4933550080,
+                "bits_per_second": 39468795863.9576,
+                "retransmits": 1517,
+                "omitted": false,
+                "sender": true
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 30.000077,
+                  "seconds": 30.000077,
+                  "bytes": 154166689416,
+                  "bits_per_second": 41111011659.33674,
+                  "retransmits": 47338,
+                  "max_snd_cwnd": 1467972,
+                  "max_rtt": 294,
+                  "min_rtt": 93,
+                  "mean_rtt": 168,
+                  "sender": true
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 30.040568,
+                  "seconds": 30.000077,
+                  "bytes": 154164396032,
+                  "bits_per_second": 41054988316.33276,
+                  "sender": true
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 30.000077,
+              "seconds": 30.000077,
+              "bytes": 154166689416,
+              "bits_per_second": 41111011659.33674,
+              "retransmits": 47338,
+              "sender": true
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 30.040568,
+              "seconds": 30.040568,
+              "bytes": 154164396032,
+              "bits_per_second": 41054988316.33276,
+              "sender": true
+            },
+            "cpu_utilization_percent": {
+              "host_total": 38.1338227340445,
+              "host_user": 0.6504689630327155,
+              "host_system": 37.48335709502226,
+              "remote_total": 63.72486929403591,
+              "remote_user": 1.835806243031383,
+              "remote_system": 61.88906032915442
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        },
+        "tft_metadata": {
+          "reverse": false,
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "server": {
+            "name": "worker-247",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-247",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        }
+      },
+      "plugins": [
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec tools-pod-worker-246-measure-cpu -- mpstat -P ALL 30 1",
+          "result": {
+            "cpu": "all",
+            "percent_usr": 0.51,
+            "percent_nice": 0.0,
+            "percent_sys": 0.17,
+            "percent_iowait": 0.0,
+            "percent_irq": 0.03,
+            "percent_soft": 0.02,
+            "percent_steal": 0.0,
+            "percent_guest": 0.0,
+            "percent_gnice": 0.0,
+            "percent_idle": 99.27,
+            "type": "cpu",
+            "time": "19:28:52"
+          },
+          "plugin_metadata": {
+            "name": "MeasureCPU",
+            "node_name": "worker-246",
+            "pod_name": "tools-pod-worker-246-measure-cpu"
+          },
+          "name": "measure_cpu"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec tools-pod-worker-247-measure-cpu -- mpstat -P ALL 30 1",
+          "result": {
+            "cpu": "all",
+            "percent_usr": 0.31,
+            "percent_nice": 0.0,
+            "percent_sys": 1.89,
+            "percent_iowait": 0.0,
+            "percent_irq": 0.08,
+            "percent_soft": 1.69,
+            "percent_steal": 0.0,
+            "percent_guest": 0.0,
+            "percent_gnice": 0.0,
+            "percent_idle": 96.03,
+            "type": "cpu",
+            "time": "19:28:52"
+          },
+          "plugin_metadata": {
+            "name": "MeasureCPU",
+            "node_name": "worker-247",
+            "pod_name": "tools-pod-worker-247-measure-cpu"
+          },
+          "name": "measure_cpu"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec -t tools-pod-worker-246-measure-cpu -- ipmitool dcmi power reading",
+          "result": {
+            "measure_power": "356.21590909090907"
+          },
+          "plugin_metadata": {
+            "name": "MeasurePower",
+            "node_name": "worker-246",
+            "pod_name": "tools-pod-worker-246-measure-cpu"
+          },
+          "name": "measure_power"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec -t tools-pod-worker-247-measure-cpu -- ipmitool dcmi power reading",
+          "result": {
+            "measure_power": "385.264367816092"
+          },
+          "plugin_metadata": {
+            "name": "MeasurePower",
+            "node_name": "worker-247",
+            "pod_name": "tools-pod-worker-247-measure-cpu"
+          },
+          "name": "measure_power"
+        }
+      ]
+    },
+    {
+      "flow_test": {
+        "success": true,
+        "msg": null,
+        "command": " exec sriov-pod-worker-247-client-5201 -- iperf3 -c 10.131.0.106 -p 5201 --json -t 30 -R",
+        "result": {
+          "start": {
+            "connected": [
+              {
+                "socket": 5,
+                "local_host": "10.131.0.107",
+                "local_port": 51958,
+                "remote_host": "10.131.0.106",
+                "remote_port": 5201
+              }
+            ],
+            "version": "iperf 3.9",
+            "system_info": "Linux sriov-pod-worker-247-client-5201 5.14.0-284.69.1.el9_2.x86_64 #1 SMP PREEMPT_DYNAMIC Fri May 31 14:47:07 EDT 2024 x86_64",
+            "timestamp": {
+              "time": "Mon, 17 Jun 2024 19:28:55 GMT",
+              "timesecs": 1718652535
+            },
+            "connecting_to": {
+              "host": "10.131.0.106",
+              "port": 5201
+            },
+            "cookie": "jgqz24wfjlfkpavg6nzw46w25xb53hkj7pmo",
+            "tcp_mss_default": 1348,
+            "sock_bufsize": 0,
+            "sndbuf_actual": 16384,
+            "rcvbuf_actual": 131072,
+            "test_start": {
+              "protocol": "TCP",
+              "num_streams": 1,
+              "blksize": 131072,
+              "omit": 0,
+              "duration": 30,
+              "bytes": 0,
+              "blocks": 0,
+              "reverse": 1,
+              "tos": 0
+            }
+          },
+          "intervals": [
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 1.000015,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 3262251008,
+                  "bits_per_second": 26097616068.137924,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 0,
+                "end": 1.000015,
+                "seconds": 1.0000150203704834,
+                "bytes": 3262251008,
+                "bits_per_second": 26097616068.137924,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 1.000015,
+                  "end": 2.000008,
+                  "seconds": 0.9999930262565613,
+                  "bytes": 4850712576,
+                  "bits_per_second": 38805971230.88725,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 1.000015,
+                "end": 2.000008,
+                "seconds": 0.9999930262565613,
+                "bytes": 4850712576,
+                "bits_per_second": 38805971230.88725,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 2.000008,
+                  "end": 3.000016,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4411621376,
+                  "bits_per_second": 35292689124.5014,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 2.000008,
+                "end": 3.000016,
+                "seconds": 1.0000079870224,
+                "bytes": 4411621376,
+                "bits_per_second": 35292689124.5014,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 3.000016,
+                  "end": 4.000024,
+                  "seconds": 1.0000079870224,
+                  "bytes": 4751622144,
+                  "bits_per_second": 38012673543.92493,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 3.000016,
+                "end": 4.000024,
+                "seconds": 1.0000079870224,
+                "bytes": 4751622144,
+                "bits_per_second": 38012673543.92493,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 4.000024,
+                  "end": 5.000136,
+                  "seconds": 1.0001120567321777,
+                  "bytes": 4357226496,
+                  "bits_per_second": 34853906353.15044,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 4.000024,
+                "end": 5.000136,
+                "seconds": 1.0001120567321777,
+                "bytes": 4357226496,
+                "bits_per_second": 34853906353.15044,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 5.000136,
+                  "end": 6.000059,
+                  "seconds": 0.9999229907989502,
+                  "bytes": 5569642496,
+                  "bits_per_second": 44560571542.01277,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 5.000136,
+                "end": 6.000059,
+                "seconds": 0.9999229907989502,
+                "bytes": 5569642496,
+                "bits_per_second": 44560571542.01277,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 6.000059,
+                  "end": 7.000005,
+                  "seconds": 0.9999459981918335,
+                  "bytes": 5068554240,
+                  "bits_per_second": 40550623727.00354,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 6.000059,
+                "end": 7.000005,
+                "seconds": 0.9999459981918335,
+                "bytes": 5068554240,
+                "bits_per_second": 40550623727.00354,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 7.000005,
+                  "end": 8.000016,
+                  "seconds": 1.0000109672546387,
+                  "bytes": 4684644352,
+                  "bits_per_second": 37476743799.00773,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 7.000005,
+                "end": 8.000016,
+                "seconds": 1.0000109672546387,
+                "bytes": 4684644352,
+                "bits_per_second": 37476743799.00773,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 8.000016,
+                  "end": 9.00001,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4753981440,
+                  "bits_per_second": 38032080475.75333,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 8.000016,
+                "end": 9.00001,
+                "seconds": 0.9999939799308777,
+                "bytes": 4753981440,
+                "bits_per_second": 38032080475.75333,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 9.00001,
+                  "end": 10.000004,
+                  "seconds": 0.9999939799308777,
+                  "bytes": 4371906560,
+                  "bits_per_second": 34975463034.705055,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 9.00001,
+                "end": 10.000004,
+                "seconds": 0.9999939799308777,
+                "bytes": 4371906560,
+                "bits_per_second": 34975463034.705055,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 10.000004,
+                  "end": 11.00001,
+                  "seconds": 1.0000059604644775,
+                  "bytes": 5678170112,
+                  "bits_per_second": 45425090141.36382,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 10.000004,
+                "end": 11.00001,
+                "seconds": 1.0000059604644775,
+                "bytes": 5678170112,
+                "bits_per_second": 45425090141.36382,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 11.00001,
+                  "end": 12.000033,
+                  "seconds": 1.0000230073928833,
+                  "bytes": 5476974592,
+                  "bits_per_second": 43814788671.942924,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 11.00001,
+                "end": 12.000033,
+                "seconds": 1.0000230073928833,
+                "bytes": 5476974592,
+                "bits_per_second": 43814788671.942924,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 12.000033,
+                  "end": 13.000013,
+                  "seconds": 0.9999799728393555,
+                  "bytes": 5675286528,
+                  "bits_per_second": 45403201521.21064,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 12.000033,
+                "end": 13.000013,
+                "seconds": 0.9999799728393555,
+                "bytes": 5675286528,
+                "bits_per_second": 45403201521.21064,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 13.000013,
+                  "end": 14.000011,
+                  "seconds": 0.9999979734420776,
+                  "bytes": 5449842688,
+                  "bits_per_second": 43598829859.554054,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 13.000013,
+                "end": 14.000011,
+                "seconds": 0.9999979734420776,
+                "bytes": 5449842688,
+                "bits_per_second": 43598829859.554054,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 14.000011,
+                  "end": 15.000002,
+                  "seconds": 0.999990999698639,
+                  "bytes": 5115609088,
+                  "bits_per_second": 40925241043.50267,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 14.000011,
+                "end": 15.000002,
+                "seconds": 0.999990999698639,
+                "bytes": 5115609088,
+                "bits_per_second": 40925241043.50267,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 15.000002,
+                  "end": 16.000019,
+                  "seconds": 1.0000170469284058,
+                  "bytes": 5851054080,
+                  "bits_per_second": 46807634713.6022,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 15.000002,
+                "end": 16.000019,
+                "seconds": 1.0000170469284058,
+                "bytes": 5851054080,
+                "bits_per_second": 46807634713.6022,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 16.000019,
+                  "end": 17.000006,
+                  "seconds": 0.999987006187439,
+                  "bytes": 5518131200,
+                  "bits_per_second": 44145623219.9535,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 16.000019,
+                "end": 17.000006,
+                "seconds": 0.999987006187439,
+                "bytes": 5518131200,
+                "bits_per_second": 44145623219.9535,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 17.000006,
+                  "end": 18.000117,
+                  "seconds": 1.0001109838485718,
+                  "bytes": 5583273984,
+                  "bits_per_second": 44661235196.235954,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 17.000006,
+                "end": 18.000117,
+                "seconds": 1.0001109838485718,
+                "bytes": 5583273984,
+                "bits_per_second": 44661235196.235954,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 18.000117,
+                  "end": 19.000017,
+                  "seconds": 0.999899983406067,
+                  "bytes": 5453119488,
+                  "bits_per_second": 43629319559.938,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 18.000117,
+                "end": 19.000017,
+                "seconds": 0.999899983406067,
+                "bytes": 5453119488,
+                "bits_per_second": 43629319559.938,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 19.000017,
+                  "end": 20.000042,
+                  "seconds": 1.0000250339508057,
+                  "bytes": 5088870400,
+                  "bits_per_second": 40709944069.26287,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 19.000017,
+                "end": 20.000042,
+                "seconds": 1.0000250339508057,
+                "bytes": 5088870400,
+                "bits_per_second": 40709944069.26287,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 20.000042,
+                  "end": 21.000017,
+                  "seconds": 0.999975025653839,
+                  "bytes": 4840882176,
+                  "bits_per_second": 38728024615.092865,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 20.000042,
+                "end": 21.000017,
+                "seconds": 0.999975025653839,
+                "bytes": 4840882176,
+                "bits_per_second": 38728024615.092865,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 21.000017,
+                  "end": 22.000004,
+                  "seconds": 0.999987006187439,
+                  "bytes": 4732223488,
+                  "bits_per_second": 37858279827.39196,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 21.000017,
+                "end": 22.000004,
+                "seconds": 0.999987006187439,
+                "bytes": 4732223488,
+                "bits_per_second": 37858279827.39196,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 22.000004,
+                  "end": 23.000019,
+                  "seconds": 1.0000150203704834,
+                  "bytes": 4064542720,
+                  "bits_per_second": 32515853359.835953,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 22.000004,
+                "end": 23.000019,
+                "seconds": 1.0000150203704834,
+                "bytes": 4064542720,
+                "bits_per_second": 32515853359.835953,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 23.000019,
+                  "end": 24.000001,
+                  "seconds": 0.9999819993972778,
+                  "bytes": 5697961984,
+                  "bits_per_second": 45584516420.77037,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 23.000019,
+                "end": 24.000001,
+                "seconds": 0.9999819993972778,
+                "bytes": 5697961984,
+                "bits_per_second": 45584516420.77037,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 24.000001,
+                  "end": 25.000013,
+                  "seconds": 1.0000120401382446,
+                  "bytes": 4743888896,
+                  "bits_per_second": 37950654236.8765,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 24.000001,
+                "end": 25.000013,
+                "seconds": 1.0000120401382446,
+                "bytes": 4743888896,
+                "bits_per_second": 37950654236.8765,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 25.000013,
+                  "end": 26.000009,
+                  "seconds": 0.9999960064888,
+                  "bytes": 3970826240,
+                  "bits_per_second": 31766736780.81912,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 25.000013,
+                "end": 26.000009,
+                "seconds": 0.9999960064888,
+                "bytes": 3970826240,
+                "bits_per_second": 31766736780.81912,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 26.000009,
+                  "end": 27.000091,
+                  "seconds": 1.000082015991211,
+                  "bytes": 4606787584,
+                  "bits_per_second": 36851278277.88465,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 26.000009,
+                "end": 27.000091,
+                "seconds": 1.000082015991211,
+                "bytes": 4606787584,
+                "bits_per_second": 36851278277.88465,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 27.000091,
+                  "end": 28.000025,
+                  "seconds": 0.9999340176582336,
+                  "bytes": 4938792960,
+                  "bits_per_second": 39512950837.02633,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 27.000091,
+                "end": 28.000025,
+                "seconds": 0.9999340176582336,
+                "bytes": 4938792960,
+                "bits_per_second": 39512950837.02633,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 28.000025,
+                  "end": 29.000003,
+                  "seconds": 0.999978005886078,
+                  "bytes": 4838391808,
+                  "bits_per_second": 38707985811.84964,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 28.000025,
+                "end": 29.000003,
+                "seconds": 0.999978005886078,
+                "bytes": 4838391808,
+                "bits_per_second": 38707985811.84964,
+                "omitted": false,
+                "sender": false
+              }
+            },
+            {
+              "streams": [
+                {
+                  "socket": 5,
+                  "start": 29.000003,
+                  "end": 30.00008,
+                  "seconds": 1.00007700920105,
+                  "bytes": 5362810880,
+                  "bits_per_second": 42899183408.16005,
+                  "omitted": false,
+                  "sender": false
+                }
+              ],
+              "sum": {
+                "start": 29.000003,
+                "end": 30.00008,
+                "seconds": 1.00007700920105,
+                "bytes": 5362810880,
+                "bits_per_second": 42899183408.16005,
+                "omitted": false,
+                "sender": false
+              }
+            }
+          ],
+          "end": {
+            "streams": [
+              {
+                "sender": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 30.04057,
+                  "seconds": 30.04057,
+                  "bytes": 148772681784,
+                  "bits_per_second": 39619136862.9823,
+                  "retransmits": 48298,
+                  "max_snd_cwnd": 0,
+                  "max_rtt": 0,
+                  "min_rtt": 0,
+                  "mean_rtt": 0,
+                  "sender": false
+                },
+                "receiver": {
+                  "socket": 5,
+                  "start": 0,
+                  "end": 30.00008,
+                  "seconds": 30.00008,
+                  "bytes": 148769603584,
+                  "bits_per_second": 39671788497.63067,
+                  "sender": false
+                }
+              }
+            ],
+            "sum_sent": {
+              "start": 0,
+              "end": 30.04057,
+              "seconds": 30.04057,
+              "bytes": 148772681784,
+              "bits_per_second": 39619136862.9823,
+              "retransmits": 48298,
+              "sender": false
+            },
+            "sum_received": {
+              "start": 0,
+              "end": 30.00008,
+              "seconds": 30.00008,
+              "bytes": 148769603584,
+              "bits_per_second": 39671788497.63067,
+              "sender": false
+            },
+            "cpu_utilization_percent": {
+              "host_total": 76.47678750852897,
+              "host_user": 2.418178055654131,
+              "host_system": 74.0586127771965,
+              "remote_total": 31.932466986496134,
+              "remote_user": 0.4906103657859598,
+              "remote_system": 31.441856620710173
+            },
+            "sender_tcp_congestion": "cubic",
+            "receiver_tcp_congestion": "cubic"
+          }
+        },
+        "tft_metadata": {
+          "reverse": true,
+          "test_case_id": "POD_TO_POD_SAME_NODE",
+          "test_type": "IPERF_TCP",
+          "server": {
+            "name": "worker-247",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          },
+          "client": {
+            "name": "worker-247",
+            "pod_type": "SRIOV",
+            "is_tenant": true,
+            "index": 0
+          }
+        }
+      },
+      "plugins": [
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec tools-pod-worker-246-measure-cpu -- mpstat -P ALL 30 1",
+          "result": {
+            "cpu": "all",
+            "percent_usr": 0.46,
+            "percent_nice": 0.0,
+            "percent_sys": 0.16,
+            "percent_iowait": 0.0,
+            "percent_irq": 0.03,
+            "percent_soft": 0.02,
+            "percent_steal": 0.0,
+            "percent_guest": 0.0,
+            "percent_gnice": 0.0,
+            "percent_idle": 99.33,
+            "type": "cpu",
+            "time": "19:29:25"
+          },
+          "plugin_metadata": {
+            "name": "MeasureCPU",
+            "node_name": "worker-246",
+            "pod_name": "tools-pod-worker-246-measure-cpu"
+          },
+          "name": "measure_cpu"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec tools-pod-worker-247-measure-cpu -- mpstat -P ALL 30 1",
+          "result": {
+            "cpu": "all",
+            "percent_usr": 0.31,
+            "percent_nice": 0.0,
+            "percent_sys": 1.81,
+            "percent_iowait": 0.0,
+            "percent_irq": 0.07,
+            "percent_soft": 1.66,
+            "percent_steal": 0.0,
+            "percent_guest": 0.0,
+            "percent_gnice": 0.0,
+            "percent_idle": 96.15,
+            "type": "cpu",
+            "time": "19:29:25"
+          },
+          "plugin_metadata": {
+            "name": "MeasureCPU",
+            "node_name": "worker-247",
+            "pod_name": "tools-pod-worker-247-measure-cpu"
+          },
+          "name": "measure_cpu"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec -t tools-pod-worker-246-measure-cpu -- ipmitool dcmi power reading",
+          "result": {
+            "measure_power": "355.65168539325845"
+          },
+          "plugin_metadata": {
+            "name": "MeasurePower",
+            "node_name": "worker-246",
+            "pod_name": "tools-pod-worker-246-measure-cpu"
+          },
+          "name": "measure_power"
+        },
+        {
+          "success": true,
+          "msg": null,
+          "command": "exec -t tools-pod-worker-247-measure-cpu -- ipmitool dcmi power reading",
+          "result": {
+            "measure_power": "382.75"
+          },
+          "plugin_metadata": {
+            "name": "MeasurePower",
+            "node_name": "worker-247",
+            "pod_name": "tools-pod-worker-247-measure-cpu"
+          },
+          "name": "measure_power"
+        }
+      ]
+    }
+  ]
+}

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -2,20 +2,17 @@ import datetime
 import json
 import perf
 
-from dataclasses import asdict
 from pathlib import Path
-from typing import Any
 
 import host
 import testConfig
+import tftbase
 
-from common import serialize_enum
 from evaluator import Evaluator
 from logger import logger
 from task import Task
 from testConfig import ConfigDescriptor
 from testSettings import TestSettings
-from tftbase import TFT_TESTS
 from tftbase import TftAggregateOutput
 
 
@@ -68,12 +65,9 @@ class TrafficFlowTests:
     def _dump_result_to_log(
         self, tft_output: list[TftAggregateOutput], *, log_file: str
     ) -> None:
-        # Dump test outputs into log file
-        json_out: dict[str, list[dict[str, Any]]] = {TFT_TESTS: []}
-        for out in tft_output:
-            json_out[TFT_TESTS].append(asdict(out))
-        with open(log_file, "w") as output_file:
-            json.dump(serialize_enum(json_out), output_file)
+        out = tftbase.output_list_serialize(tft_output)
+        with open(log_file, "w") as f:
+            json.dump(out, f)
 
     def evaluate_run_success(self, cfg_descr: ConfigDescriptor, log_file: Path) -> bool:
         # For the result of every test run, check the status of each run log to


### PR DESCRIPTION
We write the result to a YAML and parse them back.

This mostly uses `common.dataclass_{to,from}_dict()`, except that the list of `TftAggregateOutput` is (at the highest level) not a dataclass (it's a dictionary with a"tft-tests" key and a list of `TftAggregateOutput`). That fact makes the parsing more effort than if it were just a dataclass that we can pass to `common.dataclass_from_dict()`.

Also, use `common.dataclass_to_dict()` in `Evaluator.dump_to_json()`