### PR TITLE
[th/k8sClient-debug] add K8sClient.oc_{debug,get}() helpers and no longer use crictl from test image

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -4,17 +4,12 @@ RUN dnf install -y 'dnf-command(config-manager)'
 
 RUN dnf config-manager --set-enabled crb
 
-RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/devel:kubic:libcontainers:stable.repo
-
-RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo
-
 RUN dnf install -y epel-next-release epel-release
 
 RUN dnf install \
         --allowerasing \
         /usr/bin/python \
         coreutils \
-        cri-tools \
         ethtool \
         git \
         httpd \

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -1,13 +1,17 @@
+import json
 import kubernetes  # type: ignore
 import logging
 import os
 import shlex
+import sys
 import typing
 import yaml
 
 from collections.abc import Iterable
 
 import host
+
+from logger import logger
 
 
 class K8sClient:
@@ -45,6 +49,25 @@ class K8sClient:
             return shlex.split(cmd)
         return list(cmd)
 
+    def _oc_get_full_cmd(
+        self,
+        *,
+        cmd: str | Iterable[str],
+        namespace: typing.Optional[str] = None,
+    ) -> list[str]:
+        namespace_args: tuple[str, ...]
+        if namespace:
+            namespace_args = ("-n", namespace)
+        else:
+            namespace_args = ()
+        return [
+            "kubectl",
+            "--kubeconfig",
+            self._kc,
+            *namespace_args,
+            *self._oc_get_cmd(cmd),
+        ]
+
     def oc(
         self,
         cmd: str | Iterable[str],
@@ -53,19 +76,8 @@ class K8sClient:
         die_on_error: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> host.Result:
-        namespace_args: tuple[str, ...]
-        if namespace:
-            namespace_args = ("-n", namespace)
-        else:
-            namespace_args = ()
         return host.local.run(
-            [
-                "kubectl",
-                "--kubeconfig",
-                self._kc,
-                *namespace_args,
-                *self._oc_get_cmd(cmd),
-            ],
+            self._oc_get_full_cmd(cmd=cmd, namespace=namespace),
             die_on_error=die_on_error,
             log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
         )
@@ -85,3 +97,43 @@ class K8sClient:
             die_on_error=die_on_error,
             namespace=namespace,
         )
