### PR TITLE
Added tests for multi-home and multi-network

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ tft:
         plugins:
           - name: (15)
           - name: (15)
-kubeconfig: (16)
-kubeconfig_infra: (16)
+        secondary_network_nad: "(16)"
+kubeconfig: (17)
+kubeconfig_infra: (17)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -79,6 +80,9 @@ kubeconfig_infra: (16)
     | 24 | HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE |
     | 25 | POD_TO_EXTERNAL |
     | 26 | HOST_TO_EXTERNAL |
+    | 27 | POD_TO_POD_2ND_INTERFACE_SAME_NODE |
+    | 28 | POD_TO_POD_2ND_INTERFACE_DIFF_NODE |
+    | 29 | POD_TO_POD_MULTI_NETWORK_POLICY |
 4. "duration" - The duration that each individual test will run for.
 5. "name" - This is the connection name. Any string value to identify the connection.
 6. "type" - Supported types of connections are iperf-tcp, iperf-udp, netperf-tcp-stream, netperf-tcp-rr
@@ -96,7 +100,8 @@ kubeconfig_infra: (16)
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
-16. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+16. "secondary_network_nad" - The name of the secondary network for multi-homing and multi-networkpolicies tests.
+17. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,5 +22,7 @@ tft:
           - name: measure_cpu
           - name: measure_power
           - name: validate_offload
+        # Secondary network is required for tests 27, 28 and 29
+        # secondary_network_nad: "default/ocp-secondary"
 kubeconfig:
 kubeconfig_infra:

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -130,6 +130,21 @@ IPERF_TCP:
       threshold: 18
     Reverse:
       threshold: 10
+  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
 IPERF_UDP:
   - id: 1 # POD_TO_POD_SAME_NODE
     Normal:
@@ -257,6 +272,21 @@ IPERF_UDP:
     Reverse:
       threshold: 5
   - id: 26 # HOST_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
     Normal:
       threshold: 5
     Reverse:

--- a/manifests/allow-egress-mnp.yaml.j2
+++ b/manifests/allow-egress-mnp.yaml.j2
@@ -1,0 +1,17 @@
+kind: MultiNetworkPolicy
+apiVersion: k8s.cni.cncf.io/v1beta1
+metadata:
+  namespace: {{ name_space }}
+  name: allow-egress-mnp
+  labels:
+    tft-tests: "{{ index }}"
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: {{ secondary_network_nad }}
+spec:
+  podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}
+      ports:
+        - port: {{ egress_port }}
+          protocol: TCP

--- a/manifests/allow-ingress-mnp.yaml.j2
+++ b/manifests/allow-ingress-mnp.yaml.j2
@@ -1,0 +1,17 @@
+kind: MultiNetworkPolicy
+apiVersion: k8s.cni.cncf.io/v1beta1
+metadata:
+  namespace: {{ name_space }}
+  name: allow-ingress-mnp
+  labels:
+    tft-tests: "{{ index }}"
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: {{ secondary_network_nad }}
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: {{ ingress_port }}
+          protocol: TCP

--- a/manifests/pod-secondary-network.yaml.j2
+++ b/manifests/pod-secondary-network.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ name_space }}
+  name: {{ pod_name }}
+  labels:
+    tft-tests: "{{ index }}"
+    tft-port: "{{ port }}"
+  annotations:
+    k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }}
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: {{ node_name }}
+  containers:
+  - name: {{ pod_name }}
+    image: {{ test_image }}
+    command: {{ command }}
+    args: {{ args }}
+    imagePullPolicy: {{ image_pull_policy }}

--- a/task.py
+++ b/task.py
@@ -282,6 +282,7 @@ class Task(ABC):
             "args": [],
             "index": f"{self.index}",
             "node_name": self.node_name,
