### PR TITLE
[th/eval-result-rework] cleanup evaluation of results

### DIFF
--- a/common.py
+++ b/common.py
@@ -219,6 +219,19 @@ def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
     return output
 
 
+T = TypeVar("T")
+
+
+def dict_get_typed(d: typing.Mapping[Any, Any], key: Any, vtype: type[T]) -> T:
+    try:
+        v = d[key]
+    except KeyError:
+        raise KeyError(f'missing key "{key}"')
+    if not isinstance(v, vtype):
+        raise TypeError(f'key "{key}" expected type {vtype} but has value "{v}"')
+    return v
+
+
 def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> str:
     with open(in_file_name) as inFile:
         contents = inFile.read()
@@ -240,9 +253,6 @@ def serialize_enum(
         return [serialize_enum(item) for item in data]
     else:
         return data
-
-
-T = TypeVar("T")
 
 
 def dataclass_to_dict(obj: "DataclassInstance") -> dict[str, Any]:

--- a/evaluator.py
+++ b/evaluator.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Optional
 
 import evalConfig
-import pluginbase
 import tftbase
 
 from common import dataclass_to_dict
@@ -108,8 +107,7 @@ class Evaluator:
             result = self._eval_flow_test(run.flow_test)
             test_results.append(result)
             for plugin_output in run.plugins:
-                plugin = pluginbase.get_by_name(plugin_output.name)
-                plugin_result = plugin.eval_log(
+                plugin_result = plugin_output.plugin.eval_log(
                     plugin_output, run.flow_test.tft_metadata
                 )
                 if plugin_result is not None:

--- a/evaluator.py
+++ b/evaluator.py
@@ -84,7 +84,7 @@ class Evaluator:
             test_id=md.test_case_id,
             test_type=md.test_type,
             reverse=md.reverse,
-            success=bitrate_gbps.is_passing(bitrate_threshold),
+            success=run.success and bitrate_gbps.is_passing(bitrate_threshold),
             bitrate_gbps=bitrate_gbps,
         )
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -13,7 +13,6 @@ import tftbase
 from common import dataclass_to_dict
 from common import strict_dataclass
 from logger import logger
-from testType import TestTypeHandler
 from tftbase import Bitrate
 from tftbase import IperfOutput
 from tftbase import TestCaseType
@@ -67,7 +66,6 @@ class Evaluator:
     def _eval_flow_test(self, run: IperfOutput) -> TestResult:
         md = run.tft_metadata
 
-        bitrate_gbps = Bitrate.NA
         bitrate_threshold: Optional[float] = None
 
         # We accept a missing eval_config entry. That is also because we can
@@ -78,14 +76,13 @@ class Evaluator:
             cfg_test_case = cfg.test_cases.get(md.test_case_id)
             if cfg_test_case is not None:
                 bitrate_threshold = cfg_test_case.get_threshold(is_reverse=md.reverse)
-            bitrate_gbps = TestTypeHandler.get(cfg.test_type).calculate_gbps(run.result)
 
         return TestResult(
             test_id=md.test_case_id,
             test_type=md.test_type,
             reverse=md.reverse,
-            success=run.success and bitrate_gbps.is_passing(bitrate_threshold),
-            bitrate_gbps=bitrate_gbps,
+            success=run.success and run.bitrate_gbps.is_passing(bitrate_threshold),
+            bitrate_gbps=run.bitrate_gbps,
         )
 
     def eval_log(

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -76,14 +76,9 @@ class TaskMeasureCPU(PluginTask):
             # satisfy the linter. jc.parse returns a list of dicts in this case
             parsed_data = cast(list[dict[str, Any]], jc.parse("mpstat", data))
             return PluginOutput(
-                plugin_metadata={
-                    "name": "MeasureCPU",
-                    "node_name": self.node_name,
-                    "pod_name": self.pod_name,
-                },
+                plugin_metadata=self.get_plugin_metadata(),
                 command=cmd,
                 result=parsed_data[0],
-                name=plugin.PLUGIN_NAME,
             )
 
         return TaskOperation(

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -88,16 +88,11 @@ class TaskMeasurePower(PluginTask):
                 time.sleep(0.2)
 
             return PluginOutput(
-                plugin_metadata={
-                    "name": "MeasurePower",
-                    "node_name": self.node_name,
-                    "pod_name": self.pod_name,
-                },
+                plugin_metadata=self.get_plugin_metadata(),
                 command=cmd,
                 result={
                     "measure_power": f"{total_pwr/iteration}",
                 },
-                name=plugin.PLUGIN_NAME,
             )
 
         return TaskOperation(

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -252,15 +252,10 @@ class TaskValidateOffload(PluginTask):
                 f"tx_packet_end: {parsed_data.get('tx_end', 'N/A')}\n"
             )
             return PluginOutput(
+                plugin_metadata=self.get_plugin_metadata(),
                 success=success_result,
                 command=ethtool_cmd,
-                plugin_metadata={
-                    "name": "GetEthtoolStats",
-                    "node_name": self.node_name,
-                    "pod_name": self.pod_name,
-                },
                 result=parsed_data,
-                name=plugin.PLUGIN_NAME,
             )
 
         return TaskOperation(

--- a/task.py
+++ b/task.py
@@ -442,3 +442,10 @@ class PluginTask(Task):
     @abstractmethod
     def plugin(self) -> Plugin:
         pass
+
+    def get_plugin_metadata(self) -> tftbase.PluginMetadata:
+        return tftbase.PluginMetadata(
+            plugin_name=self.plugin.PLUGIN_NAME,
+            node_name=self.node_name,
+            pod_name=self.pod_name,
+        )

--- a/testType.py
+++ b/testType.py
@@ -2,12 +2,9 @@ import typing
 
 from abc import ABC
 from abc import abstractmethod
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
 
 from logger import logger
-from tftbase import Bitrate
 from tftbase import TestType
 
 
@@ -28,10 +25,6 @@ class TestTypeHandler(ABC):
         self, ts: "TestSettings"
     ) -> tuple["PerfServer", "PerfClient"]:
         pass
-
-    def calculate_gbps(self, result: Mapping[str, Any]) -> Bitrate:
-        # This type does not implement calculating gbps.
-        return Bitrate.NA
 
     def can_run_reverse(self) -> bool:
         return False

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -80,6 +80,7 @@ class HttpClient(perf.PerfClient):
                 result={
                     "result": common.dataclass_to_dict(r),
                 },
+                bitrate_gbps=tftbase.Bitrate.NA,
             )
 
         return TaskOperation(

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -99,6 +99,7 @@ class NetPerfClient(perf.PerfClient):
                 tft_metadata=self.ts.get_test_metadata(),
                 command=cmd,
                 result=parsed_data,
+                bitrate_gbps=tftbase.Bitrate.NA,
             )
 
         return TaskOperation(

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Any
+from typing import Optional
 
 import perf
 import tftbase
@@ -16,6 +18,50 @@ from tftbase import TestType
 
 NETPERF_SERVER_EXE = "netserver"
 NETPERF_CLIENT_EXE = "netperf"
+
+
+def netperf_parse(testname: Any, data: str) -> dict[str, float]:
+
+    # Let's accept both the testname as string and as TestType enum.
+    s_testname = str(testname)
+    if s_testname.startswith("TestType."):
+        s_testname = s_testname[len("TestType.") :]
+    if s_testname.startswith("NETPERF_"):
+        s_testname = s_testname[len("NETPERF_") :]
+
+    if s_testname == "TCP_RR":
+        headers = [
+            "Socket Send Bytes",
+            "Size Receive Bytes",
+            "Request Size Bytes",
+            "Response Size Bytes",
+            "Elapsed Time Seconds",
+            "Transaction Rate Per Second",
+        ]
+    elif s_testname == "TCP_STREAM":
+        headers = [
+            "Receive Socket Size Bytes",
+            "Send Socket Size Bytes",
+            "Send Message Size Bytes",
+            "Elapsed Time Seconds",
+            "Throughput 10^6bits/sec",
+        ]
+    else:
+        raise TypeError(f'invalid testname "{testname}"')
+
+    lines = data.split("\n")
+
+    values: Optional[list[float]] = None
+    if len(lines) >= 7:
+        slist = [s.strip() for s in lines[6].split()]
+        try:
+            values = [float(s) for s in slist]
+        except ValueError:
+            pass
+    if not values or len(values) != len(headers):
+        raise ValueError("Cannot parse netperf output for tcp-stream: {repr(data)}")
+
+    return dict(zip(headers, values))
 
 
 @dataclass(frozen=True)
@@ -66,40 +112,42 @@ class NetPerfClient(perf.PerfClient):
             self.ts.clmo_barrier.wait()
             r = self.run_oc_exec(cmd)
             self.ts.event_client_finished.set()
-            if not r.success:
-                return BaseOutput.from_cmd(r)
 
-            data = r.out
+            success_result = False
+            parsed_data: dict[str, float] = {}
+            bitrate_gbps = tftbase.Bitrate.NA
 
-            lines = data.strip().split("\n")
+            if r.success:
+                data = r.out
+                try:
+                    parsed_data = netperf_parse(self.test_type, data)
+                except ValueError:
+                    pass
+                else:
+                    success_result = True
 
-            if self.test_type == TestType.NETPERF_TCP_STREAM:
-                headers = [
-                    "Receive Socket Size Bytes",
-                    "Send Socket Size Bytes",
-                    "Send Message Size Bytes",
-                    "Elapsed Time Seconds",
-                    "Throughput 10^6bits/sec",
-                ]
-                values = lines[6].split()
-            else:
-                headers = [
-                    "Socket Send Bytes",
-                    "Size Receive Bytes",
-                    "Request Size Bytes",
-                    "Response Size Bytes",
-                    "Elapsed Time Seconds",
-                    "Transaction Rate Per Second",
-                ]
-                values = lines[6].split()
-
-            parsed_data = dict(zip(headers, values))
+            if success_result:
+                if self.test_type == TestType.NETPERF_TCP_STREAM:
+                    try:
+                        x = float(parsed_data["Throughput 10^6bits/sec"])
+                    except Exception:
+                        success_result = False
+                    else:
+                        bitrate_gbps = tftbase.Bitrate(tx=x / 1000.0)
+                else:
+                    try:
+                        x = float(parsed_data["Transaction Rate Per Second"])
+                    except Exception:
+                        success_result = False
+                    else:
+                        bitrate_gbps = tftbase.Bitrate(tx=x / 1000.0)
 
             return IperfOutput(
+                success=success_result,
                 tft_metadata=self.ts.get_test_metadata(),
                 command=cmd,
                 result=parsed_data,
-                bitrate_gbps=tftbase.Bitrate.NA,
+                bitrate_gbps=bitrate_gbps,
             )
 
         return TaskOperation(

--- a/tests/input1.json
+++ b/tests/input1.json
@@ -406,6 +406,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 38.848,
+          "rx": 38.691
         }
       },
       "plugins": []
@@ -756,6 +760,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 42.193,
+          "rx": 42.364
         }
       },
       "plugins": []