+
+    def oc_get(
+        self,
+        what: str,
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> typing.Optional[dict[str, typing.Any]]:
+        cmd = ["get", what, "-o", "json"]
+        ret = self.oc(
+            cmd,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        if not ret.success:
+            # No need for extra logging in this failure case. self.oc() already
+            # did all the logging we want.
+            return None
+
+        try:
+            data = json.loads(ret.out)
+        except ValueError:
+            data = None
+
+        if not isinstance(data, dict):
+            cmd_s = shlex.join(self._oc_get_full_cmd(cmd=cmd, namespace=namespace))
+            if not may_fail or die_on_error:
+                logger.error(
+                    f"Command {cmd_s} did not return a JSON dictionary but {ret.debug_str()}"
+                )
+            else:
+                logger.debug(f"Command {cmd_s} did not return a JSON dictionary")
+            if die_on_error:
+                sys.exit(-1)
+            return None
+
+        return data

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -5,6 +5,8 @@ import shlex
 import typing
 import yaml
 
+from collections.abc import Iterable
+
 import host
 
 
@@ -37,19 +39,49 @@ class K8sClient:
             for e in self._client.list_node(label_selector=label_selector).items
         ]
 
+    @staticmethod
+    def _oc_get_cmd(cmd: str | Iterable[str]) -> list[str]:
+        if isinstance(cmd, str):
+            return shlex.split(cmd)
+        return list(cmd)
+
     def oc(
         self,
-        cmd: str,
+        cmd: str | Iterable[str],
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> host.Result:
-        namespace_args: tuple[str, ...] = ()
+        namespace_args: tuple[str, ...]
         if namespace:
             namespace_args = ("-n", namespace)
+        else:
+            namespace_args = ()
         return host.local.run(
-            ["kubectl", "--kubeconfig", self._kc, *namespace_args, *shlex.split(cmd)],
+            [
+                "kubectl",
+                "--kubeconfig",
+                self._kc,
+                *namespace_args,
+                *self._oc_get_cmd(cmd),
+            ],
             die_on_error=die_on_error,
             log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
+        )
+
+    def oc_exec(
+        self,
+        cmd: str | Iterable[str],
+        *,
+        pod_name: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> host.Result:
+        return self.oc(
+            ["exec", pod_name, "--", *self._oc_get_cmd(cmd)],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
         )

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import typing
 
 from typing import Optional
@@ -170,8 +171,9 @@ class TaskValidateOffload(PluginTask):
         self.render_file("Server Pod Yaml")
 
     def extract_vf_rep(self) -> Optional[str]:
-        r = self.run_oc_exec(
-            f"crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json"
+
+        r = self.run_oc_debug(
+            f"/host/usr/bin/crictl '--runtime-endpoint=unix:///host/run/crio/crio.sock' ps -a --name={shlex.quote(self.perf_pod_name)} -o json",
         )
 
         iface: Optional[str] = None

--- a/task.py
+++ b/task.py
@@ -335,11 +335,14 @@ class Task(ABC):
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
+        pod_name: Optional[str] = None,
         namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
     ) -> host.Result:
+        if pod_name is None:
+            pod_name = self.pod_name
         return self.client.oc_exec(
             cmd,
-            pod_name=self.pod_name,
+            pod_name=pod_name,
             may_fail=may_fail,
             die_on_error=die_on_error,
             namespace=self._run_oc_namespace(namespace),

--- a/task.py
+++ b/task.py
@@ -348,6 +348,21 @@ class Task(ABC):
             namespace=self._run_oc_namespace(namespace),
         )
 
+    def run_oc_get(
+        self,
+        what: str,
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
+    ) -> typing.Optional[dict[str, typing.Any]]:
+        return self.client.oc_get(
+            what,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=self._run_oc_namespace(namespace),
+        )
+
     def get_pod_ip(self) -> str:
         r = self.run_oc(f"get pod {self.pod_name} -o yaml", die_on_error=True)
         y = yaml.safe_load(r.out)

--- a/task.py
+++ b/task.py
@@ -2,7 +2,6 @@ import enum
 import json
 import logging
 import os
-import shlex
 import sys
 import threading
 import typing
@@ -21,11 +20,12 @@ import common
 import host
 import tftbase
 
+from k8sClient import K8sClient
 from logger import logger
-from testSettings import TestSettings
-from tftbase import ClusterMode
-from tftbase import BaseOutput
 from pluginbase import Plugin
+from testSettings import TestSettings
+from tftbase import BaseOutput
+from tftbase import ClusterMode
 
 
 T = TypeVar("T")
@@ -300,23 +300,33 @@ class Task(ABC):
     def initialize(self) -> None:
         pass
 
+    @property
+    def client(self) -> K8sClient:
+        return self.tc.client(tenant=self.tenant)
+
+    def _run_oc_namespace(
+        self,
+        namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
+    ) -> Optional[str]:
+        if isinstance(namespace, common._MISSING_TYPE):
+            # By default, set use self.get_namespace(). You can select another
+            # namespace or no namespace (by setting to None).
+            namespace = self.get_namespace()
+        return namespace
+
     def run_oc(
         self,
-        cmd: str,
+        cmd: str | Iterable[str],
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
         namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
     ) -> host.Result:
-        if isinstance(namespace, common._MISSING_TYPE):
-            # By default, set use self.get_namespace(). You can select another
-            # namespace or no namespace (by setting to None).
-            namespace = self.get_namespace()
-        return self.tc.client(tenant=self.tenant).oc(
+        return self.client.oc(
             cmd,
             may_fail=may_fail,
             die_on_error=die_on_error,
-            namespace=namespace,
+            namespace=self._run_oc_namespace(namespace),
         )
 
     def run_oc_exec(
@@ -327,15 +337,12 @@ class Task(ABC):
         die_on_error: bool = False,
         namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
     ) -> host.Result:
-        if isinstance(cmd, str):
-            argv = shlex.split(cmd)
-        else:
-            argv = list(cmd)
-        return self.run_oc(
-            f"exec {shlex.quote(self.pod_name)} -- {shlex.join(argv)}",
+        return self.client.oc_exec(
+            cmd,
+            pod_name=self.pod_name,
             may_fail=may_fail,
             die_on_error=die_on_error,
-            namespace=namespace,
+            namespace=self._run_oc_namespace(namespace),
         )
 
     def get_pod_ip(self) -> str:

--- a/task.py
+++ b/task.py
@@ -363,6 +363,31 @@ class Task(ABC):
             namespace=self._run_oc_namespace(namespace),
         )
 
+    def run_oc_debug(
+        self,
+        cmd: str | Iterable[str],
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        node_name: Optional[str] = None,
+        test_image: Optional[str] = None,
+        namespace: Optional[str] = None,
+    ) -> host.Result:
+        if node_name is None:
+            node_name = self.node_name
+        if test_image is None:
+            test_image = tftbase.get_tft_test_image()
+        if namespace is None:
+            namespace = self.get_namespace()
+        return self.client.oc_debug(
+            cmd,
+            node_name=node_name,
+            test_image=test_image,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
     def get_pod_ip(self) -> str:
         r = self.run_oc(f"get pod {self.pod_name} -o yaml", die_on_error=True)
         y = yaml.safe_load(r.out)


### PR DESCRIPTION
- add helpers

   - `K8sClient.oc_debug()` + `K8sClient.oc_get()` (which wrap `kubectl debug|get` via `K8sClient.oc()`)
   - `Task.run_oc_debug()` + `Task.run_oc_get()`

- `kubectl debug` is more cumbersome to use than `oc debug`. But those issues are mostly worked around.

- no longer use and install `crictl` (`cri-tools` package) in the test image at   `quay.io/wizhao/tft-tools:latest`. Instead, use the crictl tool from the worker node (and do so via `Task.run_oc_debug()`). 

  - to install `crictl` in `quay.io/wizhao/tft-tools:latest` we had to enable an openSUSE repository (which yesterday was 503 Service Unavailable, it's back again).
  - the test container image targets different Openshift/Kubernetes version. While it probably works, it's not clear that installing some `crictl` version will work on the different versions that run on the node. What would be better, is to use the `crictl` version that is installed on the node, that we want to interact with.