### PR TITLE
[th/jinja2-command] fix/rework setting the "command" in Jinja2 manifest templates

### DIFF
--- a/manifests/host-pod.yaml.j2
+++ b/manifests/host-pod.yaml.j2
@@ -14,8 +14,7 @@ spec:
   containers:
   - name: {{ pod_name }}
     image: {{ test_image }}
-    command:
-      - "{{ command }}"
+    command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
     securityContext:

--- a/manifests/pod.yaml.j2
+++ b/manifests/pod.yaml.j2
@@ -12,7 +12,6 @@ spec:
   containers:
   - name: {{ pod_name }}
     image: {{ test_image }}
-    command:
-      - "{{ command }}"
+    command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -14,7 +14,6 @@ spec:
   containers:
   - name: {{ pod_name }}
     image: {{ test_image }}
-    command:
-      - "{{ command }}"
+    command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}

--- a/manifests/tools-pod.yaml.j2
+++ b/manifests/tools-pod.yaml.j2
@@ -12,8 +12,7 @@ spec:
   containers:
   - name: {{ pod_name }}
     image: {{ test_image }}
-    command:
-      - "{{ command }}"
+    command: {{ command }}
     args: {{ args }}
     imagePullPolicy: {{ image_pull_policy }}
     securityContext:

--- a/task.py
+++ b/task.py
@@ -270,7 +270,7 @@ class Task(ABC):
             "name_space": self.get_namespace(),
             "test_image": tftbase.get_tft_test_image(),
             "image_pull_policy": tftbase.get_tft_image_pull_policy(),
-            "command": "/usr/bin/container-entry-point.sh",
+            "command": ["/usr/bin/container-entry-point.sh"],
             "args": [],
             "index": f"{self.index}",
             "node_name": self.node_name,

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -1,4 +1,3 @@
-import json
 import shlex
 
 from dataclasses import dataclass
@@ -43,10 +42,10 @@ class HttpServer(perf.PerfServer):
 
     def get_template_args(self) -> dict[str, str | list[str]]:
 
-        extra_args: dict[str, str] = {}
+        extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
             extra_args["command"] = "python3"
-            extra_args["args"] = json.dumps(self.cmd_line_args())
+            extra_args["args"] = self.cmd_line_args()
 
         return {
             **super().get_template_args(),

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -33,6 +33,7 @@ test_type_handler_http = TestTypeHandlerHttp()
 class HttpServer(perf.PerfServer):
     def cmd_line_args(self) -> list[str]:
         return [
+            "python3",
             "-m",
             "http.server",
             "-d",
@@ -44,7 +45,6 @@ class HttpServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = ["python3"]
             extra_args["args"] = self.cmd_line_args()
 
         return {
@@ -53,7 +53,7 @@ class HttpServer(perf.PerfServer):
         }
 
     def _create_setup_operation_get_thread_action_cmd(self) -> str:
-        return f"python3 {shlex.join(self.cmd_line_args())}"
+        return shlex.join(self.cmd_line_args())
 
     def _create_setup_operation_get_cancel_action_cmd(self) -> str:
         return "killall python3"

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -44,7 +44,7 @@ class HttpServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = "python3"
+            extra_args["command"] = ["python3"]
             extra_args["args"] = self.cmd_line_args()
 
         return {

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -70,8 +70,7 @@ class IperfServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = [IPERF_EXE]
-            extra_args["args"] = ["-s", "-p", f"{self.port}"]
+            extra_args["args"] = [IPERF_EXE, "-s", "-p", f"{self.port}"]
 
         return {
             **super().get_template_args(),

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -68,10 +68,10 @@ test_type_handler_iperf_udp = TestTypeHandlerIperf(TestType.IPERF_UDP)
 class IperfServer(perf.PerfServer):
     def get_template_args(self) -> dict[str, str | list[str]]:
 
-        extra_args: dict[str, str] = {}
+        extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
             extra_args["command"] = IPERF_EXE
-            extra_args["args"] = f'["-s", "-p", "{self.port}"]'
+            extra_args["args"] = ["-s", "-p", f"{self.port}"]
 
         return {
             **super().get_template_args(),

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -70,7 +70,7 @@ class IperfServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = IPERF_EXE
+            extra_args["command"] = [IPERF_EXE]
             extra_args["args"] = ["-s", "-p", f"{self.port}"]
 
         return {

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -82,8 +82,7 @@ class NetPerfServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = [NETPERF_SERVER_EXE]
-            extra_args["args"] = ["-p", f"{self.port}", "-N"]
+            extra_args["args"] = [NETPERF_SERVER_EXE, "-p", f"{self.port}", "-N"]
 
         return {
             **super().get_template_args(),

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -80,10 +80,10 @@ test_type_handler_netperf_tcp_rr = TestTypeHandlerNetPerf(TestType.NETPERF_TCP_R
 class NetPerfServer(perf.PerfServer):
     def get_template_args(self) -> dict[str, str | list[str]]:
 
-        extra_args: dict[str, str] = {}
+        extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
             extra_args["command"] = NETPERF_SERVER_EXE
-            extra_args["args"] = f'["-p", "{self.port}", "-N"]'
+            extra_args["args"] = ["-p", f"{self.port}", "-N"]
 
         return {
             **super().get_template_args(),

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -82,7 +82,7 @@ class NetPerfServer(perf.PerfServer):
 
         extra_args: dict[str, str | list[str]] = {}
         if self.exec_persistent:
-            extra_args["command"] = NETPERF_SERVER_EXE
+            extra_args["command"] = [NETPERF_SERVER_EXE]
             extra_args["args"] = ["-p", f"{self.port}", "-N"]
 
         return {


### PR DESCRIPTION
- fix "args" jinja2 variable for "persistent" mode.

- make the "{{ command }}" a plain list via `command: {{ command }}` instead of `command: [ "{{ command }}" ]`. The code that generates the template variables is now in full control of specifying a list, instead of something inside a list inside double quotes.

- in "persistent" mode, let tasks only overwrite "args" (CMD) instead of "command" (ENTRYPOINT). That way, they inherit the entrypoint of the Task parent process, which is sensibly set to `/usr/bin/container-entry-point.sh`.