### PR TITLE
[th/k8sclient-kubeconfig-from-env] k8sClient: use kubeconfig from environment with K8sClient

### DIFF
--- a/k8sClient.py
+++ b/k8sClient.py
@@ -9,7 +9,13 @@ import host
 
 
 class K8sClient:
-    def __init__(self, kubeconfig: str):
+    def __init__(self, kubeconfig: typing.Optional[str] = None):
+        if kubeconfig is None:
+            kubeconfig = os.getenv("KUBECONFIG")
+            if not kubeconfig:
+                raise RuntimeError(
+                    "KUBECONFIG environment variable not set and no kubeconfig argument specified"
+                )
         if not os.path.exists(kubeconfig):
             raise RuntimeError(
                 f"KUBECONFIG={shlex.quote(kubeconfig)} file does not exist"


### PR DESCRIPTION
This is mainly useful for manual testing, when firing up K8sClient in the REPL or with `python -c "import k8sClient; ..."`.

All code in the project, still passes an explicit kubeconfig argument. And in those cases, that is probably a good idea.