@@ -1166,6 +1174,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.925,
+          "rx": 13.868
         }
       },
       "plugins": []
@@ -1516,6 +1528,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.495,
+          "rx": 13.547
         }
       },
       "plugins": []
@@ -1926,6 +1942,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 38.713,
+          "rx": 38.558
         }
       },
       "plugins": []
@@ -2276,6 +2296,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 42.326,
+          "rx": 42.496
         }
       },
       "plugins": []
@@ -2686,6 +2710,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.852,
+          "rx": 13.795
         }
       },
       "plugins": []
@@ -3036,6 +3064,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.297,
+          "rx": 13.347
         }
       },
       "plugins": []
@@ -3446,6 +3478,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 38.24,
+          "rx": 38.087
         }
       },
       "plugins": []
@@ -3796,6 +3832,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 37.242,
+          "rx": 37.392
         }
       },
       "plugins": []
@@ -4206,6 +4246,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 23.416,
+          "rx": 23.322
         }
       },
       "plugins": []
@@ -4556,6 +4600,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 19.342,
+          "rx": 19.416
         }
       },
       "plugins": []
@@ -4966,6 +5014,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 38.524,
+          "rx": 38.37
         }
       },
       "plugins": []
@@ -5316,6 +5368,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 42.108,
+          "rx": 42.277
         }
       },
       "plugins": []
