### PR TITLE
[th/crictl-from-node] don't install crictl/cri-tools in test image and use the one from the node (chroot /host)

### DIFF
--- a/images/Containerfile
+++ b/images/Containerfile
@@ -4,17 +4,12 @@ RUN dnf install -y 'dnf-command(config-manager)'
 
 RUN dnf config-manager --set-enabled crb
 
-RUN curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/devel:kubic:libcontainers:stable.repo
-
-RUN curl -L -o /etc/yum.repos.d/benchmark:openSUSE_Factory.repo https://download.opensuse.org/repositories/benchmark/openSUSE_Factory/benchmark.repo
-
 RUN dnf install -y epel-next-release epel-release
 
 RUN dnf install \
         --allowerasing \
         /usr/bin/python \
         coreutils \
-        cri-tools \
         ethtool \
         git \
         httpd \

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import typing
 
 from typing import Optional
@@ -170,8 +171,9 @@ class TaskValidateOffload(PluginTask):
         self.render_file("Server Pod Yaml")
 
     def extract_vf_rep(self) -> Optional[str]:
+
         r = self.run_oc_exec(
-            f"crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ps -a --name={self.perf_pod_name} -o json"
+            f"chroot /host crictl ps -a --name={shlex.quote(self.perf_pod_name)} -o json",
         )
 
         iface: Optional[str] = None


### PR DESCRIPTION
This replaces parts of https://github.com/wizhaoredhat/ocp-traffic-flow-tests/pull/105

See https://github.com/wizhaoredhat/ocp-traffic-flow-tests/pull/105#issuecomment-2250160362