### PR TITLE
[th/test-meta-data-indexes] TestMetadata: record the tft/test_cases/connections indexes

### DIFF
--- a/testSettings.py
+++ b/testSettings.py
@@ -141,6 +141,9 @@ class TestSettings:
 
     def get_test_metadata(self) -> TestMetadata:
         return TestMetadata(
+            tft_idx=self.cfg_descr.tft_idx,
+            test_cases_idx=self.cfg_descr.test_cases_idx,
+            connections_idx=self.cfg_descr.connections_idx,
             test_case_id=self.test_case_id,
             test_type=self.connection.test_type,
             reverse=self.reverse,

--- a/tests/input1.json
+++ b/tests/input1.json
@@ -3,6 +3,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -417,6 +420,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -771,6 +777,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1185,6 +1194,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -1539,6 +1551,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1953,6 +1968,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -2307,6 +2325,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -2721,6 +2742,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3075,6 +3099,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -3489,6 +3516,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3843,6 +3873,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -4257,6 +4290,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -4611,6 +4647,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5025,6 +5064,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -5379,6 +5421,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5793,6 +5838,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6147,6 +6195,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -6561,6 +6612,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6915,6 +6969,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -7329,6 +7386,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -7683,6 +7743,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8097,6 +8160,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -8451,6 +8517,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8865,6 +8934,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9219,6 +9291,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -9633,6 +9708,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9987,6 +10065,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -10401,6 +10482,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -10755,6 +10839,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11169,6 +11256,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -11523,6 +11613,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11937,6 +12030,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -12291,6 +12387,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -12705,6 +12804,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13059,6 +13161,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -13473,6 +13578,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13827,6 +13935,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -14241,6 +14352,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -14595,6 +14709,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -15009,6 +15126,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,

--- a/tests/input2.json
+++ b/tests/input2.json
@@ -3,6 +3,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "invalid_test_case_id",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -417,6 +420,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -771,6 +777,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1185,6 +1194,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -1539,6 +1551,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1953,6 +1968,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -2307,6 +2325,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -2721,6 +2742,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3075,6 +3099,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -3489,6 +3516,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3843,6 +3873,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -4257,6 +4290,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -4611,6 +4647,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5025,6 +5064,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -5379,6 +5421,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5793,6 +5838,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6147,6 +6195,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -6561,6 +6612,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6915,6 +6969,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -7329,6 +7386,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -7683,6 +7743,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8097,6 +8160,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -8451,6 +8517,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8865,6 +8934,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9219,6 +9291,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -9633,6 +9708,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9987,6 +10065,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -10401,6 +10482,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -10755,6 +10839,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11169,6 +11256,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -11523,6 +11613,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11937,6 +12030,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -12291,6 +12387,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -12705,6 +12804,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13059,6 +13161,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -13473,6 +13578,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13827,6 +13935,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -14241,6 +14352,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -14595,6 +14709,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -15009,6 +15126,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,

--- a/tests/input3.json
+++ b/tests/input3.json
@@ -3,6 +3,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "invalid_test_type",
           "reverse": false,
@@ -417,6 +420,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -771,6 +777,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1185,6 +1194,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -1539,6 +1551,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1953,6 +1968,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -2307,6 +2325,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -2721,6 +2742,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3075,6 +3099,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -3489,6 +3516,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3843,6 +3873,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -4257,6 +4290,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -4611,6 +4647,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5025,6 +5064,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -5379,6 +5421,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5793,6 +5838,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6147,6 +6195,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -6561,6 +6612,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6915,6 +6969,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -7329,6 +7386,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -7683,6 +7743,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8097,6 +8160,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -8451,6 +8517,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8865,6 +8934,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9219,6 +9291,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -9633,6 +9708,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9987,6 +10065,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -10401,6 +10482,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -10755,6 +10839,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11169,6 +11256,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -11523,6 +11613,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11937,6 +12030,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -12291,6 +12387,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -12705,6 +12804,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13059,6 +13161,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -13473,6 +13578,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13827,6 +13935,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -14241,6 +14352,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -14595,6 +14709,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -15009,6 +15126,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,

--- a/tests/input4.json
+++ b/tests/input4.json
@@ -3,6 +3,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -417,6 +420,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -771,6 +777,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1185,6 +1194,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -1539,6 +1551,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -1953,6 +1968,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -2307,6 +2325,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -2721,6 +2742,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3075,6 +3099,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -3489,6 +3516,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -3843,6 +3873,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -4257,6 +4290,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -4611,6 +4647,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5025,6 +5064,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -5379,6 +5421,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -5793,6 +5838,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6147,6 +6195,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -6561,6 +6612,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -6915,6 +6969,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -7329,6 +7386,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -7683,6 +7743,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8097,6 +8160,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -8451,6 +8517,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -8865,6 +8934,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9219,6 +9291,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -9633,6 +9708,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -9987,6 +10065,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -10401,6 +10482,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -10755,6 +10839,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11169,6 +11256,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -11523,6 +11613,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -11937,6 +12030,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_POD_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -12291,6 +12387,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -12705,6 +12804,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_SAME_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13059,6 +13161,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -13473,6 +13578,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -13827,6 +13935,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -14241,6 +14352,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "POD_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,
@@ -14595,6 +14709,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": false,
@@ -15009,6 +15126,9 @@
     {
       "flow_test": {
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "test_case_id": "HOST_TO_EXTERNAL",
           "test_type": "IPERF_TCP",
           "reverse": true,

--- a/tests/input5.json
+++ b/tests/input5.json
@@ -973,6 +973,9 @@
           }
         },
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "reverse": false,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",
@@ -1866,6 +1869,9 @@
           }
         },
         "tft_metadata": {
+          "tft_idx": 0,
+          "test_cases_idx": 0,
+          "connections_idx": 0,
           "reverse": true,
           "test_case_id": "POD_TO_POD_SAME_NODE",
           "test_type": "IPERF_TCP",

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -32,6 +32,9 @@ def test_test_metadata() -> None:
         name="client_pod", pod_type=PodType.NORMAL, is_tenant=False, index=1
     )
     metadata = TestMetadata(
+        tft_idx=0,
+        test_cases_idx=0,
+        connections_idx=0,
         reverse=False,
         test_case_id=TestCaseType.POD_TO_POD_SAME_NODE,
         test_type=TestType.IPERF_TCP,
@@ -53,6 +56,9 @@ def test_iperf_output() -> None:
         name="client_pod", pod_type=PodType.NORMAL, is_tenant=False, index=1
     )
     metadata = TestMetadata(
+        tft_idx=0,
+        test_cases_idx=0,
+        connections_idx=0,
         reverse=False,
         test_case_id=TestCaseType.POD_TO_POD_SAME_NODE,
         test_type=TestType.IPERF_TCP,

--- a/tftbase.py
+++ b/tftbase.py
@@ -219,6 +219,9 @@ class PluginResult:
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
 class TestMetadata:
+    tft_idx: int
+    test_cases_idx: int
+    connections_idx: int
     test_case_id: TestCaseType
     test_type: TestType
     reverse: bool


### PR DESCRIPTION
The input configuration for TFT is a YAML with nested lists of tests, test-cases and connections. Record in the test meta data of the output the indexes, so that we know for which particular test the respective result is.

This allows to associate the test result with the corresponding entry in the test config YAML.