@@ -5726,6 +5782,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.972,
+          "rx": 13.915
         }
       },
       "plugins": []
@@ -6076,6 +6136,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.186,
+          "rx": 13.236
         }
       },
       "plugins": []
@@ -6486,6 +6550,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 38.301,
+          "rx": 38.148
         }
       },
       "plugins": []
@@ -6836,6 +6904,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 42.024,
+          "rx": 42.192
         }
       },
       "plugins": []
@@ -7246,6 +7318,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.675,
+          "rx": 13.618
         }
       },
       "plugins": []
@@ -7596,6 +7672,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.075,
+          "rx": 13.124
         }
       },
       "plugins": []
@@ -8006,6 +8086,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 27.355,
+          "rx": 27.247
         }
       },
       "plugins": []
@@ -8356,6 +8440,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 34.828,
+          "rx": 34.967
         }
       },
       "plugins": []
@@ -8766,6 +8854,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 12.276,
+          "rx": 12.228
         }
       },
       "plugins": []
@@ -9116,6 +9208,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.792,
+          "rx": 13.845
         }
       },
       "plugins": []
@@ -9526,6 +9622,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 27.11,
+          "rx": 27.004
         }
       },
       "plugins": []
@@ -9876,6 +9976,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 28.941,
+          "rx": 29.055
         }
       },
       "plugins": []