+            "secondary_network_nad": self.ts.connection.secondary_network_nad,
         }
 
     def render_file(
@@ -383,6 +384,20 @@ class Task(ABC):
             raise RuntimeError("Failure to get static.podIP for {self.pod_name}")
         return pod_ip
 
+    def get_secondary_ip(self) -> str:
+        jsonpath = "{.metadata.annotations.k8s\\.ovn\\.org\\/pod-networks}"
+        r = self.run_oc(
+            f"get pod {self.pod_name} -o jsonpath='{jsonpath}'", die_on_error=True
+        )
+
+        y = yaml.safe_load(r.out)
+        ip_address_with_cidr = typing.cast(
+            str, y[self.ts.connection.secondary_network_nad]["ip_address"]
+        )
+        ip_address = ip_address_with_cidr.split("/")[0] if ip_address_with_cidr else ""
+        logger.info(f"Secondary IP: {ip_address}")
+        return ip_address
+
     def create_cluster_ip_service(self) -> str:
         in_file_template = "./manifests/svc-cluster-ip.yaml.j2"
         out_file_yaml = "./manifests/yamls/svc-cluster-ip.yaml"
@@ -418,6 +433,56 @@ class Task(ABC):
 
         return self.run_oc(
             "get service tft-nodeport-service -o=jsonpath='{.spec.clusterIP}'"
+        ).out
+
+    def create_ingress_multi_network_policy(self, ingressPort: int) -> str:
+        in_file_template = "./manifests/allow-ingress-mnp.yaml.j2"
+        out_file_yaml = "./manifests/yamls/allow-ingress-mnp.yaml"
+
+        template_args = {
+            **self.get_template_args(),
+            "ingress_port": f"{ingressPort}",
+        }
+
+        self.render_file(
+            "Ingress Multi Network Policy",
+            in_file_template,
+            out_file_yaml,
+            template_args,
+        )
+        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
+        if r.returncode != 0:
+            if "already exists" not in r.err:
+                logger.info(r)
+                sys.exit(-1)
+
+        return self.run_oc(
+            "get multi-networkpolicies allow-ingress-mnp", die_on_error=True
+        ).out
+
+    def create_egress_multi_network_policy(self, egressPort: int) -> str:
+        in_file_template = "./manifests/allow-egress-mnp.yaml.j2"
+        out_file_yaml = "./manifests/yamls/allow-egress-mnp.yaml"
+
+        template_args = {
+            **self.get_template_args(),
+            "egress_port": f"{egressPort}",
+        }
+
+        self.render_file(
+            "Egress Multi Network Policy",
+            in_file_template,
+            out_file_yaml,
+            template_args,
+        )
+        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
+        if r.returncode != 0:
+            if "already exists" not in r.err:
+                logger.info(r)
+                sys.exit(-1)
+
+        return self.run_oc(
+            "get multi-networkpolicies allow-egress-mnp", die_on_error=True
         ).out
 
     def start_setup(self) -> None:
@@ -589,6 +654,15 @@ class ServerTask(Task, ABC):
             in_file_template = ""
             out_file_yaml = ""
             pod_name = EXTERNAL_PERF_SERVER
+        elif connection_mode in (
+            ConnectionMode.MULTI_HOME,
+            ConnectionMode.MULTI_NETWORK,
+        ):
+            in_file_template = "./manifests/pod-secondary-network.yaml.j2"
+            out_file_yaml = (
+                f"./manifests/yamls/pod-secondary-network-{node_name}-server.yaml"
+            )
+            pod_name = f"normal-pod-secondary-network-{node_name}-server-{port}"
         elif pod_type == PodType.SRIOV:
             in_file_template = "./manifests/sriov-pod.yaml.j2"
             out_file_yaml = f"./manifests/yamls/sriov-pod-{node_name}-server.yaml"
@@ -635,6 +709,10 @@ class ServerTask(Task, ABC):
 
             self.cluster_ip_addr = self.create_cluster_ip_service()
             self.nodeport_ip_addr = self.create_node_port_service(self.port + 25000)
+
+        if self.connection_mode == ConnectionMode.MULTI_NETWORK:
+            self.create_ingress_multi_network_policy(self.port)
+            self.create_egress_multi_network_policy(self.port)
 
     def confirm_server_alive(self) -> None:
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
@@ -722,8 +800,15 @@ class ClientTask(Task, ABC):
         pod_type = ts.client_pod_type
         node_name = self.node_name
         port = server.port
+        connection_mode = ts.connection_mode
 
-        if pod_type == PodType.SRIOV:
+        if connection_mode in (ConnectionMode.MULTI_HOME, ConnectionMode.MULTI_NETWORK):
+            in_file_template = "./manifests/pod-secondary-network.yaml.j2"
+            out_file_yaml = (
+                f"./manifests/yamls/pod-secondary-network-{node_name}-client.yaml"
+            )
+            pod_name = f"normal-pod-secondary-network-{node_name}-client-{port}"
+        elif pod_type == PodType.SRIOV:
             in_file_template = "./manifests/sriov-pod.yaml.j2"
             out_file_yaml = f"./manifests/yamls/sriov-pod-{node_name}-client.yaml"
             pod_name = f"sriov-pod-{node_name}-client-{port}"
@@ -775,6 +860,12 @@ class ClientTask(Task, ABC):
             external_pod_ip = self.get_podman_ip(self.server.pod_name)
             logger.debug(f"get_target_ip() External connection to {external_pod_ip}")
             return external_pod_ip
+        elif self.connection_mode in (
+            ConnectionMode.MULTI_NETWORK,
+            ConnectionMode.MULTI_HOME,
+        ):
+            server_ip2 = self.server.get_secondary_ip()
+            return server_ip2
         server_ip = self.server.get_pod_ip()
         logger.debug(f"get_target_ip() Connection to server at {server_ip}")
         return server_ip

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -7,7 +7,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import common  # noqa: E402
 import tftbase  # noqa: E402
 
-from tftbase import ConnectionMode  # noqa: E402
 from tftbase import FlowTestOutput  # noqa: E402
 from tftbase import PodInfo  # noqa: E402
 from tftbase import PodType  # noqa: E402
@@ -117,72 +116,3 @@ def test_iperf_output() -> None:
 
 def test_test_case_typ_infos() -> None:
     assert list(tftbase._test_case_typ_infos) == list(TestCaseType)
-
-
-def test_test_case_type_to_connection_mode() -> None:
-    def _alternative(test_case_id: TestCaseType) -> ConnectionMode:
-        if test_case_id.value in (5, 6, 7, 8, 17, 18, 19, 20):
-            return ConnectionMode.CLUSTER_IP
-        if test_case_id.value in (9, 10, 11, 12, 21, 22, 23, 24):
-            return ConnectionMode.NODE_PORT_IP
-        if test_case_id.value in (25, 26):
-            return ConnectionMode.EXTERNAL_IP
-        return ConnectionMode.POD_IP
-
-    for test_case_type in TestCaseType:
-        assert _alternative(
-            test_case_type
-        ) == tftbase.test_case_type_to_connection_mode(test_case_type)
-
-
-def test_test_case_type_is_same_node() -> None:
-    def _alternative(test_id: TestCaseType) -> bool:
-        return test_id.value in (1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23)
-
-    for test_case_type in TestCaseType:
-        assert _alternative(test_case_type) == tftbase.test_case_type_is_same_node(
-            test_case_type
-        )
-
-
-def test_test_case_type_to_server_pod_type() -> None:
-    def _alternative(
-        test_id: TestCaseType,
-        cfg_pod_type: PodType,
-    ) -> PodType:
-        if test_id.value in (3, 4, 7, 8, 19, 20, 23, 24):
-            return PodType.HOSTBACKED
-
-        if cfg_pod_type == PodType.SRIOV:
-            return PodType.SRIOV
-
-        return PodType.NORMAL
-
-    for pod_type in PodType:
-        for test_case_type in TestCaseType:
-            assert _alternative(
-                test_case_type, pod_type
-            ) == tftbase.test_case_type_to_server_pod_type(test_case_type, pod_type)
-
-
-def test_test_case_type_to_client_pod_type() -> None:
-    def _alternative(
-        test_id: TestCaseType,
-        cfg_pod_type: PodType,
-    ) -> PodType:
-        if (
-            test_id.value >= TestCaseType.HOST_TO_HOST_SAME_NODE.value
-            and test_id.value <= TestCaseType.HOST_TO_EXTERNAL.value
-        ):
-            return PodType.HOSTBACKED
-
-        if cfg_pod_type == PodType.SRIOV:
-            return PodType.SRIOV
-
-        return PodType.NORMAL
-
-    for pod_type in PodType:
-        for test_case_type in TestCaseType:
-            assert _alternative(
-                test_case_type, pod_type
-            ) == tftbase.test_case_type_to_client_pod_type(test_case_type, pod_type)

--- a/tftbase.py
+++ b/tftbase.py
@@ -117,6 +117,9 @@ class TestCaseType(Enum):
     HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE = 24
     POD_TO_EXTERNAL = 25
     HOST_TO_EXTERNAL = 26
+    POD_TO_POD_2ND_INTERFACE_SAME_NODE = 27
+    POD_TO_POD_2ND_INTERFACE_DIFF_NODE = 28
+    POD_TO_POD_MULTI_NETWORK_POLICY = 29
 
 
 class ConnectionMode(Enum):
@@ -124,6 +127,8 @@ class ConnectionMode(Enum):
     CLUSTER_IP = 2
     NODE_PORT_IP = 3
     EXTERNAL_IP = 4
+    MULTI_NETWORK = 5
+    MULTI_HOME = 6
 
 
 class NodeLocation(Enum):
@@ -510,6 +515,24 @@ _test_case_typ_infos = {
         is_same_node=False,
         is_server_hostbacked=False,
         is_client_hostbacked=True,
+    ),
+    TestCaseType.POD_TO_POD_2ND_INTERFACE_SAME_NODE: TestCaseTypInfo(
+        connection_mode=ConnectionMode.MULTI_HOME,
+        is_same_node=True,
+        is_server_hostbacked=False,
+        is_client_hostbacked=False,
+    ),
+    TestCaseType.POD_TO_POD_2ND_INTERFACE_DIFF_NODE: TestCaseTypInfo(
+        connection_mode=ConnectionMode.MULTI_HOME,
+        is_same_node=False,
+        is_server_hostbacked=False,
+        is_client_hostbacked=False,
+    ),
+    TestCaseType.POD_TO_POD_MULTI_NETWORK_POLICY: TestCaseTypInfo(
+        connection_mode=ConnectionMode.MULTI_NETWORK,
+        is_same_node=False,
+        is_server_hostbacked=False,
+        is_client_hostbacked=False,
     ),
 }
 

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -49,6 +49,15 @@ class TrafficFlowTests:
             raise Exception("cleanup_previous_testspace(): Failed to delete services")
         logger.info(f"Cleaned services with label tft-tests in namespace {namespace}")
         logger.info(
+            f"Cleaning multi-networkpolicies with label tft-tests in namespace {namespace}"
+        )
+        r = cfg_descr.tc.client_tenant.oc(
+            f"delete multi-networkpolicies -n {namespace} -l tft-tests"
+        )
+        logger.info(
+            f"Cleaned multi-networkpolicies with label tft-tests in namespace {namespace}"
+        )
+        logger.info(
             f"Cleaning external containers {task.EXTERNAL_PERF_SERVER} (if present)"
         )
         cmd = f"podman rm --force --time 10 {task.EXTERNAL_PERF_SERVER}"

