### PR TITLE
[th/config-kubeconfig] make kubeconfig/kubeconfig_infra configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ tft:
         plugins:
           - name: (15)
           - name: (15)
+kubeconfig: (16)
+kubeconfig_infra: (16)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -94,6 +96,9 @@ tft:
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
+16. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+  files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
+  are detected based on the files we find at /root/kubeconfig.*.
 
 ## Running the tests
 

--- a/common.py
+++ b/common.py
@@ -451,11 +451,6 @@ def structparse_check_strdict(arg: Any, yamlpath: str) -> dict[str, Any]:
             raise ValueError(
                 f'"{yamlpath}": expects all dictionary keys to be strings but got {type(k)}'
             )
-        if v is None:
-            # None is not allowed, because we use that to indicate a missing key.
-            # I also think that yaml.safe_load() cannot ever create None entries,
-            # so this limitation is fine (and the code actually shouldn't be reachable)
-            raise ValueError(f'"{yamlpath}.{k}": cannot have None values')
 
     # We shallow-copy the dictionary, because the caller will remove entries
     # to find unknown entries (see _check_empty_dict()).

--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,5 @@ tft:
           - name: measure_cpu
           - name: measure_power
           - name: validate_offload
+kubeconfig:
+kubeconfig_infra:

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,5 +1,6 @@
 import kubernetes  # type: ignore
 import logging
+import os
 import shlex
 import typing
 import yaml
@@ -9,6 +10,10 @@ import host
 
 class K8sClient:
     def __init__(self, kubeconfig: str):
+        if not os.path.exists(kubeconfig):
+            raise RuntimeError(
+                f"KUBECONFIG={shlex.quote(kubeconfig)} file does not exist"
+            )
         self._kc = kubeconfig
         with open(kubeconfig) as f:
             c = yaml.safe_load(f)

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -110,7 +110,7 @@ def test_config1() -> None:
     tc = testConfig.TestConfig(config_path=file, kubeconfigs=testConfigKubeconfigsArgs1)
     assert isinstance(tc, testConfig.TestConfig)
     assert isinstance(tc.full_config, dict)
-    assert list(tc.full_config.keys()) == ["tft"]
+    assert list(tc.full_config.keys()) == ["tft", "kubeconfig", "kubeconfig_infra"]
 
     assert tc.config.tft[0].name == "Test 1"
     assert tc.config.tft[0].connections[0].name == "Connection_1"
@@ -146,12 +146,19 @@ tft:
        plugins:
          - name: measure_cpu
          - measure_power
+kubeconfig: /path/to/kubeconfig
+kubeconfig_infra: /path/to/kubeconfig_infra
 """
     )
     tc = testConfig.TestConfig(
         full_config=full_config, kubeconfigs=testConfigKubeconfigsArgs1
     )
     assert isinstance(tc, testConfig.TestConfig)
+
+    assert tc.config.kubeconfig == "/path/to/kubeconfig"
+    assert tc.config.kubeconfig_infra == "/path/to/kubeconfig_infra"
+    assert tc.kubeconfig == tc.config.kubeconfig
+    assert tc.kubeconfig_infra == tc.config.kubeconfig_infra
 
     assert tc.config.tft[0].test_cases == (
         TestCaseType(1),
@@ -188,6 +195,12 @@ tft:
         full_config=full_config, kubeconfigs=testConfigKubeconfigsArgs1
     )
     assert isinstance(tc, testConfig.TestConfig)
+
+    assert tc.config.kubeconfig is None
+    assert tc.config.kubeconfig_infra is None
+    assert tc.kubeconfig == testConfigKubeconfigsArgs1[0]
+    assert tc.kubeconfig_infra == testConfigKubeconfigsArgs1[1]
+
     assert tc.config.tft[0].name == "Test 1"
     assert tc.config.tft[0].namespace == "default"
     assert tc.config.tft[0].test_cases == tuple(


### PR DESCRIPTION
Make kubeconfig/kubeconfig_infra configurable in the config YAML.

Based on that, we also detect the cluster mode SINGLE/DPU.

Fixes: https://github.com/wizhaoredhat/ocp-traffic-flow-tests/issues/25


The autodetection still works as before. As far as autodetect goes, I think that is good enough. Anything further requires explicit configuration (which this PR adds).