@@ -10286,6 +10390,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 23.409,
+          "rx": 23.314
         }
       },
       "plugins": []
@@ -10636,6 +10744,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 23.318,
+          "rx": 23.407
         }
       },
       "plugins": []
@@ -11046,6 +11158,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 27.442,
+          "rx": 27.333
         }
       },
       "plugins": []
@@ -11396,6 +11512,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 34.916,
+          "rx": 35.056
         }
       },
       "plugins": []
@@ -11806,6 +11926,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 12.237,
+          "rx": 12.189
         }
       },
       "plugins": []
@@ -12156,6 +12280,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 13.842,
+          "rx": 13.895
         }
       },
       "plugins": []
@@ -12566,6 +12694,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 28.272,
+          "rx": 28.159
         }
       },
       "plugins": []
@@ -12916,6 +13048,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 30.23,
+          "rx": 30.351
         }
       },
       "plugins": []
@@ -13326,6 +13462,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 23.415,
+          "rx": 23.32
         }
       },
       "plugins": []
@@ -13676,6 +13816,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 22.807,
+          "rx": 22.894
         }
       },
       "plugins": []
@@ -14086,6 +14230,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 9.3752,
+          "rx": 9.3357
         }
       },
       "plugins": []
@@ -14436,6 +14584,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 9.3376,
+          "rx": 9.3729
         }
       },
       "plugins": []
@@ -14846,6 +14998,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 9.4165,
+          "rx": 9.3762
         }
       },
       "plugins": []
@@ -15196,6 +15352,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 9.3784,
+          "rx": 9.4138
         }
       },
       "plugins": []

--- a/tests/input2.json
+++ b/tests/input2.json
@@ -406,6 +406,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -756,6 +760,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1166,6 +1174,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1516,6 +1528,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1926,6 +1942,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2276,6 +2296,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2686,6 +2710,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3036,6 +3064,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3446,6 +3478,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3796,6 +3832,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4206,6 +4246,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4556,6 +4600,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4966,6 +5014,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5316,6 +5368,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5726,6 +5782,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6076,6 +6136,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6486,6 +6550,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6836,6 +6904,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7246,6 +7318,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7596,6 +7672,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8006,6 +8086,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8356,6 +8440,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8766,6 +8854,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9116,6 +9208,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9526,6 +9622,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9876,6 +9976,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10286,6 +10390,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10636,6 +10744,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11046,6 +11158,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11396,6 +11512,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11806,6 +11926,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12156,6 +12280,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12566,6 +12694,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12916,6 +13048,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13326,6 +13462,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13676,6 +13816,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14086,6 +14230,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14436,6 +14584,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14846,6 +14998,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -15196,6 +15352,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []

