### PR TITLE
[th/jinja2util] common,jinja2util: move common.j2_render() to new "jinja2util.py" module

### DIFF
--- a/common.py
+++ b/common.py
@@ -307,23 +307,6 @@ def dict_get_typed(
     return v
 
 
-def j2_render_data(contents: str, kwargs: dict[str, Any]) -> str:
-    import jinja2
-
-    template = jinja2.Template(contents)
-    rendered = template.render(**kwargs)
-    return rendered
-
-
-def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> str:
-    with open(in_file_name) as inFile:
-        contents = inFile.read()
-    rendered = j2_render_data(contents, kwargs)
-    with open(out_file_name, "w") as outFile:
-        outFile.write(rendered)
-    return rendered
-
-
 def serialize_enum(
     data: Enum | dict[Any, Any] | list[Any] | Any
 ) -> str | dict[Any, Any] | list[Any] | Any:

--- a/jinja2util.py
+++ b/jinja2util.py
@@ -1,0 +1,18 @@
+import jinja2
+
+from typing import Any
+
+
+def j2_render_data(contents: str, kwargs: dict[str, Any]) -> str:
+    template = jinja2.Template(contents)
+    rendered = template.render(**kwargs)
+    return rendered
+
+
+def j2_render(in_file_name: str, out_file_name: str, kwargs: dict[str, Any]) -> str:
+    with open(in_file_name) as inFile:
+        contents = inFile.read()
+    rendered = j2_render_data(contents, kwargs)
+    with open(out_file_name, "w") as outFile:
+        outFile.write(rendered)
+    return rendered

--- a/task.py
+++ b/task.py
@@ -20,6 +20,7 @@ from typing import TypeVar
 
 import common
 import host
+import jinja2util
 import netdev
 import tftbase
 
@@ -300,7 +301,7 @@ class Task(ABC):
         logger.info(
             f'Generate {log_info} "{out_file_yaml}" (from "{in_file_template}", for {self.log_name})'
         )
-        rendered = common.j2_render(in_file_template, out_file_yaml, template_args)
+        rendered = jinja2util.j2_render(in_file_template, out_file_yaml, template_args)
 
         rendered_dict = yaml.safe_load(rendered)
         logger.debug(f'"{in_file_template}" contains: {json.dumps(rendered_dict)}')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,7 +7,6 @@ import sys
 import typing
 
 from enum import Enum
-from typing import Any
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -471,18 +470,3 @@ def test_dataclass_tofrom_dict() -> None:
     assert type(common.dataclass_from_dict(C10, {"x": 1.0}).x) is float
     assert type(c10.x) is int
     assert type(C10(1.0).x) is float
-
-
-def test_j2_render() -> None:
-    def _r(contents: str, **kwargs: Any) -> str:
-        return common.j2_render_data(contents, kwargs)
-
-    assert _r("", a="1") == ""
-    assert _r("val: {{a}}", a=1) == "val: 1"
-    assert _r("val: {{a}}", a="1") == "val: 1"
-    assert _r("val: {{a}}", a="a") == "val: a"
-    assert _r("val: {{a}}", a="a b") == "val: a b"
-    assert _r("val: {{a|tojson}}", a=1) == "val: 1"
-    assert _r("val: {{a|tojson}}", a="1") == 'val: "1"'
-    assert _r("val: {{a|tojson}}", a="a") == 'val: "a"'
-    assert _r("val: {{a|tojson}}", a="a b") == 'val: "a b"'

--- a/tests/test_jinja2util.py
+++ b/tests/test_jinja2util.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+from typing import Any
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import jinja2util  # noqa: E402
+
+
+def test_j2_render() -> None:
+    def _r(contents: str, **kwargs: Any) -> str:
+        return jinja2util.j2_render_data(contents, kwargs)
+
+    assert _r("", a="1") == ""
+    assert _r("val: {{a}}", a=1) == "val: 1"
+    assert _r("val: {{a}}", a="1") == "val: 1"
+    assert _r("val: {{a}}", a="a") == "val: a"
+    assert _r("val: {{a}}", a="a b") == "val: a b"
+    assert _r("val: {{a|tojson}}", a=1) == "val: 1"
+    assert _r("val: {{a|tojson}}", a="1") == 'val: "1"'
+    assert _r("val: {{a|tojson}}", a="a") == 'val: "a"'
+    assert _r("val: {{a|tojson}}", a="a b") == 'val: "a b"'


### PR DESCRIPTION
"common" should not depend on additional pip modules. We should be able to copy it somewhere and use with minimal effort (e.g. not need to install additional pip modules).

This is almost the case, except for common.j2_render() and common.j2_render_data(). Move those two functions to a new module "jinja2util.py".