### PR TITLE
[th/fix-print-results] print_results: fix the script after changing the output format

### DIFF
--- a/print_results.sh
+++ b/print_results.sh
@@ -3,7 +3,7 @@
 # Helper script to print results in consice human-friendly way. Return an error code in the event any failure is detected.
 
 print_details() {
-    jq '. | "Test ID: \(.test_id), Test Type: \(.test_type), Reverse: \(.reverse), TX Bitrate: \(.bitrate_gbps.tx) Gbps, RX Bitrate: \(.bitrate_gbps.rx) Gbps"'
+    jq '. | "Test ID: \(.tft_metadata.test_case_id), Test Type: \(.tft_metadata.test_type), Reverse: \(.tft_metadata.reverse), TX Bitrate: \(.bitrate_gbps.tx) Gbps, RX Bitrate: \(.bitrate_gbps.rx) Gbps"'
 }
 
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
We discussed, and there is the choice that the output format of the tool does not need to be stable. That is, it is not guaranteed that you can parse outputs of a different version of the tool.

Consequently, the output was changed. However, it missed to update print_results.sh for those changes. Fix it.

Fixes: 1b574558c51c ('evaluator: record TestMetadata in TestResult')

CC: @SalDaniele 