--- a/tests/input3.json
+++ b/tests/input3.json
@@ -406,6 +406,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -756,6 +760,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1166,6 +1174,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1516,6 +1528,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1926,6 +1942,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2276,6 +2296,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2686,6 +2710,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3036,6 +3064,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3446,6 +3478,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3796,6 +3832,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4206,6 +4246,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4556,6 +4600,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4966,6 +5014,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5316,6 +5368,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5726,6 +5782,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6076,6 +6136,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6486,6 +6550,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6836,6 +6904,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7246,6 +7318,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7596,6 +7672,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8006,6 +8086,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8356,6 +8440,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8766,6 +8854,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9116,6 +9208,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9526,6 +9622,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9876,6 +9976,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10286,6 +10390,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10636,6 +10744,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11046,6 +11158,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11396,6 +11512,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11806,6 +11926,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12156,6 +12280,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12566,6 +12694,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12916,6 +13048,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13326,6 +13462,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13676,6 +13816,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14086,6 +14230,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14436,6 +14584,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14846,6 +14998,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -15196,6 +15352,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []

--- a/tests/input4.json
+++ b/tests/input4.json
@@ -406,6 +406,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -756,6 +760,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1166,6 +1174,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1516,6 +1528,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -1926,6 +1942,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2276,6 +2296,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -2686,6 +2710,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3036,6 +3064,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3446,6 +3478,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -3796,6 +3832,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4206,6 +4246,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4556,6 +4600,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -4966,6 +5014,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5316,6 +5368,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -5726,6 +5782,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6076,6 +6136,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6486,6 +6550,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -6836,6 +6904,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7246,6 +7318,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -7596,6 +7672,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8006,6 +8086,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8356,6 +8440,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -8766,6 +8854,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9116,6 +9208,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9526,6 +9622,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -9876,6 +9976,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10286,6 +10390,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -10636,6 +10744,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11046,6 +11158,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11396,6 +11512,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -11806,6 +11926,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12156,6 +12280,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12566,6 +12694,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -12916,6 +13048,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13326,6 +13462,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -13676,6 +13816,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14086,6 +14230,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14436,6 +14584,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -14846,6 +14998,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []
@@ -15196,6 +15352,10 @@
             "sender_tcp_congestion": "cubic",
             "receiver_tcp_congestion": "cubic"
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": []

--- a/tests/input5.json
+++ b/tests/input5.json
@@ -988,6 +988,10 @@
             "is_tenant": true,
             "index": 0
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": [
@@ -1877,6 +1881,10 @@
             "is_tenant": true,
             "index": 0
           }
+        },
+        "bitrate_gbps": {
+          "tx": 0.0,
+          "rx": 0.0
         }
       },
       "plugins": [

--- a/tests/input5.json
+++ b/tests/input5.json
@@ -1011,11 +1011,10 @@
             "time": "19:28:52"
           },
           "plugin_metadata": {
-            "name": "MeasureCPU",
+            "plugin_name": "measure_cpu",
             "node_name": "worker-246",
             "pod_name": "tools-pod-worker-246-measure-cpu"
-          },
-          "name": "measure_cpu"
+          }
         },
         {
           "success": true,
@@ -1037,11 +1036,10 @@
             "time": "19:28:52"
           },
           "plugin_metadata": {
-            "name": "MeasureCPU",
+            "plugin_name": "measure_cpu",
             "node_name": "worker-247",
             "pod_name": "tools-pod-worker-247-measure-cpu"
-          },
-          "name": "measure_cpu"
+          }
         },
         {
           "success": true,
@@ -1051,11 +1049,10 @@
             "measure_power": "356.21590909090907"
           },
           "plugin_metadata": {
-            "name": "MeasurePower",
+            "plugin_name": "measure_power",
             "node_name": "worker-246",
             "pod_name": "tools-pod-worker-246-measure-cpu"
-          },
-          "name": "measure_power"
+          }
         },
         {
           "success": true,
@@ -1065,11 +1062,10 @@
             "measure_power": "385.264367816092"
           },
           "plugin_metadata": {
-            "name": "MeasurePower",
+            "plugin_name": "measure_power",
             "node_name": "worker-247",
             "pod_name": "tools-pod-worker-247-measure-cpu"
-          },
-          "name": "measure_power"
+          }
         }
       ]
     },
