### PR TITLE
[th/task-aggregate-output] task: let base implementation aggregate_output() handle flow-test result

### DIFF
--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -7,7 +7,6 @@ import common
 import perf
 import tftbase
 
-from logger import logger
 from perf import PerfClient
 from perf import PerfServer
 from task import TaskOperation
@@ -87,13 +86,3 @@ class HttpClient(perf.PerfClient):
             log_name=self.log_name,
             thread_action=_thread_action,
         )
-
-    def _aggregate_output(
-        self,
-        result: tftbase.AggregatableOutput,
-        out: tftbase.TftAggregateOutput,
-    ) -> None:
-        assert isinstance(result, IperfOutput)
-
-        logger.info(f"Results of {self.ts.get_test_str()}")
-        out.flow_test = result

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -140,16 +140,6 @@ class IperfClient(perf.PerfClient):
         out: tftbase.TftAggregateOutput,
     ) -> None:
         assert isinstance(result, IperfOutput)
-
-        out.flow_test = result
-
-        # Print summary to console logs
-        logger.info(f"Results of {self.ts.get_test_str()}:")
-        if self.iperf_error_occurred(result.result):
-            logger.error(
-                "Encountered error while running test:\n" f"  {result.result['error']}"
-            )
-            return
         if self.test_type == TestType.IPERF_TCP:
             self.print_tcp_results(result.result)
         if self.test_type == TestType.IPERF_UDP:
@@ -188,6 +178,3 @@ class IperfClient(perf.PerfClient):
             f"  Total Lost Packets: {total_lost_packets}\n"
             f"  Total Lost Percent: {total_lost_percent:.2f}%"
         )
-
-    def iperf_error_occurred(self, data: Mapping[str, Any]) -> bool:
-        return "error" in data

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -5,7 +5,6 @@ from typing import Optional
 import perf
 import tftbase
 
-from logger import logger
 from perf import PerfClient
 from perf import PerfServer
 from task import TaskOperation
@@ -154,16 +153,3 @@ class NetPerfClient(perf.PerfClient):
             log_name=self.log_name,
             thread_action=_thread_action,
         )
-
-    def _aggregate_output(
-        self,
-        result: tftbase.AggregatableOutput,
-        out: tftbase.TftAggregateOutput,
-    ) -> None:
-        assert isinstance(result, IperfOutput)
-
-        out.flow_test = result
-
-        # Print summary to console logs
-        logger.info(f"Results of {self.ts.get_test_str()}:")
-        logger.info(f"{result.result}:")


### PR DESCRIPTION
Instead of having TestTypeHandler implementations override _aggregate_output(), move the common code to Task.aggregate_output().

If a TestType implementation really wants to overwrite Task.aggregate_output(), it still can. However, that should not be necessary, because Task.aggregate_output() already all that should be necessary. In particular, it honors IperfOutput's "success" field, which allows Task.aggregate_output()  to do the right thing, without having a per-test-type override.

Task._aggregate_output() still exists and some implementations use it for logging. That part is still task specific, because the base class does not know how to interpret the details of the task.