### PR TITLE
[th/plugin-result-name] plugin: record the plugin name in PluginResult

### DIFF
--- a/pluginbase.py
+++ b/pluginbase.py
@@ -67,6 +67,7 @@ class Plugin(ABC):
                 f"{self.PLUGIN_NAME} plugin succeded for {common.dataclass_to_json(md)}"
             )
         return PluginResult(
+            plugin_name=self.PLUGIN_NAME,
             test_id=md.test_case_id,
             test_type=md.test_type,
             reverse=md.reverse,

--- a/tftbase.py
+++ b/tftbase.py
@@ -204,12 +204,14 @@ class PluginResult:
     """Result of a single plugin from a given run
 
     Attributes:
+        plugin_name: the plugin
         test_id: TestCaseType enum representing the type of traffic test (i.e. POD_TO_POD_SAME_NODE <1> )
         test_type: TestType enum representing the traffic protocol (i.e. iperf_tcp)
         reverse: Specify whether test is client->server or reversed server->client
         success: boolean representing whether the test passed or failed
     """
 
+    plugin_name: str
     test_id: TestCaseType
     test_type: TestType
     reverse: bool


### PR DESCRIPTION
Otherwise it is pretty hard to see, which of the results came from which plugin.