--- a/updated-eval-config.yaml
+++ b/updated-eval-config.yaml
@@ -130,6 +130,21 @@ IPERF_TCP:
   Reverse:
     threshold: 10
   id: 26
+- Normal:
+    threshold: 24
+  Reverse:
+    threshold: 34
+  id: 27
+- Normal:
+    threshold: 9
+  Reverse:
+    threshold: 11
+  id: 28
+- Normal:
+    threshold: 7
+  Reverse:
+    threshold: 9
+  id: 29
 IPERF_UDP:
 - Normal:
     threshold: 5
@@ -261,3 +276,18 @@ IPERF_UDP:
   Reverse:
     threshold: 5
   id: 26
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 27
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 28
+- Normal:
+    threshold: 5
+  Reverse:
+    threshold: 5
+  id: 29


### PR DESCRIPTION
This MR adds three new tests to test multi-homing and multi-networkpolicies scenarios:
- POD_TO_POD_2ND_INTERFACE_SAME_NODE
- POD_TO_POD_2ND_INTERFACE_DIFF_NODE
- POD_TO_POD_MULTI_NETWORK_POLICY

These tests assume that a secondary network already exists. A sample network attachment definition to test the changes is given below:
```
apiVersion: k8s.cni.cncf.io/v1
kind: NetworkAttachmentDefinition
metadata:
  annotations:
    meta.helm.sh/release-name: ovn-kubernetes
    meta.helm.sh/release-namespace: default
  name: ovn-secondary
  namespace: default
  labels:
    tft-tests: "{{ index }}"
spec:
  config: '{ "cniVersion": "0.4.0", "name": "ovn-secondary", "netAttachDefName": "default/ovn-secondary",
    "isSecondary": true, "subnets": "10.245.0.0/16/24", "mtu": 1400, "type": "ovn-k8s-cni-overlay",
    "topology":"layer3", "logFile": "/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log",
    "logLevel": "5", "logfile-maxsize": 100, "logfile-maxbackups": 5, "logfile-maxage":
    5 }'
```