### PR TITLE
[th/measure-power-parse] pluginMeasurePower: improve error reporting of "measure_power" plugin

### DIFF
--- a/tests/test_pluginMeasurePower.py
+++ b/tests/test_pluginMeasurePower.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pluginMeasurePower  # noqa: E402
+
+
+def test_extract() -> None:
+    out = "\n    Instantaneous power reading:                   346 Watts\n    Minimum during sampling period:                 12 Watts\n    Maximum during sampling period:                703 Watts\n    Average power reading over sample period:      346 Watts\n    IPMI timestamp:                           Tue Jul 16 14:57:49 2024\n    Sampling period:                          00000001 Seconds.\n    Power reading state is:                   activated\n\n\n"
+
+    r = pluginMeasurePower._extract(out)
+    assert r == 346


### PR DESCRIPTION
There is no need for individual logger.error() calls. We already call self.run_oc_exec(), which will log an ERROR with the full output of the command. That is more useful already.

Also, when running ipmitool or parsing its output fails, signal an error and set a reason message.