### PR TITLE
[th/container-fix-shutdown] fix shutdown of test pods, use tini init process and minor cleanups

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -11,6 +11,8 @@ RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download
 RUN dnf install -y epel-next-release epel-release
 
 RUN dnf install \
+        --allowerasing \
+        coreutils \
         cri-tools \
         ethtool \
         git \

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -25,6 +25,7 @@ RUN dnf install \
         net-tools \
         netperf \
         pciutils \
+        procps-ng \
         python3 \
         sysstat \
         tcpdump \

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -31,6 +31,7 @@ RUN dnf install \
         python3 \
         sysstat \
         tcpdump \
+        tini \
         util-linux \
         vim \
         wget \
@@ -38,4 +39,7 @@ RUN dnf install \
 
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 
-CMD ["/bin/bash"]
+COPY ./images/container-entry-point.sh /usr/bin/container-entry-point.sh
+
+ENTRYPOINT ["/usr/bin/container-entry-point.sh"]
+CMD ["/usr/bin/sleep", "infinity"]

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -1,8 +1,14 @@
 FROM quay.io/centos/centos:stream9
 
+RUN dnf install -y 'dnf-command(config-manager)'
+
+RUN dnf config-manager --set-enabled crb
+
 RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/devel:kubic:libcontainers:stable.repo
 
 RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo
+
+RUN dnf install -y epel-next-release epel-release
 
 RUN dnf install \
         cri-tools \

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -4,7 +4,28 @@ RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://do
 
 RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo
 
-RUN INSTALL_PKGS="vim wget jq python3 git cri-tools net-tools iptables iproute pciutils ethtool httpd iperf3 tcpdump sysstat ipmitool util-linux netperf nc iputils" && yum install -y ${INSTALL_PKGS}
+RUN dnf install \
+        cri-tools \
+        ethtool \
+        git \
+        httpd \
+        iperf3 \
+        ipmitool \
+        iproute \
+        iptables \
+        iputils \
+        jq \
+        nc \
+        net-tools \
+        netperf \
+        pciutils \
+        python3 \
+        sysstat \
+        tcpdump \
+        util-linux \
+        vim \
+        wget \
+        -y
 
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 

--- a/images/container-entry-point.sh
+++ b/images/container-entry-point.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$#" -eq 0 ] ; then
+    ARGS=("/usr/bin/sleep" "infinity")
+else
+    ARGS=("$@")
+fi
+
+exec /usr/bin/tini -p SIGTERM -g -e 143 -- "${ARGS[@]}"

--- a/manifests/tools-pod.yaml.j2
+++ b/manifests/tools-pod.yaml.j2
@@ -14,7 +14,7 @@ spec:
     image: {{ test_image }}
     command:
       - "{{ command }}"
-    args: ["{{ args }}"]
+    args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
     securityContext:
       privileged: true

--- a/perf.py
+++ b/perf.py
@@ -54,7 +54,7 @@ class PerfServer(Task, abc.ABC):
         self.out_file_yaml = out_file_yaml
         self.pod_name = pod_name
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str] = {}
         if self.connection_mode != ConnectionMode.EXTERNAL_IP:
@@ -191,7 +191,7 @@ class PerfClient(Task, abc.ABC):
         self.out_file_yaml = out_file_yaml
         self.pod_name = pod_name
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
             "default_network": self.ts.conf_client.default_network,

--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -52,7 +52,7 @@ class TaskMeasureCPU(PluginTask):
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
         self.node_name = node_name
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -62,7 +62,7 @@ class TaskMeasurePower(PluginTask):
         self.pod_name = f"tools-pod-{self.node_name}-measure-cpu"
         self.node_name = node_name
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -1,5 +1,6 @@
 import json
 import typing
+
 from typing import Optional
 
 import common
@@ -157,7 +158,7 @@ class TaskValidateOffload(PluginTask):
         self.perf_pod_name = perf_instance.pod_name
         self.perf_pod_type = perf_instance.pod_type
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             **super().get_template_args(),
             "pod_name": self.pod_name,

--- a/task.py
+++ b/task.py
@@ -265,7 +265,7 @@ class Task(ABC):
     def get_duration(self) -> int:
         return self.ts.cfg_descr.get_tft().duration
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
         return {
             "name_space": self.get_namespace(),
             "test_image": tftbase.get_tft_test_image(),
@@ -281,7 +281,7 @@ class Task(ABC):
         log_info: str,
         in_file_template: Optional[str] = None,
         out_file_yaml: Optional[str] = None,
-        template_args: Optional[dict[str, str]] = None,
+        template_args: Optional[dict[str, str | list[str]]] = None,
     ) -> None:
         if in_file_template is None:
             in_file_template = self.in_file_template

--- a/task.py
+++ b/task.py
@@ -270,7 +270,7 @@ class Task(ABC):
             "name_space": self.get_namespace(),
             "test_image": tftbase.get_tft_test_image(),
             "image_pull_policy": tftbase.get_tft_image_pull_policy(),
-            "command": "/sbin/init",
+            "command": "/usr/bin/container-entry-point.sh",
             "args": [],
             "index": f"{self.index}",
             "node_name": self.node_name,

--- a/task.py
+++ b/task.py
@@ -271,7 +271,7 @@ class Task(ABC):
             "test_image": tftbase.get_tft_test_image(),
             "image_pull_policy": tftbase.get_tft_image_pull_policy(),
             "command": "/sbin/init",
-            "args": "",
+            "args": [],
             "index": f"{self.index}",
             "node_name": self.node_name,
         }

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -41,7 +41,7 @@ class HttpServer(perf.PerfServer):
             f"{self.port}",
         ]
 
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str] = {}
         if self.exec_persistent:

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -66,7 +66,7 @@ test_type_handler_iperf_udp = TestTypeHandlerIperf(TestType.IPERF_UDP)
 
 
 class IperfServer(perf.PerfServer):
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str] = {}
         if self.exec_persistent:

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -78,7 +78,7 @@ test_type_handler_netperf_tcp_rr = TestTypeHandlerNetPerf(TestType.NETPERF_TCP_R
 
 
 class NetPerfServer(perf.PerfServer):
-    def get_template_args(self) -> dict[str, str]:
+    def get_template_args(self) -> dict[str, str | list[str]]:
 
         extra_args: dict[str, str] = {}
         if self.exec_persistent:


### PR DESCRIPTION
- `oc delete` is used to cleanup the created pods. Those pods ran `/sbin/init`, which was unkillable by SIGTERM. Hence, every test would waste 30 seconds waiting to kill those containers. Replace that with `tini`, which can be killed fast.

See also: https://github.com/krallin/tini

- enable EPEL/CBR in the test image `quay.io/wizhao/tft-tools:latest`. Also install `psproc-ng` and `coreutils` for better usability of the container when debugging.