### PR TITLE
[th/log-test-start] testType: adjust logging for test start

### DIFF
--- a/testSettings.py
+++ b/testSettings.py
@@ -124,22 +124,20 @@ class TestSettings:
         return tftbase.test_case_type_get_node_location(self.test_case_id)
 
     def get_test_info(self) -> str:
-        return f"""{self.connection.test_type.name} TEST CONFIGURATION
-        Test Case {self.test_case_id}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.nodeLocation.name}
+        return f"""type={self.connection.test_type.name}, test-case={self.test_case_id.name}: {self.client_pod_type.name} pod to {self.connection_mode.name} to {self.server_pod_type.name} pod - {self.nodeLocation.name}
         Client Node: {self.conf_client.name}
             Tenant={self.client_is_tenant}
             Index={self.client_index}
         Server Node: {self.node_server_name}
             Exec Persistence: {self.conf_server.persistent}
             Tenant={self.server_is_tenant}
-            Index={self.server_index}
-        """
+            Index={self.server_index}"""
 
     def get_test_str(self) -> str:
         direction = ""
         if self.reverse:
             direction = "-REV"
-        return f"{self.test_case_id}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.nodeLocation.name}{direction}"
+        return f"{self.test_case_id.name}-{self.client_pod_type.name}_TO_{self.connection_mode.name}_TO_{self.server_pod_type.name}-{self.nodeLocation.name}{direction}"
 
     def get_test_metadata(self) -> TestMetadata:
         return TestMetadata(

--- a/testType.py
+++ b/testType.py
@@ -19,9 +19,7 @@ class TestTypeHandler(ABC):
     def create_server_client(
         self, ts: "TestSettings"
     ) -> tuple["PerfServer", "PerfClient"]:
-        logger.info(
-            f"Initializing {self.test_type} server/client for test:\n {ts.get_test_info()}"
-        )
+        logger.info(f"Starting test {ts.get_test_info()}")
         assert ts.connection.test_type == self.test_type
         return self._create_server_client(ts)
 


### PR DESCRIPTION
The previous output is rather verbose:
```
    2024-06-20 09:13:44 INFO    [th:139821715986240]: Initializing TestType.HTTP server/client for test:
     HTTP TEST CONFIGURATION
            Test Case TestCaseType.POD_TO_POD_SAME_NODE: SRIOV pod to POD_IP to SRIOV pod - SAME_NODE
            Client Node: worker-247
                Tenant=True
                Index=0
            Server Node: worker-247
                Exec Persistence: False
                Tenant=True
                Index=0

    2024-06-20 09:13:44 DEBUG   [th:139821715986240]: ...
```
Shorten it to
```
    2024-06-20 09:14:58 INFO    [th:140067496519488]: Starting test type=HTTP, test-case=POD_TO_POD_SAME_NODE: SRIOV pod to POD_IP to SRIOV pod - SAME_NODE
            Client Node: worker-247
                Tenant=True
                Index=0
            Server Node: worker-247
                Exec Persistence: False
                Tenant=True
                Index=0
    2024-06-20 09:14:58 DEBUG   [th:140067496519488]: ...
```
In particular, if you grep for "Starting", you can see useful information at one line:
```
    2024-06-20 09:14:58 INFO    [th:140067496519488]: Starting test type=HTTP, test-case=POD_TO_POD_SAME_NODE: SRIOV pod to POD_IP to SRIOV pod - SAME_NODE
```