### PR TITLE
[th/http-with-duration] http: honor test "duration" for HTTP test

### DIFF
--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -1,9 +1,11 @@
 import json
 import shlex
+import time
 
 from dataclasses import dataclass
 
 import common
+import host
 import perf
 import tftbase
 
@@ -67,13 +69,25 @@ class HttpClient(perf.PerfClient):
 
         def _thread_action() -> BaseOutput:
             self.ts.clmo_barrier.wait()
-            r = self.run_oc_exec(cmd)
+
+            def _check_success(r: host.Result) -> bool:
+                return r.success and r.out == "ocp-traffic-flow-tests\n" and r.err == ""
+
+            sleep_time = 0.2
+            end_timestamp = time.monotonic() + self.get_duration() - sleep_time
+
+            while True:
+                r = self.run_oc_exec(cmd)
+                if not _check_success(r):
+                    break
+                if time.monotonic() >= end_timestamp:
+                    break
+                time.sleep(sleep_time)
+
             self.ts.event_client_finished.set()
 
             return IperfOutput(
-                success=(
-                    r.success and r.out == "ocp-traffic-flow-tests\n" and r.err == ""
-                ),
+                success=_check_success(r),
                 tft_metadata=self.ts.get_test_metadata(),
                 command=cmd,
                 result={


### PR DESCRIPTION
Previously, the test would just fetch the page once and quit (fast). It's not clear how the test duration makes sense for the HTTP test, but I think it makes the most sense to poll the page for the requested duration (with a sleep time of 0.2 seconds).