### PR TITLE
[th/python3-in-test-image] install python3.11 venv and basic python sources in test container image

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -49,6 +49,12 @@ RUN /opt/pyvenv3.11/bin/python -m pip install \
         kubernetes \
         pytest
 
+COPY \
+    common.py \
+    host.py \
+    logger.py \
+    /opt/ocp-tft/
+
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 
 COPY ./images/container-entry-point.sh /usr/bin/container-entry-point.sh

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -12,6 +12,7 @@ RUN dnf install -y epel-next-release epel-release
 
 RUN dnf install \
         --allowerasing \
+        /usr/bin/python \
         coreutils \
         cri-tools \
         ethtool \
@@ -29,6 +30,7 @@ RUN dnf install \
         pciutils \
         procps-ng \
         python3 \
+        python3.11 \
         sysstat \
         tcpdump \
         tini \
@@ -36,6 +38,16 @@ RUN dnf install \
         vim \
         wget \
         -y
+
+RUN python3.11 -m venv /opt/pyvenv3.11
+RUN /opt/pyvenv3.11/bin/python -m pip install --upgrade pip
+RUN /opt/pyvenv3.11/bin/python -m pip install \
+        PyYAML==6.0.1 \
+        dataclasses \
+        jc \
+        jinja2 \
+        kubernetes \
+        pytest
 
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 


### PR DESCRIPTION
In   `quay.io/wizhao/tft-tools:latest`:

- install python3.11 and setup a venv in `/usr/opt/pyvenv-3.11` with a few pip package.
- copy some of the base python sources to `/usr/opt/ocp-tft`. Currently, this is not very exciting, it will be more interesting when we have a few python utilities there, that we can run via the container (e.g. via `oc exec`).