@@ -1904,11 +1900,10 @@
             "time": "19:29:25"
           },
           "plugin_metadata": {
-            "name": "MeasureCPU",
+            "plugin_name": "measure_cpu",
             "node_name": "worker-246",
             "pod_name": "tools-pod-worker-246-measure-cpu"
-          },
-          "name": "measure_cpu"
+          }
         },
         {
           "success": true,
@@ -1930,11 +1925,10 @@
             "time": "19:29:25"
           },
           "plugin_metadata": {
-            "name": "MeasureCPU",
+            "plugin_name": "measure_cpu",
             "node_name": "worker-247",
             "pod_name": "tools-pod-worker-247-measure-cpu"
-          },
-          "name": "measure_cpu"
+          }
         },
         {
           "success": true,
@@ -1944,11 +1938,10 @@
             "measure_power": "355.65168539325845"
           },
           "plugin_metadata": {
-            "name": "MeasurePower",
+            "plugin_name": "measure_power",
             "node_name": "worker-246",
             "pod_name": "tools-pod-worker-246-measure-cpu"
-          },
-          "name": "measure_power"
+          }
         },
         {
           "success": true,
@@ -1958,11 +1951,10 @@
             "measure_power": "382.75"
           },
           "plugin_metadata": {
-            "name": "MeasurePower",
+            "plugin_name": "measure_power",
             "node_name": "worker-247",
             "pod_name": "tools-pod-worker-247-measure-cpu"
-          },
-          "name": "measure_power"
+          }
         }
       ]
     }

--- a/tests/test_pluginValidateOffload.py
+++ b/tests/test_pluginValidateOffload.py
@@ -1,0 +1,64 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pluginValidateOffload  # noqa: E402
+
+
+def test_ethtool_parse_stat() -> None:
+
+    assert pluginValidateOffload.ethtool_stat_parse("") == {}
+
+    data = """NIC statistics:
+     tx_packets: 2537925
+     rx_packets: 5645343
+     tx_errors: 0
+     rx_errors: 0
+     rx_missed: 0
+     align_errors: 0
+     tx_single_collisions: 0
+     tx_multi_collisions: 0
+     rx_unicast: 5373570
+     rx_broadcast: 226191
+     rx_multicast: 45582
+     tx_aborted: 0
+     tx_underrun: 0
+"""
+    expected_d = {
+        "tx_packets": "2537925",
+        "rx_packets": "5645343",
+        "tx_errors": "0",
+        "rx_errors": "0",
+        "rx_missed": "0",
+        "align_errors": "0",
+        "tx_single_collisions": "0",
+        "tx_multi_collisions": "0",
+        "rx_unicast": "5373570",
+        "rx_broadcast": "226191",
+        "rx_multicast": "45582",
+        "tx_aborted": "0",
+        "tx_underrun": "0",
+    }
+
+    d = pluginValidateOffload.ethtool_stat_parse(data)
+    assert d == expected_d
+    assert list(d) == list(expected_d)
+
+    assert pluginValidateOffload.ethtool_stat_get_packets(d, "tx") == 2537925
+    assert pluginValidateOffload.ethtool_stat_get_packets(d, "rx") == 5645343
+    assert pluginValidateOffload.ethtool_stat_get_packets(d, "foo") is None
+
+    res: dict[str, int] = {}
+    assert pluginValidateOffload.ethtool_stat_get_startend(res, data, "start")
+    assert res == {
+        "rx_start": 5645343,
+        "tx_start": 2537925,
+    }
+    assert pluginValidateOffload.ethtool_stat_get_startend(res, data, "end")
+    assert res == {
+        "rx_start": 5645343,
+        "tx_start": 2537925,
+        "rx_end": 5645343,
+        "tx_end": 2537925,
+    }

