### PR TITLE
[th/eval-all-plugins] evaluator: enable plugin evaluation for all plugins

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -104,8 +104,9 @@ class Evaluator:
             result = self._eval_flow_test(run.flow_test)
             test_results.append(result)
             for plugin_output in run.plugins:
-                plugin_result = plugin_output.plugin.eval_log(
-                    plugin_output, run.flow_test.tft_metadata
+                plugin_result = plugin_output.plugin.eval_plugin_output(
+                    run.flow_test.tft_metadata,
+                    plugin_output,
                 )
                 if plugin_result is not None:
                     plugin_results.append(plugin_result)

--- a/pluginbase.py
+++ b/pluginbase.py
@@ -4,6 +4,8 @@ from abc import ABC
 from abc import abstractmethod
 from typing import Optional
 
+import common
+
 from logger import logger
 from tftbase import PluginOutput
 from tftbase import PluginResult
@@ -51,11 +53,25 @@ class Plugin(ABC):
     ) -> list["PluginTask"]:
         pass
 
-    def eval_log(
-        self, plugin_output: PluginOutput, md: TestMetadata
+    def eval_plugin_output(
+        self,
+        md: TestMetadata,
+        plugin_output: PluginOutput,
     ) -> Optional[PluginResult]:
-        # Some plugins don't have this implemented. They do nothing.
-        return None
+        if not plugin_output.success:
+            logger.error(
+                f"{self.PLUGIN_NAME} plugin failed for {common.dataclass_to_json(md)}: {plugin_output.err_msg}"
+            )
+        else:
+            logger.debug(
+                f"{self.PLUGIN_NAME} plugin succeded for {common.dataclass_to_json(md)}"
+            )
+        return PluginResult(
+            test_id=md.test_case_id,
+            test_type=md.test_type,
+            reverse=md.reverse,
+            success=plugin_output.success,
+        )
 
 
 _plugins: dict[str, Plugin] = {}


### PR DESCRIPTION
Of the 3 existing plugins, only "validate_offload" implemented Plugin.eval_log(), which is called by Evaluator for collecting the result. All our plugins should be collected in the results.

Instead of implementing eval_log() for all plugins, rework how it works.

The existing eval_log() implementation of PluginValidateOffload only performed some static check on the PluginOutput. Now, already when running the test, this check is run and PluginOutput.success is set.

Later, the default implementation of Plugin.eval_plugin_output() (previously Plugin.eval_log()) considers PluginOutput.success. This way, we have it implemented for all plugin types, they just need to set the right PluginOutput.success.

Note that Plugin.eval_plugin_output() no longer does anything plugin-specific. It only considers PluginOutput.success. In the future, we may want that the valuation needs to consider the plugin, so we keep this as a virtual function of Plugin.