### PR TITLE
[th/host-run-surrogateescape] host: avoid duplicate decoding with "errors='surrogateescape'"

### DIFF
--- a/host.py
+++ b/host.py
@@ -176,7 +176,7 @@ class Host(ABC):
                 pass
             elif not is_binary and (
                 decode_errors is None
-                or decode_errors in ("strict", "ignore", "replace")
+                or decode_errors in ("strict", "ignore", "replace", "surrogateescape")
             ):
                 # We are good. The output is not binary, and the caller did not
                 # request some unusual decoding. We already did the decoding.


### PR DESCRIPTION
`errors='surrogateescape'` is a very useful way for handling binary output of commands as if they were strings.

Adjust `Host.run()` to avoid trying to `decode()` such strings twice. We first always decode with `errors='strict'`, to see whether the input is valid UTF-8. If it is, we don't need to decode a second time with `errors='surrogateescape'`. Add that optimization.