### PR TITLE
[th/netdev-utils] add "netdev.py" with utilities for reading sysfs and getting information from iproute2/ethtool

### DIFF
--- a/common.py
+++ b/common.py
@@ -109,6 +109,12 @@ def iter_get_first(
     return v0
 
 
+def iter_filter_none(lst: typing.Iterable[Optional[T]]) -> typing.Iterable[T]:
+    for v in lst:
+        if v is not None:
+            yield v
+
+
 def enum_convert(
     enum_type: Type[E],
     value: Any,

--- a/common.py
+++ b/common.py
@@ -245,6 +245,11 @@ def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
     return output
 
 
+def dict_add_optional(vdict: dict[T1, T2], key: T1, val: Optional[T2]) -> None:
+    if val is not None:
+        vdict[key] = val
+
+
 @typing.overload
 def dict_get_typed(
     d: typing.Mapping[Any, Any],

--- a/common.py
+++ b/common.py
@@ -245,6 +245,22 @@ def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
     return output
 
 
+def json_parse_list(jstr: str, *, strict_parsing: bool = False) -> list[Any]:
+    try:
+        lst = json.loads(jstr)
+    except ValueError:
+        if strict_parsing:
+            raise
+        return []
+
+    if not isinstance(lst, list):
+        if strict_parsing:
+            raise ValueError("JSON data does not contain a list")
+        return []
+
+    return lst
+
+
 def dict_add_optional(vdict: dict[T1, T2], key: T1, val: Optional[T2]) -> None:
     if val is not None:
         vdict[key] = val

--- a/common.py
+++ b/common.py
@@ -88,6 +88,27 @@ def str_to_bool(
     raise ValueError(f"Value {val} is not a boolean")
 
 
+def iter_get_first(
+    lst: typing.Iterable[T],
+    *,
+    unique: bool = False,
+    force_unique: bool = False,
+) -> Optional[T]:
+    v0: Optional[T] = None
+    for idx, v in enumerate(lst):
+        if idx == 0:
+            v0 = v
+            continue
+        if force_unique:
+            raise RuntimeError("Iterable was expected to only contain one entry")
+        if unique:
+            # We have more than one entries. The caller requested to reject
+            # that.
+            return None
+        return v0
+    return v0
+
+
 def enum_convert(
     enum_type: Type[E],
     value: Any,

--- a/common.py
+++ b/common.py
@@ -20,6 +20,13 @@ if typing.TYPE_CHECKING:
     from _typeshed import DataclassInstance
 
 
+E = TypeVar("E", bound=Enum)
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+TCallable = typing.TypeVar("TCallable", bound=typing.Callable[..., typing.Any])
+
+
 # This is used as default value for some arguments, to recognize that the
 # caller didn't specify the argument. This is useful, when we want to
 # explicitly distinguish between having an argument unset or set to any value.
@@ -40,10 +47,6 @@ def bool_to_str(val: bool, *, format: str = "true") -> str:
     if format == "yes":
         return "yes" if val else "no"
     raise ValueError(f'Invalid format "{format}"')
-
-
-T1 = TypeVar("T1")
-T2 = TypeVar("T2")
 
 
 def str_to_bool(
@@ -83,9 +86,6 @@ def str_to_bool(
         return on_error
 
     raise ValueError(f"Value {val} is not a boolean")
-
-
-E = TypeVar("E", bound=Enum)
 
 
 def enum_convert(
@@ -216,9 +216,6 @@ def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
         raise ValueError(f"Invalid {enum_type} value of type {type(value)}")
 
     return output
-
-
-T = TypeVar("T")
 
 
 @typing.overload
@@ -465,9 +462,6 @@ def dataclass_check(
         _post_check = getattr(type(instance), "_post_check", None)
         if _post_check is not None:
             _post_check(instance)
-
-
-TCallable = typing.TypeVar("TCallable", bound=typing.Callable[..., typing.Any])
 
 
 def strict_dataclass(cls: TCallable) -> TCallable:

--- a/host.py
+++ b/host.py
@@ -296,3 +296,9 @@ class LocalHost(Host):
 
 
 local = LocalHost()
+
+
+def host_or_local(host: Optional[Host]) -> Host:
+    if host is None:
+        return local
+    return host

--- a/images/Containerfile
+++ b/images/Containerfile
@@ -43,12 +43,16 @@ RUN /opt/pyvenv3.11/bin/python -m pip install \
         jinja2 \
         kubernetes \
         pytest
+RUN ln -s /opt/pyvenv3.11/bin/python /usr/bin/python-pyvenv3.11
 
 COPY \
     common.py \
     host.py \
     logger.py \
+    netdev.py \
     /opt/ocp-tft/
+
+RUN echo -e "#!/bin/bash\nexec /opt/pyvenv3.11/bin/python /opt/ocp-tft/netdev.py \"\$@\"" > /usr/bin/ocp-tft-netdev && chmod +x /usr/bin/ocp-tft-netdev
 
 RUN mkdir -p /etc/ocp-traffic-flow-tests && echo "ocp-traffic-flow-tests" > /etc/ocp-traffic-flow-tests/data
 

--- a/netdev.py
+++ b/netdev.py
@@ -1,0 +1,215 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import host
+import common
+
+from common import strict_dataclass
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class IPRouteAddressInfoEntry:
+    family: str
+    local: str
+
+    def _post_check(self) -> None:
+        if not isinstance(self.family, str) or self.family not in ("inet", "inet6"):
+            raise ValueError("Invalid address family")
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class IPRouteAddressEntry:
+    ifindex: int
+    ifname: str
+    flags: tuple[str, ...]
+    master: Optional[str]
+    address: str  # Ethernet address.
+    addr_info: tuple[IPRouteAddressInfoEntry, ...]
+
+    def has_carrier(self) -> bool:
+        return "NO-CARRIER" not in self.flags
+
+
+def ip_addrs_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+) -> list[IPRouteAddressEntry]:
+    ret: list[IPRouteAddressEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteAddressEntry(
+                ifindex=e["ifindex"],
+                ifname=e["ifname"],
+                flags=tuple(e["flags"]),
+                master=e["master"] if "master" in e else None,
+                address=e["address"],
+                addr_info=tuple(
+                    IPRouteAddressInfoEntry(
+                        family=addr["family"],
+                        local=addr["local"],
+                    )
+                    for addr in e["addr_info"]
+                ),
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_addrs(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteAddressEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json addr",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_addrs_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class IPRouteLinkEntry:
+    ifindex: int
+    ifname: str
+    flags: tuple[str, ...]
+    mtu: int
+    operstate: str
+    link_info_kind: Optional[str]
+
+
+def ip_links_parse(
+    jstr: str, *, strict_parsing: bool = False, ifname: Optional[str] = None
+) -> list[IPRouteLinkEntry]:
+    ret: list[IPRouteLinkEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+
+            link_info_kind: Optional[str] = None
+            link_info = e.get("linkinfo")
+            if link_info is not None:
+                link_info_kind = link_info.get("info_kind")
+
+            entry = IPRouteLinkEntry(
+                ifindex=e["ifindex"],
+                ifname=e["ifname"],
+                mtu=int(e["mtu"]),
+                flags=tuple(e["flags"]),
+                operstate=(e["operstate"]),
+                link_info_kind=link_info_kind,
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_links(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteLinkEntry]:
+    # If @ifname is requested, we could issue a `ip -json link show $IFNAME`. However,
+    # that means we do different things for requesting one link vs. all links. That
+    # seems undesirable. Instead, in all cases fetch all links. Any filtering then happens
+    # in code that we control. Performance should not make a difference, since the JSON data
+    # is probably small anyway (compared to the overhead of invoking a shell command).
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json -d link",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-link on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_links_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class IPRouteRouteEntry:
+    dst: str
+    dev: str
+
+
+def ip_routes_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+) -> list[IPRouteRouteEntry]:
+    ret: list[IPRouteRouteEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteRouteEntry(
+                dst=e["dst"],
+                dev=e["dev"],
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        ret.append(entry)
+    return ret
+
+
+def ip_routes(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> list[IPRouteRouteEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json route",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_routes_parse(ret.out, strict_parsing=strict_parsing)
+
+
+def normalize_ifname(ifname: str | bytes) -> bytes:
+    if isinstance(ifname, str):
+        ifname = ifname.encode("utf-8", errors="surrogateescape")
+    elif not isinstance(ifname, bytes):
+        raise TypeError(f"Unexpected ifname of type {type(ifname)}")
+    return ifname

--- a/netdev.py
+++ b/netdev.py
@@ -1,10 +1,142 @@
+import json
+import os
+import re
+
+from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Any
 from typing import Optional
 
 import host
 import common
 
 from common import strict_dataclass
+from common import dict_add_optional
+
+
+def _parse_line(line: str, caption: str) -> Optional[str]:
+    if line.startswith(caption):
+        return line[len(caption) :]
+    return None
+
+
+_isspace_kernel_set = {c[0] for c in (b" ", b"\n", b"\t", b"\r", b"\f", b"\v", b"\240")}
+
+
+def isspace_kernel(c: int | bytes) -> bool:
+    # mirrors kernel's isspace() from "include/linux/ctype.h", which treats as
+    # space the common ASCII spaces, including '\v' (vertical tab), but also
+    # '\240' (non-breaking space, NBSP in Latin-1). */
+    if isinstance(c, int):
+        if c < 0 or c > 255:
+            raise ValueError("Integer is not a valid byte")
+    elif isinstance(c, bytes):
+        if len(c) != 1:
+            raise ValueError("Requires a single byte as argument")
+        c = c[0]
+    else:
+        raise TypeError("Expects either an integer or a single byte")
+
+    return c in _isspace_kernel_set
+
+
+def normalize_ifname(ifname: str | bytes, *, validate: bool = False) -> bytes:
+    if isinstance(ifname, str):
+        ifname = ifname.encode("utf-8", errors="surrogateescape")
+    elif not isinstance(ifname, bytes):
+        raise TypeError(f"Unexpected ifname of type {type(ifname)}")
+
+    if validate:
+        if not ifname:
+            raise ValueError("Ifname cannot be empty")
+        if b"/" in ifname:
+            raise ValueError("Ifname cannot contain slash")
+        if ifname in (b".", b".."):
+            raise ValueError(f'Ifname cannot be "{ifname.decode()}"')
+        if len(ifname) > 15:
+            raise ValueError("Ifname cannot be longer than 15 characters")
+        if b":" in ifname:
+            raise ValueError("Ifname cannot contain colon")
+        for c in ifname:
+            if c == 0:
+                raise ValueError("Invalid zero bytes")
+            if isspace_kernel(c):
+                raise ValueError("Invalid white space")
+
+    return ifname
+
+
+def validate_ifname(ifname: str | bytes) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    #
+    # See also, dev_valid_name() in kernel.
+    ifname = normalize_ifname(ifname, validate=True)
+    return ifname.decode(errors="surrogateescape")
+
+
+def validate_ifname_or_none(ifname: str | bytes) -> Optional[str]:
+    try:
+        return validate_ifname(ifname)
+    except ValueError:
+        return None
+
+
+_pciaddr_re = re.compile("^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]$")
+
+
+def validate_pciaddr(pciaddr: str | bytes) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(pciaddr, bytes):
+        try:
+            pciaddr = pciaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"PCI address cannot contain non UTF-8 characters ({repr(pciaddr)})"
+            )
+    elif not isinstance(pciaddr, str):
+        raise TypeError(f"PCI address of unexpected type {type(pciaddr)}")
+    if not pciaddr:
+        raise ValueError("PCI address cannot be empty")
+    if not _pciaddr_re.search(pciaddr):
+        raise ValueError(f"PCI address contains invalid characters ({repr(pciaddr)})")
+    if pciaddr in (".", ".."):
+        raise ValueError(f'PCI address cannot be "{pciaddr}"')
+    return pciaddr
+
+
+_ethaddr_re = re.compile("^[0-9a-fA-F:]+$")
+
+
+def validate_ethaddr(ethaddr: str | bytes) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(ethaddr, bytes):
+        try:
+            ethaddr = ethaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"Ethernet address cannot contain non UTF-8 characters ({repr(ethaddr)})"
+            )
+    elif not isinstance(ethaddr, str):
+        raise TypeError(f"Ethernet address of unexpected type {type(ethaddr)}")
+    if not _ethaddr_re.search(ethaddr):
+        raise ValueError(
+            f"Ethernet address contains invalid characters ({repr(ethaddr)})"
+        )
+    return ethaddr.lower()
+
+
+def pciaddr_get_func_address(pciaddr: Optional[str | bytes]) -> Optional[int]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/master/sriovnet_switchdev.go#L172
+    if pciaddr is None:
+        return None
+
+    pciaddr = validate_pciaddr(pciaddr)
+
+    last_char = pciaddr[-1]
+    return int(last_char)
 
 
 @strict_dataclass
@@ -43,7 +175,7 @@ def ip_addrs_parse(
         try:
             entry = IPRouteAddressEntry(
                 ifindex=e["ifindex"],
-                ifname=e["ifname"],
+                ifname=validate_ifname(e["ifname"]),
                 flags=tuple(e["flags"]),
                 master=e["master"] if "master" in e else None,
                 address=e["address"],
@@ -94,10 +226,17 @@ def ip_addrs(
 class IPRouteLinkEntry:
     ifindex: int
     ifname: str
+    address: Optional[str]
+    permaddr: Optional[str]
     flags: tuple[str, ...]
     mtu: int
     operstate: str
     link_info_kind: Optional[str]
+
+    def match_ifname(self, ifname: Optional[str | bytes]) -> bool:
+        if ifname is None:
+            return False
+        return normalize_ifname(self.ifname) == normalize_ifname(ifname)
 
 
 def ip_links_parse(
@@ -112,13 +251,23 @@ def ip_links_parse(
             if link_info is not None:
                 link_info_kind = link_info.get("info_kind")
 
+            address = e.get("address")
+            if address is not None:
+                address = validate_ethaddr(address)
+
+            permaddr = e.get("permaddr")
+            if permaddr is not None:
+                permaddr = validate_ethaddr(permaddr)
+
             entry = IPRouteLinkEntry(
                 ifindex=e["ifindex"],
-                ifname=e["ifname"],
+                ifname=validate_ifname(e["ifname"]),
                 mtu=int(e["mtu"]),
                 flags=tuple(e["flags"]),
                 operstate=(e["operstate"]),
                 link_info_kind=link_info_kind,
+                address=address,
+                permaddr=permaddr,
             )
         except (KeyError, ValueError, TypeError):
             if strict_parsing:
@@ -176,7 +325,7 @@ def ip_routes_parse(
         try:
             entry = IPRouteRouteEntry(
                 dst=e["dst"],
-                dev=e["dev"],
+                dev=validate_ifname(e["dev"]),
             )
         except (KeyError, ValueError, TypeError):
             if strict_parsing:
@@ -207,9 +356,591 @@ def ip_routes(
     return ip_routes_parse(ret.out, strict_parsing=strict_parsing)
 
 
-def normalize_ifname(ifname: str | bytes) -> bytes:
-    if isinstance(ifname, str):
-        ifname = ifname.encode("utf-8", errors="surrogateescape")
-    elif not isinstance(ifname, bytes):
-        raise TypeError(f"Unexpected ifname of type {type(ifname)}")
-    return ifname
+def ethtool_permaddr(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: str | bytes,
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-P", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -P {repr(ifname)} failed ({ret})")
+        return None
+
+    permaddr: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "Permanent address: ")) is not None:
+            permaddr = x
+
+    if permaddr is None:
+        return None
+
+    try:
+        return validate_ethaddr(permaddr)
+    except Exception:
+        return None
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class EthtoolDriverInfo:
+    ifname: str
+    driver: Optional[str]
+    version: Optional[str]
+    firmware_version: Optional[str]
+
+
+def ethtool_driver(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: str | bytes,
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[EthtoolDriverInfo]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-i", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -i {repr(ifname)} failed ({ret})")
+        return None
+
+    driver: Optional[str] = None
+    version: Optional[str] = None
+    firmware_version: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "driver: ")) is not None:
+            driver = x
+        elif (x := _parse_line(line, "version: ")) is not None:
+            version = x
+        elif (x := _parse_line(line, "firmware-version: ")) is not None:
+            firmware_version = x
+
+    return EthtoolDriverInfo(
+        ifname=ifname,
+        driver=driver,
+        version=version,
+        firmware_version=firmware_version,
+    )
+
+
+def _sysctl_parse_str(s: Optional[str | bytes]) -> Optional[str]:
+    if s is None:
+        return None
+
+    if isinstance(s, bytes):
+        try:
+            s = s.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return None
+
+    if not isinstance(s, str):
+        return None
+
+    return s.strip()
+
+
+def sysctl_read(
+    path: str | bytes,
+    *,
+    strip: bool = True,
+    fail_on_error: bool = False,
+) -> Optional[str]:
+
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except Exception:
+        if fail_on_error:
+            raise
+        return None
+
+    # We always return a `str`, but invalid characters are escaped
+    # via "surrogateescape". Depending on what you need to do, you
+    # may need to consider that.
+    s = data.decode("utf-8", errors="surrogateescape")
+    if strip:
+        s = s.strip()
+    return s
+
+
+def sysctl_phys_port_name_parse(s: Optional[str | bytes]) -> Optional[tuple[int, int]]:
+    # Parses the output of /sys/class/net/$IFNAME/phys_port_name
+    #
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L84C6-L84C19
+
+    s = _sysctl_parse_str(s)
+    if s is None:
+        return None
+
+    m = re.search("^(c[0-9]+)?pf([0-9]+)vf([0-9]+)$", s)
+    if m:
+        try:
+            return (int(m.group(2)), int(m.group(3)))
+        except Exception:
+            pass
+
+    # old kernel syntax of phys_port_name is vf index
+    m = re.search("^[0-9]+$", s)
+    if m:
+        try:
+            return (0, int(m.group()))
+        except Exception:
+            pass
+
+    return None
+
+
+def get_phys_port_name(ifname: str | bytes) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_port_name")
+
+
+def get_phys_switch_id(ifname: str | bytes) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_switch_id")
+
+
+def get_ifnames() -> list[str]:
+    try:
+        ifs1 = os.listdir(b"/sys/class/net/")
+    except Exception:
+        return []
+    return sorted(common.iter_filter_none(validate_ifname(i) for i in ifs1))
+
+
+def get_pciaddrs() -> list[str]:
+    path = "/sys/bus/pci/devices/"
+    pcis = os.listdir(path)
+    pcis = [validate_pciaddr(p) for p in pcis if os.path.exists(path + p + "/net/")]
+    pcis2 = {k: None for k in pcis}
+    return list(pcis2)
+
+
+def _get_pciaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        pciaddr = path[i + 1 :]
+    else:
+        pciaddr = path
+    try:
+        return validate_pciaddr(pciaddr)
+    except Exception:
+        return None
+
+
+def _get_usbaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        usbaddr = path[i + 1 :]
+    else:
+        usbaddr = path
+    if not re.search("^[-0-9a-f.:]+$", usbaddr):
+        return None
+    return usbaddr
+
+
+def get_busaddr_from_ifname(ifname: str | bytes) -> Optional[tuple[str, str]]:
+    ifname = validate_ifname(ifname)
+    try:
+        path = os.readlink(f"/sys/class/net/{ifname}/device")
+    except Exception:
+        return None
+
+    pciaddr = _get_pciaddr_from_path(path)
+    if pciaddr is not None and os.path.exists(f"/sys/bus/pci/devices/{pciaddr}"):
+        return ("pci", pciaddr)
+
+    usbaddr = _get_usbaddr_from_path(path)
+    if usbaddr is not None and os.path.exists(f"/sys/bus/usb/devices/{usbaddr}"):
+        return ("usb", usbaddr)
+
+    return None
+
+
+def get_pciaddr_from_ifname(ifname: str | bytes) -> Optional[str]:
+    busaddr = get_busaddr_from_ifname(ifname)
+    if busaddr is None:
+        return None
+    bustype, busaddress = busaddr
+    if bustype != "pci":
+        return None
+    return busaddress
+
+
+def _get_ifnames_from_dir(dirname: str) -> Optional[list[str]]:
+    try:
+        devices = os.listdir(dirname)
+    except Exception:
+        return None
+    return sorted(common.iter_filter_none(validate_ifname_or_none(d) for d in devices))
+
+
+def get_ifnames_from_pciaddr(pciaddr: str) -> Optional[list[str]]:
+    return _get_ifnames_from_dir(
+        f"/sys/bus/pci/devices/{validate_pciaddr(pciaddr)}/net/"
+    )
+
+
+def get_ifindex_from_ifname(ifname: str | bytes) -> Optional[int]:
+    ifname = validate_ifname(ifname)
+    try:
+        v = sysctl_read(f"/sys/class/net/{ifname}/ifindex")
+    except Exception:
+        pass
+    else:
+        if v:
+            try:
+                return int(v)
+            except Exception:
+                pass
+    return None
+
+
+def get_address_from_ifname(ifname: str | bytes) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    try:
+        data = sysctl_read(f"/sys/class/net/{ifname}/address")
+        if data:
+            return validate_ethaddr(data)
+    except Exception:
+        pass
+    return None
+
+
+def is_switchdev(ifname: str | bytes) -> bool:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L102
+    return bool(get_phys_switch_id(ifname))
+
+
+def get_uplink_representor(pciaddr: str) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L116
+    pciaddr = validate_pciaddr(pciaddr)
+
+    devicePath = f"/sys/bus/pci/devices/{pciaddr}/physfn/net"
+    if not os.path.exists(devicePath):
+        devicePath = f"/sys/bus/pci/devices/{pciaddr}/net"
+        if not os.path.exists(devicePath):
+            return None
+
+    devices = _get_ifnames_from_dir(devicePath)
+    for device in devices or ():
+        if not is_switchdev(device):
+            continue
+        # Try to get the phys port name, if not exists then fallback to check without it
+        # phys_port_name should be in formant p<port-num> e.g p0,p1,p2 ...etc.
+        port_name = get_phys_port_name(device)
+        if port_name is not None:
+            if not re.search("^p[0-9]+$", port_name):
+                continue
+        return device
+
+    return None
+
+
+def get_vf_representor(uplink_ifname: str | bytes, vf_index: int) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L143
+    uplink_ifname = validate_ifname(uplink_ifname)
+
+    phys_switch_id = get_phys_switch_id(uplink_ifname)
+    if phys_switch_id is None:
+        return None
+
+    uplink_pciaddr = get_pciaddr_from_ifname(uplink_ifname)
+    uplink_pci_func_address = pciaddr_get_func_address(uplink_pciaddr)
+
+    devices = _get_ifnames_from_dir(f"/sys/class/net/{uplink_ifname}/subsystem")
+    for device in devices or ():
+        device_switch_id = get_phys_switch_id(device)
+        if device_switch_id != phys_switch_id:
+            continue
+        port_name = sysctl_phys_port_name_parse(get_phys_port_name(device))
+        if port_name is None:
+            continue
+        if port_name[0] != uplink_pci_func_address:
+            continue
+        if port_name[1] != vf_index:
+            continue
+
+        return device
+
+    return None
+
+
+def get_vfs_for_representor(uplink_pciaddr: str) -> list[tuple[str, int]]:
+    uplink_pciaddr = validate_pciaddr(uplink_pciaddr)
+
+    path = f"/sys/bus/pci/devices/{uplink_pciaddr}"
+
+    try:
+        files = os.listdir(path)
+    except Exception:
+        return []
+
+    result: list[tuple[str, int]] = []
+
+    regex = re.compile("^virtfn(\\d+)$")
+
+    for file in files:
+        m = regex.search(file)
+        if not m:
+            continue
+
+        try:
+            vf_index = int(m.group(1))
+        except Exception:
+            continue
+
+        try:
+            data = os.readlink(f"{path}/{file}")
+        except Exception:
+            continue
+        pciaddr = _get_pciaddr_from_path(data)
+
+        if pciaddr is None:
+            continue
+
+        result.append((pciaddr, vf_index))
+
+    return result
+
+
+@common.repeat_for_same_result
+def get_device_infos(with_ethtool: bool = True) -> list[dict[str, Any]]:
+
+    result = []
+
+    devices: set[tuple[Optional[str], Optional[str]]] = set()
+
+    link_infos: dict[str, Optional[IPRouteLinkEntry]]
+    link_infos = {ifname: None for ifname in get_ifnames()}
+    link_infos.update((lnk.ifname, lnk) for lnk in ip_links())
+
+    ifnames_tmp = set(link_infos)
+    for pciaddr1 in get_pciaddrs():
+        ifnames1 = get_ifnames_from_pciaddr(pciaddr1)
+        if ifnames1:
+            for ifname1 in ifnames1:
+                devices.add((pciaddr1, ifname1))
+                ifnames_tmp.discard(ifname1)
+        else:
+            devices.add((pciaddr1, None))
+    for ifname1 in ifnames_tmp:
+        devices.add((None, ifname1))
+
+    for device in devices:
+        res: dict[str, Any] = {}
+
+        pciaddr, ifname = device
+
+        if ifname is not None:
+            link_info = link_infos.get(ifname)
+            if link_info is not None:
+                res["ifindex"] = link_info.ifindex
+            else:
+                dict_add_optional(res, "ifindex", get_ifindex_from_ifname(ifname))
+        else:
+            link_info = None
+
+        if ifname is not None:
+            res["ifname"] = ifname
+
+        if pciaddr is not None:
+            res["pciaddr"] = pciaddr
+        elif ifname is not None:
+            busaddr = get_busaddr_from_ifname(ifname)
+            if busaddr is not None:
+                bustype, busaddress = busaddr
+                if bustype == "usb":
+                    res["usbaddr"] = busaddress
+
+        if ifname is not None:
+            link_dict: dict[str, Any] = {}
+
+            if link_info is not None:
+                li_dict = common.dataclass_to_dict(link_info)
+                del li_dict["ifindex"]
+                del li_dict["ifname"]
+            else:
+                li_dict = {}
+
+            li_address = li_dict.get("address")
+            if li_address is None:
+                li_address = get_address_from_ifname(ifname)
+
+            li_permaddr = li_dict.get("permaddr")
+            if li_permaddr is None:
+                li_permaddr = ethtool_permaddr(ifname=ifname)
+
+            dict_add_optional(link_dict, "address", li_address)
+            dict_add_optional(link_dict, "permaddr", li_permaddr)
+
+            if link_info is not None:
+                del li_dict["address"]
+                del li_dict["permaddr"]
+                if li_dict.get("link_info_kind", 1) is None:
+                    del li_dict["link_info_kind"]
+                link_dict.update(li_dict)
+
+            res["link"] = link_dict
+
+        if ifname is not None:
+            dict_add_optional(res, "phys_port_name", get_phys_port_name(ifname))
+            dict_add_optional(res, "phys_switch_id", get_phys_switch_id(ifname))
+
+        if pciaddr is not None:
+            dict_add_optional(res, "uplink_rep_ifname", get_uplink_representor(pciaddr))
+
+        if with_ethtool:
+            if ifname is not None:
+                ethdata = ethtool_driver(ifname=ifname)
+                if ethdata is not None:
+                    d3 = common.dataclass_to_dict(ethdata)
+                    del d3["ifname"]
+                    res["ethtool"] = d3
+
+        result.append(res)
+
+    uplink_reps: list[str] = sorted(
+        common.iter_filter_none(x1.get("uplink_rep_ifname") for x1 in result)
+    )
+
+    for uplink_rep_ifname in uplink_reps:
+        uplink_rep_pciaddr = get_pciaddr_from_ifname(uplink_rep_ifname)
+        if uplink_rep_pciaddr is None:
+            continue
+        vf_infos = get_vfs_for_representor(uplink_rep_pciaddr)
+        for vf_info in vf_infos:
+            vf_pciaddr, vf_index = vf_info
+
+            inf_vf = common.iter_get_first(
+                r for r in result if r.get("pciaddr") == vf_pciaddr
+            )
+
+            vf_rep = get_vf_representor(uplink_rep_ifname, vf_index)
+            if vf_rep is not None:
+                inf_vf_rep = common.iter_get_first(
+                    r for r in result if r.get("ifname") == vf_rep
+                )
+            else:
+                inf_vf_rep = None
+
+            d2: dict[str, Any] = {
+                "uplink_rep_ifname": uplink_rep_ifname,
+                "uplink_rep_pciaddr": uplink_rep_pciaddr,
+                "vfindex": vf_index,
+            }
+            if inf_vf is not None:
+                d3 = d2.copy()
+                if inf_vf_rep is not None:
+                    dict_add_optional(d3, "vf_rep_ifname", inf_vf_rep.get("ifname"))
+                    dict_add_optional(d3, "vf_rep_ifindex", inf_vf_rep.get("ifindex"))
+                    dict_add_optional(d3, "vf_rep_pciaddr", inf_vf_rep.get("pciaddr"))
+                inf_vf["is_vf"] = d3
+            if inf_vf_rep is not None:
+                d3 = d2.copy()
+                if inf_vf is not None:
+                    dict_add_optional(d3, "vf_ifname", inf_vf.get("ifname"))
+                    dict_add_optional(d3, "vf_ifindex", inf_vf.get("ifindex"))
+                    dict_add_optional(d3, "vf_pciaddr", inf_vf.get("pciaddr"))
+                inf_vf_rep["is_vf_rep"] = d3
+
+    result.sort(
+        key=lambda x: (
+            x.get("ifindex") or 2**33,
+            x.get("ifname") or "",
+            x.get("pciaddr") or "",
+        )
+    )
+
+    return result
+
+
+def device_infos_parse_lst(
+    device_infos_str: str,
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    lst = common.json_parse_list(device_infos_str)
+    return device_infos_find(
+        lst,
+        ifname=ifname,
+        pciaddr=pciaddr,
+        vf_rep_for_pciaddr=vf_rep_for_pciaddr,
+    )
+
+
+def device_infos_find(
+    device_info_list: Iterable[Any],
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+
+    # First, filter out all non-strdicts
+    lst = [
+        di
+        for di in device_info_list
+        if (isinstance(di, dict) and all(isinstance(k, str) for k in di))
+    ]
+
+    if ifname is not None:
+        ifname = validate_ifname(ifname)
+        lst = [di for di in lst if di.get("ifname") == ifname]
+
+    if pciaddr is not None:
+        pciaddr = validate_ifname(pciaddr)
+        lst = [di for di in lst if di.get("pciaddr") == pciaddr]
+
+    if vf_rep_for_pciaddr is not None:
+
+        vf_rep_for_pciaddr = validate_pciaddr(vf_rep_for_pciaddr)
+
+        def _match(di: dict[str, Any]) -> bool:
+            x = di.get("is_vf_rep")
+            if not isinstance(x, dict):
+                return False
+            return x.get("vf_pciaddr") == vf_rep_for_pciaddr
+
+        lst = [di for di in lst if _match(di)]
+
+    return lst
+
+
+if __name__ == "__main__":
+
+    def main() -> None:
+        import argparse
+
+        commands = {f.__name__: f for f in (get_device_infos,)}
+
+        argparser = argparse.ArgumentParser(description="Helper network functions.")
+        argparser.add_argument(
+            "command",
+            choices=commands,
+            default="get_device_infos",
+            nargs="?",
+        )
+        args = argparser.parse_args()
+
+        result = commands[args.command]()
+        print(json.dumps(result))
+
+    main()

--- a/tests/test_netdev.py
+++ b/tests/test_netdev.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import host  # noqa: E402
+import netdev  # noqa: E402
+
+
+def test_ip_addrs() -> None:
+    # We expect to have at least one address configured on the system and that
+    # `ip -json addr` works. The unit test requires that.
+    assert netdev.ip_addrs(host.local)
+
+
+def test_ip_links() -> None:
+    links = netdev.ip_links(host.local)
+    assert links
+    assert [link.ifindex for link in links if link.ifname == "lo"] == [1]
+
+    assert [link.ifindex for link in netdev.ip_links(host.local, ifname="lo")] == [1]
+
+
+def test_ip_routes() -> None:
+    # We expect to have at least one route configured on the system and that
+    # `ip -json route` works. The unit test requires that.
+    assert netdev.ip_routes(host.local)

--- a/tests/test_netdev.py
+++ b/tests/test_netdev.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 import sys
 
@@ -20,8 +21,68 @@ def test_ip_links() -> None:
 
     assert [link.ifindex for link in netdev.ip_links(host.local, ifname="lo")] == [1]
 
+    ifnames = netdev.get_ifnames()
+    for ifname in ifnames:
+        ipl = netdev.ip_links(ifname=ifname)
+        assert isinstance(ipl, list)
+        assert len(ipl) == 1
+        assert ipl[0].ifname == ifname
+
 
 def test_ip_routes() -> None:
     # We expect to have at least one route configured on the system and that
     # `ip -json route` works. The unit test requires that.
     assert netdev.ip_routes(host.local)
+
+
+def test_sysctl_phys_port_name_parse() -> None:
+    assert netdev.sysctl_phys_port_name_parse("") is None
+    assert netdev.sysctl_phys_port_name_parse("  555\n") == (0, 555)
+    assert netdev.sysctl_phys_port_name_parse("  c1pf6vf55\n") == (6, 55)
+
+
+def test_validate_pciaddr() -> None:
+    assert netdev.validate_pciaddr(b"0000:ff:0a.7") == "0000:ff:0a.7"
+    assert netdev.validate_pciaddr("0000:ff:0a.7") == "0000:ff:0a.7"
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr(b"0000:ff:0a.7/")
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr("0000:ff:0A.7")
+
+
+def test_ifnames_and_pciaddrs() -> None:
+    ifnames = netdev.get_ifnames()
+    assert isinstance(ifnames, list)
+    assert all(isinstance(i, str) for i in ifnames)
+    assert "lo" in ifnames
+
+    pciaddrs = netdev.get_pciaddrs()
+    assert isinstance(pciaddrs, list)
+    assert all(isinstance(i, str) for i in pciaddrs)
+
+    ifname_to_pci: dict[str, str] = {}
+    pci_to_ifname: dict[str, str] = {}
+
+    for ifname1 in ifnames:
+        pciaddr = netdev.get_pciaddr_from_ifname(ifname1)
+        if pciaddr is not None:
+            assert pciaddr in pciaddrs
+            assert ifname1 in (netdev.get_ifnames_from_pciaddr(pciaddr) or ())
+            ifname_to_pci[ifname1] = pciaddr
+
+    for pci in pciaddrs:
+        ifnames2 = netdev.get_ifnames_from_pciaddr(pci)
+        if ifnames2 is not None:
+            for ifname2 in ifnames2:
+                assert ifname2 in ifnames
+                assert netdev.get_pciaddr_from_ifname(ifname2) == pci
+                pci_to_ifname[pci] = ifname2
+
+    assert {v: k for k, v in pci_to_ifname.items()} == ifname_to_pci
+    assert {v: k for k, v in ifname_to_pci.items()} == pci_to_ifname
+
+
+def test_get_device_infos() -> None:
+    result = netdev.get_device_infos()
+    assert isinstance(result, list)
+    assert "lo" in [x.get("ifname") for x in result]


### PR DESCRIPTION
This is quite extensive.

- add `netdev.ip_{links,addrs,routes}()` which wraps `ip link|addrs|routes` and parses (and validates) the output. They return Python data classes that are strongly typed.

- same for `ethtool -s`. Add `netdev.ethtool_driver()`.

- add various helpers for read sysfs files.

- since all names in kernel (e.g. interface names in `ip link` or path names in `/sys/class/net`) are not enforced to be in any encoding, the code handles that correctly by using `errors="surrogateescape"`. Almost everything should just work. Of course, the best advise is to stick to always ASCII or at least UTF-8.

- add `netdev.get_device_infos()`, which collects information about all interfaces (pciaddresses, iplink output, ethtool, their VF/VF_REP status) and returns them in a data structure, that can be printed in JSON. There are also helper functions to parse that JSON back.

- there is a main function which accepts commands. Currently, only `get_device_infos` command is supported, which collects all device informations and prints them in JSON.

- as `netdev.py` is embedded in the `quay.io/wizhao/tft-tools:latest` image, we can also call

```
$ podman run --rm --network=host quay.io/thaller/tft-tools:latest ocp-tft-netdev get_device_infos
```

or via `oc exec`.

This gives something like
```json
[
  {
    "pciaddr": "0000:ca:00.0",
    "uplink_representor": "ens7f0np0"
  },
  {
    "ifname": "1bbeefd0712_040",
    "ifindex": 40,
    "link": {
      "flags": [
        "BROADCAST",
        "MULTICAST",
        "UP",
        "LOWER_UP"
      ],
      "mtu": 1400,
      "operstate": "UP",
      "link_info_kind": null
    },
    "pciaddr": "0000:ca:00.3",
    "uplink_representor": "ens7f0np0",
    "ethtool": {
      "driver": "mlx5_core",
      "version": "5.14.0-284.75.1.el9_2.x86_64",
      "firmware_version": "16.35.3006 (MT_0000000013)"
    },
    "is_vf": {
      "uplink_representor": "ens7f0np0",
      "uplink_rep_pciaddr": "0000:ca:00.0",
      "vfindex": 1,
      "vf_rep_ifname": "ens7f0np0_1",
      "vf_rep_ifindex": 23
    }
  },
  {
    "ifname": "2e200a9662c6016",
    "ifindex": 53,
...
```

---

The point of this will be to fix finding the VF_REP for "validate_offload" plugin (https://issues.redhat.com/browse/NHE-1154). The code will first run `oc exec POD -- oc exec ocp-tft-netdev get_device_infos` to find the PCI address of `eth0`. Then it will collect `get_device_infos` in the main netns, and search the JSON for the interface that is the VR_REP for the PCI address.