### PR TITLE
[th/simple-tcp-client-server-test] simple: add a test type with a simple python tcp echo server/client

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -39,6 +39,8 @@ RUN dnf install \
 
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 
+COPY ./scripts/simple-tcp-server-client.py /usr/bin/simple-tcp-server-client
+
 COPY ./images/container-entry-point.sh /usr/bin/container-entry-point.sh
 
 ENTRYPOINT ["/usr/bin/container-entry-point.sh"]

--- a/scripts/simple-tcp-server-client.py
+++ b/scripts/simple-tcp-server-client.py
@@ -1,0 +1,307 @@
+#!/bin/python3
+
+import argparse
+import os
+import random
+import socket
+import sys
+import time
+
+from contextlib import contextmanager
+from typing import Iterator
+from typing import Optional
+from typing import Callable
+
+
+DEFAULT_ADDR = "127.0.0.1"
+DEFAULT_BUFSIZE = 65495
+DEFAULT_DURATION = 0.0
+DEFAULT_NUM_CLIENTS = 1
+DEFAULT_PORT = 5201
+DEFAULT_SLEEP = 0.001
+
+global_start_time = time.monotonic()
+
+
+def create_socket() -> socket.socket:
+    return socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+
+@contextmanager
+def socket_timeout(
+    log_name: str,
+    s: socket.socket,
+    start_time: float,
+    duration: float,
+    *,
+    done_msg: Optional[Callable[[], None]] = None,
+) -> Iterator[socket.socket]:
+    if duration <= 0.0:
+        t = None
+    else:
+        t = (start_time + duration) - time.monotonic()
+        if t <= 0.0:
+            print(f"{log_name}: duration expired. Quit")
+            sys.exit(0)
+    s.settimeout(t)
+
+    try:
+        yield s
+    except socket.timeout:
+        if done_msg is not None:
+            done_msg()
+        print(f"{log_name}: duration expired. Quit")
+        sys.exit(0)
+
+
+def sleep_timeout(
+    log_name: str,
+    start_time: float,
+    duration: float,
+    sleep_time: float,
+    *,
+    exit_code: Optional[int] = None,
+    done_msg: Optional[Callable[[], None]] = None,
+) -> bool:
+    if sleep_time <= 0.0:
+        if duration <= 0.0:
+            return True
+        t = (start_time + duration) - time.monotonic()
+    else:
+        if duration <= 0.0:
+            time.sleep(sleep_time)
+            return True
+        t = (start_time + duration) - time.monotonic()
+        if t > 0.0:
+            time.sleep(min(t, sleep_time))
+            t = (start_time + duration) - time.monotonic()
+
+    if t > 0.0:
+        return True
+
+    if done_msg is not None:
+        done_msg()
+    if exit_code is None:
+        exit_code = 0
+    print(f"{log_name}: duration expired. Quit")
+    sys.exit(exit_code)
+
+
+def run_server(
+    *,
+    s_addr: str = DEFAULT_ADDR,
+    port: int = DEFAULT_PORT,
+    sleep: float = DEFAULT_SLEEP,
+    bufsize: int = DEFAULT_BUFSIZE,
+    duration: float = DEFAULT_DURATION,
+    num_clients: int = DEFAULT_NUM_CLIENTS,
+) -> None:
+
+    start_time = global_start_time
+
+    s = create_socket()
+
+    print(f"server: listen on {s_addr}:{port}")
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((s_addr, port))
+    s.listen(1)
+
+    client_count = 0
+
+    while 1:
+        if num_clients > 0 and client_count >= num_clients:
+            print(f"server: number of clients {num_clients} reached. Quit")
+            sys.exit(0)
+        with socket_timeout("server", s, start_time, duration):
+            conn, addr = s.accept()
+        client_count += 1
+        print(
+            f"server: new connection #{client_count} on port {port} from addr {addr}."
+        )
+        msg_count = 0
+        last_time = -1000.0
+        rcv_len = 0
+        while 1:
+
+            def done_msg() -> None:
+                print(
+                    f"server: {msg_count} chunks received and returned ({rcv_len} bytes) in total"
+                )
+
+            with socket_timeout(
+                "server", conn, start_time, duration, done_msg=done_msg
+            ):
+                try:
+                    data = conn.recv(bufsize)
+                except Exception:
+                    data = b""
+            if not data:
+                done_msg()
+                print(f"server: connection {addr} closed")
+                break
+            msg_count += 1
+            rcv_len += len(data)
+            with socket_timeout(
+                "server", conn, start_time, duration, done_msg=done_msg
+            ):
+                try:
+                    conn.sendall(data)
+                except ConnectionResetError:
+                    done_msg()
+                    print(f"server: connection {addr} closed")
+                    break
+            now_time = time.monotonic()
+            if now_time - last_time >= 1.0:
+                print(
+                    f"server: {msg_count} chunks received and returned ({rcv_len} bytes)"
+                )
+                last_time = now_time
+            sleep_timeout("server", start_time, duration, sleep, done_msg=done_msg)
+        conn.close()
+
+
+def run_client(
+    *,
+    s_addr: str = DEFAULT_ADDR,
+    port: int = DEFAULT_PORT,
+    sleep: float = DEFAULT_SLEEP,
+    bufsize: int = DEFAULT_BUFSIZE,
+    duration: float = DEFAULT_DURATION,
+) -> None:
+
+    start_time = global_start_time
+
+    print(f"client: connecting to {s_addr}:{port}")
+    s = create_socket()
+
+    first_attempt = True
+    connected = False
+    while not connected:
+        try:
+            with socket_timeout("client", s, start_time, duration):
+                s.connect((s_addr, port))
+        except (ConnectionRefusedError, ConnectionAbortedError):
+            if first_attempt:
+                first_attempt = False
+                print("client: connection refused. Retry")
+            sleep_timeout("client", start_time, min(duration, 60.0), 0.5, exit_code=1)
+        else:
+            connected = True
+    print(f"client: connected to {s_addr}:{port}")
+
+    msg_count = 0
+    rcv_len = 0
+    while 1:
+
+        def done_msg() -> None:
+            print(
+                f"client: {msg_count} chunks send and received ({rcv_len} bytes) in total"
+            )
+
+        i_bufsize = random.randint(1, bufsize)
+        snd_data = os.urandom(i_bufsize)
+        with socket_timeout("client", s, start_time, duration, done_msg=done_msg):
+            s.sendall(snd_data)
+        msg_count += 1
+
+        # We first read all the data we sent back.
+        rcv_data = b""
+        while len(rcv_data) < len(snd_data):
+            s.settimeout(0.5)
+            try:
+                r = s.recv(bufsize)
+            except socket.timeout:
+                print("client: unexpected response. Server did not echo expected data")
+                sys.exit(1)
+            assert r
+            rcv_data += r
+
+        if rcv_data != snd_data:
+            print("client: unexpected response. Expect an echo of the data we sent")
+            sys.exit(1)
+
+        rcv_len += len(rcv_data)
+
+        if msg_count % 10000 == 0:
+            print(
+                f"client: {msg_count} chunks send and received ({rcv_len} bytes) for {s.getsockname()}->{s_addr}:{port}"
+            )
+        sleep_timeout("client", start_time, duration, sleep, done_msg=done_msg)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Simple TCP echo server/client")
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        help="TCP port to listen/connect (default: {DEFAULT_PORT})",
+        default=DEFAULT_PORT,
+    )
+    parser.add_argument(
+        "-a",
+        "--addr",
+        type=str,
+        help=f"IP address to listen/connect (default: {DEFAULT_ADDR}",
+        default=DEFAULT_ADDR,
+    )
+    parser.add_argument(
+        "-s",
+        "--server",
+        action="store_true",
+        help="Whether to run as server or client (default)",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        help="How many second to sleep between client send or server receive (default: {DEFAULT_SLEEP})",
+        default=DEFAULT_SLEEP,
+    )
+    parser.add_argument(
+        "--bufsize",
+        type=int,
+        help="The maximum size of the chunk send at once on the TCP stream (default: {DEFAULT_BUFSIZE})",
+        default=DEFAULT_BUFSIZE,
+    )
+    parser.add_argument(
+        "-d",
+        "--duration",
+        type=float,
+        help=f"How long before quitting (0 means infinity) (default: {DEFAULT_DURATION})",
+        default=DEFAULT_DURATION,  # noqa: E225
+    )
+    parser.add_argument(
+        "--num-clients",
+        type=int,
+        help=f"For the server, how many clients are accepted (server can only handle one client at a time) (default: {DEFAULT_NUM_CLIENTS})",
+        default=DEFAULT_NUM_CLIENTS,  # noqa: E225
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.server:
+        run_server(
+            s_addr=args.addr,
+            port=args.port,
+            sleep=args.sleep,
+            bufsize=args.bufsize,
+            duration=args.duration,
+            num_clients=args.num_clients,
+        )
+    else:
+        run_client(
+            s_addr=args.addr,
+            port=args.port,
+            sleep=args.sleep,
+            bufsize=args.bufsize,
+            duration=args.duration,
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/testConfig.py
+++ b/testConfig.py
@@ -625,6 +625,16 @@ class ConfigDescriptor:
             raise RuntimeError("No connections_idx set")
         return self.get_tft().connections[self.connections_idx]
 
+    def get_server(self) -> ConfServer:
+        c = self.get_connection()
+        assert len(c.server) == 1
+        return c.server[0]
+
+    def get_client(self) -> ConfClient:
+        c = self.get_connection()
+        assert len(c.client) == 1
+        return c.client[0]
+
     def describe_all_tft(self) -> Generator["ConfigDescriptor", None, None]:
         for tft_idx in range(len(self.tc.config.tft)):
             yield ConfigDescriptor(tc=self.tc, tft_idx=tft_idx)

--- a/testConfig.py
+++ b/testConfig.py
@@ -297,14 +297,14 @@ class ConfConnection(StructParseBaseNamed):
 
         for idx, s in enumerate(server):
             if s.args is not None:
-                if test_type not in ():
+                if test_type not in (TestType.SIMPLE,):
                     raise ValueError(
                         f'"{yamlpath}.server[{idx}].args": args are not supported for test type {test_type}'
                     )
 
         for idx, c in enumerate(client):
             if c.args is not None:
-                if test_type not in ():
+                if test_type not in (TestType.SIMPLE,):
                     raise ValueError(
                         f'"{yamlpath}.client[{idx}].args": args are not supported for test type {test_type}'
                     )

--- a/testConfig.py
+++ b/testConfig.py
@@ -57,11 +57,19 @@ class _ConfBaseClientServer(StructParseBaseNamed, abc.ABC):
     pod_type: PodType
     default_network: str
 
+    # Extra arguments for the client/server. Their actual meaning depend on the
+    # "type". These might be command line arguments passed to the tool.
+    args: Optional[tuple[str, ...]]
+
     def serialize(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.args is not None:
+            d["args"] = list(self.args)
         return {
             **super().serialize(),
             "sriov": self.sriov,
             "default-network": self.default_network,
+            **d,
         }
 
     @staticmethod
@@ -87,8 +95,27 @@ class _ConfBaseClientServer(StructParseBaseNamed, abc.ABC):
         v = vdict.pop("default-network", None)
         if v is not None:
             if not isinstance(v, str):
-                raise ValueError(f'"{yamlpath}.name": expects a string but got {name}')
+                raise ValueError(
+                    f'"{yamlpath}.default-network": expects a string but got {v}'
+                )
             default_network = v
+
+        args: Optional[list[str]] = None
+        v = vdict.pop("args", None)
+        if v is None:
+            pass
+        elif isinstance(v, str):
+            args = shlex.split(v)
+        elif isinstance(v, list):
+            if not all(isinstance(x, str) for x in v):
+                raise ValueError(
+                    f'"{yamlpath}.args": expects a list of strings but got {repr(v)}'
+                )
+            args = v
+        else:
+            raise ValueError(
+                f'"{yamlpath}.args": expects a string or a list of strings but got {repr(v)}'
+            )
 
         type_specific_kwargs = {}
 
@@ -110,6 +137,7 @@ class _ConfBaseClientServer(StructParseBaseNamed, abc.ABC):
             pod_type=pod_type,
             sriov=(pod_type == PodType.SRIOV),
             default_network=default_network,
+            args=tuple(args) if args is not None else None,
             **type_specific_kwargs,
         )
 
@@ -266,6 +294,20 @@ class ConfConnection(StructParseBaseNamed):
             raise ValueError(
                 f'"{yamlpath}.client": currently only one client entry is supported'
             )
+
+        for idx, s in enumerate(server):
+            if s.args is not None:
+                if test_type not in ():
+                    raise ValueError(
+                        f'"{yamlpath}.server[{idx}].args": args are not supported for test type {test_type}'
+                    )
+
+        for idx, c in enumerate(client):
+            if c.args is not None:
+                if test_type not in ():
+                    raise ValueError(
+                        f'"{yamlpath}.client[{idx}].args": args are not supported for test type {test_type}'
+                    )
 
         return ConfConnection(
             yamlidx=yamlidx,

--- a/testType.py
+++ b/testType.py
@@ -49,6 +49,10 @@ class TestTypeHandler(ABC):
             import testTypeHttp
 
             return testTypeHttp.test_type_handler_http
+        if test_type == TestType.SIMPLE:
+            import testTypeSimple
+
+            return testTypeSimple.test_type_handler_simple
         raise ValueError(f"Unsupported test type {test_type}")
 
 

--- a/testTypeSimple.py
+++ b/testTypeSimple.py
@@ -1,0 +1,99 @@
+import shlex
+
+from dataclasses import dataclass
+
+import common
+import perf
+import tftbase
+
+from perf import PerfClient
+from perf import PerfServer
+from task import TaskOperation
+from testSettings import TestSettings
+from testType import TestTypeHandler
+from tftbase import BaseOutput
+from tftbase import IperfOutput
+from tftbase import TestType
+
+
+@dataclass(frozen=True)
+class TestTypeHandlerSimple(TestTypeHandler):
+    def __init__(self) -> None:
+        super().__init__(TestType.SIMPLE)
+
+    def _create_server_client(self, ts: TestSettings) -> tuple[PerfServer, PerfClient]:
+        s = SimpleServer(ts=ts)
+        c = SimpleClient(ts=ts, server=s)
+        return (s, c)
+
+
+test_type_handler_simple = TestTypeHandlerSimple()
+
+CMD_SIMPLE_TCP_SERVER_CLIENT = "simple-tcp-server-client"
+
+
+class SimpleServer(perf.PerfServer):
+    def cmd_line_args(self) -> list[str]:
+        return [
+            CMD_SIMPLE_TCP_SERVER_CLIENT,
+            "--server",
+            "--addr",
+            "0.0.0.0",
+            "--port",
+            f"{self.port}",
+            *(self.ts.cfg_descr.get_server().args or ()),
+        ]
+
+    def get_template_args(self) -> dict[str, str | list[str]]:
+
+        extra_args: dict[str, str | list[str]] = {}
+        if self.exec_persistent:
+            extra_args["args"] = self.cmd_line_args()
+
+        return {
+            **super().get_template_args(),
+            **extra_args,
+        }
+
+    def _create_setup_operation_get_thread_action_cmd(self) -> str:
+        return shlex.join(self.cmd_line_args())
+
+    def _create_setup_operation_get_cancel_action_cmd(self) -> str:
+        return "killall python3"
+
+
+class SimpleClient(perf.PerfClient):
+    def cmd_line_args(self) -> list[str]:
+        return [
+            CMD_SIMPLE_TCP_SERVER_CLIENT,
+            "--addr",
+            f"{self.get_target_ip()}",
+            "--port",
+            f"{self.port}",
+            "--duration",
+            f"{self.get_duration()}",
+            *(self.ts.cfg_descr.get_client().args or ()),
+        ]
+
+    def _create_task_operation(self) -> TaskOperation:
+        cmd = shlex.join(self.cmd_line_args())
+
+        def _thread_action() -> BaseOutput:
+            self.ts.clmo_barrier.wait()
+            r = self.run_oc_exec(cmd)
+            self.ts.event_client_finished.set()
+
+            return IperfOutput(
+                success=r.success,
+                tft_metadata=self.ts.get_test_metadata(),
+                command=cmd,
+                result={
+                    "result": common.dataclass_to_dict(r),
+                },
+                bitrate_gbps=tftbase.Bitrate.NA,
+            )
+
+        return TaskOperation(
+            log_name=self.log_name,
+            thread_action=_thread_action,
+        )

--- a/tests/test_testConfig.py
+++ b/tests/test_testConfig.py
@@ -146,6 +146,15 @@ tft:
        plugins:
          - name: measure_cpu
          - measure_power
+     - name: con2
+       type: simple
+       client:
+         - name: c1
+           args: "foo '-x x'"
+       server:
+         - name: s1
+           args:
+             - "hi x"
 kubeconfig: /path/to/kubeconfig
 kubeconfig_infra: /path/to/kubeconfig_infra
 """
@@ -168,11 +177,16 @@ kubeconfig_infra: /path/to/kubeconfig_infra
         TestCaseType.HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE,
         TestCaseType.HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE,
     )
+    assert tc.config.tft[0].connections[0].test_type == TestType.IPERF_TCP
     assert tc.config.tft[0].connections[0].plugins[0].name == "measure_cpu"
     assert (
         tc.config.tft[0].connections[0].plugins[0].plugin.PLUGIN_NAME == "measure_cpu"
     )
     assert tc.config.tft[0].connections[0].plugins[1].name == "measure_power"
+
+    assert tc.config.tft[0].connections[1].test_type == TestType.SIMPLE
+    assert tc.config.tft[0].connections[1].client[0].args == ("foo", "-x x")
+    assert tc.config.tft[0].connections[1].server[0].args == ("hi x",)
 
     _check_testConfig(tc)
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -81,6 +81,7 @@ class TestType(Enum):
     HTTP = 3
     NETPERF_TCP_STREAM = 4
     NETPERF_TCP_RR = 5
+    SIMPLE = 6
 
 
 class PodType(Enum):


### PR DESCRIPTION
The purpose is to have an alternative test tool. In this case, it's a relatively simple Python script where the client connects via TCP, sends a message, and the server sends it back.

The point is also, that this script is relatively easily extendable, either for manual testing or to add a new mode. Hence you can specify additional command line arguments in the test configuration.

https://issues.redhat.com/browse/NHE-743