--- a/tests/test_testTypeNetPerf.py
+++ b/tests/test_testTypeNetPerf.py
@@ -1,0 +1,77 @@
+import os
+import pytest
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import testTypeNetPerf  # noqa: E402
+import tftbase  # noqa: E402
+
+
+def test_netperf_parse_tcp_rr() -> None:
+
+    data = """MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.131.0.169 () port 0 AF_INET : demo : first burst 0
+Local /Remote
+Socket Size   Request  Resp.   Elapsed  Trans.
+Send   Recv   Size     Size    Time     Rate         
+bytes  Bytes  bytes    bytes   secs.    per sec   
+
+16384  131072 1        1       30.00    43642.12   
+16384  131072
+"""
+
+    assert testTypeNetPerf.netperf_parse(tftbase.TestType.NETPERF_TCP_RR, data) == {
+        "Socket Send Bytes": 16384.0,
+        "Size Receive Bytes": 131072.0,
+        "Request Size Bytes": 1.0,
+        "Response Size Bytes": 1.0,
+        "Elapsed Time Seconds": 30.0,
+        "Transaction Rate Per Second": 43642.12,
+    }
+
+    data = """MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.131.0.169 () port 0 AF_INET : demo : first burst 0
+Local /Remote
+Socket Size   Request  Resp.   Elapsed  Trans.
+Send   Recv   Size     Size    Time     Rate         
+bytes  Bytes  bytes    bytes   secs.    per sec   
+
+16384  131072 1     2   1       30.00    43642.12   
+16384  131072
+"""
+
+    with pytest.raises(ValueError):
+        testTypeNetPerf.netperf_parse("TCP_RR", data)
+
+
+def test_netperf_parse_tcp_stream() -> None:
+
+    data = """MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.131.0.167 () port 0 AF_INET : demo
+Recv   Send    Send                          
+Socket Socket  Message  Elapsed              
+Size   Size    Size     Time     Throughput  
+bytes  bytes   bytes    secs.    10^6bits/sec  
+
+131072  16384  16384    30.00    35710.68   
+"""
+
+    assert testTypeNetPerf.netperf_parse("TCP_STREAM", data) == {
+        "Receive Socket Size Bytes": 131072.0,
+        "Send Socket Size Bytes": 16384.0,
+        "Send Message Size Bytes": 16384.0,
+        "Elapsed Time Seconds": 30.0,
+        "Throughput 10^6bits/sec": 35710.68,
+    }
+
+    with pytest.raises(TypeError):
+        testTypeNetPerf.netperf_parse("bogus-name", data)
+
+    data = """MIGRATED TCP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.131.0.167 () port 0 AF_INET : demo
+Recv   Send    Send                          
+Socket Socket  Message  Elapsed              
+Size   Size    Size     Time     Throughput  
+bytes  bytes   bytes    secs.    10^6bits/sec  
+
+16384  16384    30.00    35710.68   
+"""
+    with pytest.raises(ValueError):
+        testTypeNetPerf.netperf_parse("TCP_STREAM", data)

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -59,7 +59,12 @@ def test_iperf_output() -> None:
         server=server,
         client=client,
     )
-    IperfOutput(command="command", result={}, tft_metadata=metadata)
+    IperfOutput(
+        command="command",
+        result={},
+        tft_metadata=metadata,
+        bitrate_gbps=tftbase.Bitrate.NA,
+    )
 
     common.dataclass_from_dict(
         IperfOutput,
@@ -67,9 +72,31 @@ def test_iperf_output() -> None:
             "command": "command",
             "result": {},
             "tft_metadata": metadata,
+            "bitrate_gbps": {"tx": 0.0, "rx": 0.0},
         },
     )
 
