### PR TITLE
[th/oc-run-exec] task: use Task.run_oc_exec() instead of Task.run_oc()

### DIFF
--- a/perf.py
+++ b/perf.py
@@ -120,8 +120,8 @@ class PerfServer(Task, abc.ABC):
         else:
             self.setup_pod()
             ca_cmd = self._create_setup_operation_get_cancel_action_cmd()
-            cmd = f"exec {self.pod_name} -- {th_cmd}"
-            cancel_cmd = f"exec -t {self.pod_name} -- {ca_cmd}"
+            cmd = f"{th_cmd}"
+            cancel_cmd = f"{ca_cmd}"
 
         logger.info(f"Running {cmd}")
 
@@ -139,7 +139,7 @@ class PerfServer(Task, abc.ABC):
             if self.exec_persistent:
                 return BaseOutput(msg="Server is persistent")
             return BaseOutput.from_cmd(
-                self.run_oc(cmd, may_fail=ignore_failure),
+                self.run_oc_exec(cmd, may_fail=ignore_failure),
                 success=force_success,
             )
 

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -66,10 +66,10 @@ class TaskMeasureCPU(PluginTask):
     def _create_task_operation(self) -> TaskOperation:
         def _thread_action() -> BaseOutput:
 
-            cmd = f"exec {self.pod_name} -- mpstat -P ALL {self.get_duration()} 1"
             self.ts.clmo_barrier.wait()
 
-            r = self.run_oc(cmd)
+            cmd = f"mpstat -P ALL {self.get_duration()} 1"
+            r = self.run_oc_exec(cmd)
 
             data = r.out
 

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -74,12 +74,12 @@ class TaskMeasurePower(PluginTask):
 
     def _create_task_operation(self) -> TaskOperation:
         def _thread_action() -> BaseOutput:
-            cmd = f"exec -t {self.pod_name} -- ipmitool dcmi power reading"
+            cmd = "ipmitool dcmi power reading"
             self.ts.clmo_barrier.wait()
             total_pwr = 0
             iteration = 0
             while not self.ts.event_client_finished.is_set():
-                r = self.run_oc(cmd)
+                r = self.run_oc_exec(cmd)
                 if r.returncode != 0:
                     logger.error(f"Failed to get power {cmd}: {r}")
                 pwr = _extract(r)

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -64,11 +64,11 @@ class HttpServer(perf.PerfServer):
 class HttpClient(perf.PerfClient):
     def _create_task_operation(self) -> TaskOperation:
         server_ip = self.get_target_ip()
-        cmd = f"exec {self.pod_name} -- curl --fail -s http://{server_ip}:{self.port}/data"
+        cmd = f"curl --fail -s http://{server_ip}:{self.port}/data"
 
         def _thread_action() -> BaseOutput:
             self.ts.clmo_barrier.wait()
-            r = self.run_oc(cmd)
+            r = self.run_oc_exec(cmd)
             self.ts.event_client_finished.set()
 
             return IperfOutput(

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -101,15 +101,17 @@ class IperfServer(perf.PerfServer):
 class IperfClient(perf.PerfClient):
     def _create_task_operation(self) -> TaskOperation:
         server_ip = self.get_target_ip()
-        cmd = f"exec {self.pod_name} -- {IPERF_EXE} -c {server_ip} -p {self.port} --json -t {self.get_duration()}"
+        cmd = (
+            f"{IPERF_EXE} -c {server_ip} -p {self.port} --json -t {self.get_duration()}"
+        )
         if self.test_type == TestType.IPERF_UDP:
-            cmd = f" {cmd} {IPERF_UDP_OPT}"
+            cmd += f" {IPERF_UDP_OPT}"
         if self.reverse:
-            cmd = f" {cmd} {IPERF_REV_OPT}"
+            cmd += f" {IPERF_REV_OPT}"
 
         def _thread_action() -> BaseOutput:
             self.ts.clmo_barrier.wait()
-            r = self.run_oc(cmd)
+            r = self.run_oc_exec(cmd)
             self.ts.event_client_finished.set()
             if not r.success:
                 return BaseOutput.from_cmd(r)

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -58,13 +58,13 @@ class NetPerfClient(perf.PerfClient):
 
         server_ip = self.get_target_ip()
         if self.test_type == TestType.NETPERF_TCP_STREAM:
-            cmd = f"exec {self.pod_name} -- {NETPERF_CLIENT_EXE} -H {server_ip} -p {self.port} -t TCP_STREAM -l {self.get_duration()}"
+            cmd = f"{NETPERF_CLIENT_EXE} -H {server_ip} -p {self.port} -t TCP_STREAM -l {self.get_duration()}"
         else:
-            cmd = f"exec {self.pod_name} -- {NETPERF_CLIENT_EXE} -H {server_ip} -p {self.port} -t TCP_RR -l {self.get_duration()}"
+            cmd = f"{NETPERF_CLIENT_EXE} -H {server_ip} -p {self.port} -t TCP_RR -l {self.get_duration()}"
 
         def _thread_action() -> BaseOutput:
             self.ts.clmo_barrier.wait()
-            r = self.run_oc(cmd)
+            r = self.run_oc_exec(cmd)
             self.ts.event_client_finished.set()
             if not r.success:
                 return BaseOutput.from_cmd(r)


### PR DESCRIPTION
Note that in some cases we would pass on the command to the PluginOutput. So this changes the output. However, I think the command in the output is only for informational purpose, so this is probably fine. You anyway couldn't copy+paste the command, because the string already previously lacked the "--kubeconfig" and "-n" options, that are automatically added by Task.run_oc().