### PR TITLE
[th/logger-msec] logger: log milliseconds in test output

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -8,7 +8,7 @@ def configure_logger(lvl: int) -> None:
     global logger
     logger.setLevel(lvl)
 
-    fmt = "%(asctime)s %(levelname)-7s [th:%(thread)s]: %(message)s"
+    fmt = "%(asctime)s.%(msecs)03d %(levelname)-7s [th:%(thread)s]: %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(fmt, datefmt)
 


### PR DESCRIPTION
For debugging a test, it's important to see how long a command took. Whole seconds granularity is insufficient. Also show the milliseconds part.