+    o = common.dataclass_from_dict(
+        IperfOutput,
+        {
+            "command": "command",
+            "result": {},
+            "tft_metadata": metadata,
+            "bitrate_gbps": {"tx": None, "rx": 0},
+        },
+    )
+    assert o.bitrate_gbps.tx is None
+    assert o.bitrate_gbps.rx == 0.0
+
+    with pytest.raises(ValueError):
+        common.dataclass_from_dict(
+            IperfOutput,
+            {
+                "command": "command",
+                "result": {},
+                "tft_metadata": metadata,
+            },
+        )
     with pytest.raises(TypeError):
         common.dataclass_from_dict(
             IperfOutput,
@@ -77,6 +104,7 @@ def test_iperf_output() -> None:
                 "command": "command",
                 "result": {},
                 "tft_metadata": "string",
+                "bitrate_gbps": {"tx": 0.0, "rx": 0.0},
             },
         )
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -219,9 +219,9 @@ class PluginResult:
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
 class TestMetadata:
-    reverse: bool
     test_case_id: TestCaseType
     test_type: TestType
+    reverse: bool
     server: PodInfo
     client: PodInfo
 
@@ -261,9 +261,10 @@ class AggregatableOutput(BaseOutput):
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
 class IperfOutput(AggregatableOutput):
+    tft_metadata: TestMetadata
     command: str
     result: dict[str, Any]
-    tft_metadata: TestMetadata
+    bitrate_gbps: Bitrate
 
 
 @strict_dataclass

--- a/tftbase.py
+++ b/tftbase.py
@@ -67,6 +67,9 @@ def get_tft_image_pull_policy() -> str:
 TFT_TESTS = "tft-tests"
 
 
+T = typing.TypeVar("T")
+
+
 class ClusterMode(Enum):
     SINGLE = 1
     DPU = 3
@@ -268,6 +271,9 @@ class PluginOutput(AggregatableOutput):
         import pluginbase
 
         return pluginbase.get_by_name(self.name)
+
+    def result_get(self, key: str, vtype: type[T]) -> T:
+        return common.dict_get_typed(self.result, key, vtype)
 
 
 @strict_dataclass

--- a/tftbase.py
+++ b/tftbase.py
@@ -192,6 +192,14 @@ class PodInfo:
 
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
+class PluginMetadata:
+    plugin_name: str
+    node_name: str
+    pod_name: str
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
 class PluginResult:
     """Result of a single plugin from a given run
 
@@ -263,14 +271,13 @@ class IperfOutput(AggregatableOutput):
 class PluginOutput(AggregatableOutput):
     command: str
     result: dict[str, Any]
-    plugin_metadata: dict[str, str]
-    name: str
+    plugin_metadata: PluginMetadata
 
     @property
     def plugin(self) -> "Plugin":
         import pluginbase
 
-        return pluginbase.get_by_name(self.name)
+        return pluginbase.get_by_name(self.plugin_metadata.plugin_name)
 
     def result_get(self, key: str, vtype: type[T]) -> T:
         return common.dict_get_typed(self.result, key, vtype)
@@ -565,7 +572,7 @@ def output_list_parse(
                 plugin_output.plugin
             except ValueError:
                 raise RuntimeError(
-                    f'{err} has invalid plugin name "{plugin_output.name}" in result #{r_idx}'
+                    f'{err} has invalid plugin name "{plugin_output.plugin_metadata.plugin_name}" in result #{r_idx}'
                 )
 
     return output_list


### PR DESCRIPTION
- extract parsing of iperf and netperf output to (unit tested) helper functions
- let the parsing don't fail with an exception, instead signal parsing errors in the result (`success=False`).
- let the test already compute the `Bitrate` and embed it in the result. This moves the functionality from the `Evaluator` right to the place where we collect the test result. It also means, the result JSON contains also the bit rate.
- implement bitrate and evaluation for `netperf` test type.