### PR TITLE
[th/jinja2-render-data] common: add common.j2_render_data() and add test

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,7 +1,6 @@
 import abc
 import collections
 import dataclasses
-import jinja2
 import json
 import typing
 
@@ -262,11 +261,18 @@ def dict_get_typed(
     return v
 
 
+def j2_render_data(contents: str, kwargs: dict[str, Any]) -> str:
+    import jinja2
+
+    template = jinja2.Template(contents)
+    rendered = template.render(**kwargs)
+    return rendered
+
+
 def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> str:
     with open(in_file_name) as inFile:
         contents = inFile.read()
-    template = jinja2.Template(contents)
-    rendered = template.render(**kwargs)
+    rendered = j2_render_data(contents, kwargs)
     with open(out_file_name, "w") as outFile:
         outFile.write(rendered)
     return rendered

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,6 +7,7 @@ import sys
 import typing
 
 from enum import Enum
+from typing import Any
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -470,3 +471,18 @@ def test_dataclass_tofrom_dict() -> None:
     assert type(common.dataclass_from_dict(C10, {"x": 1.0}).x) is float
     assert type(c10.x) is int
     assert type(C10(1.0).x) is float
+
+
+def test_j2_render() -> None:
+    def _r(contents: str, **kwargs: Any) -> str:
+        return common.j2_render_data(contents, kwargs)
+
+    assert _r("", a="1") == ""
+    assert _r("val: {{a}}", a=1) == "val: 1"
+    assert _r("val: {{a}}", a="1") == "val: 1"
+    assert _r("val: {{a}}", a="a") == "val: a"
+    assert _r("val: {{a}}", a="a b") == "val: a b"
+    assert _r("val: {{a|tojson}}", a=1) == "val: 1"
+    assert _r("val: {{a|tojson}}", a="1") == 'val: "1"'
+    assert _r("val: {{a|tojson}}", a="a") == 'val: "a"'
+    assert _r("val: {{a|tojson}}", a="a b") == 'val: "a b"'


### PR DESCRIPTION
The behavior of Jinja2 is not obvious. Add a unit test for exposing the behavior.

Also, move the jinja2 import inside the j2_render_data() function, the
only place where it's used. "common.py" generally works with the
standard lib only, and does not depend on additional pip packages.
Having jinja2 there is a bit ugly. Move it, so you can still fully use
common.py without jinja2, except the functions j2_render() and
j2_render_data().