### PR TITLE
[th/fix-external-perf-server-run] fix podman-run for external-perf-server

### DIFF
--- a/task.py
+++ b/task.py
@@ -673,7 +673,7 @@ class ServerTask(Task, ABC):
         th_cmd = self._create_setup_operation_get_thread_action_cmd()
 
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
-            cmd = f"podman run -it --init --replace --rm -p {self.port} --name={self.pod_name} {tftbase.get_tft_test_image()} {th_cmd}"
+            cmd = f"podman run -it --replace --rm -p {self.port} --name={self.pod_name} {tftbase.get_tft_test_image()} {th_cmd}"
             cancel_cmd = f"podman rm --force {self.pod_name}"
         else:
             self.setup_pod()

--- a/task.py
+++ b/task.py
@@ -673,7 +673,11 @@ class ServerTask(Task, ABC):
         th_cmd = self._create_setup_operation_get_thread_action_cmd()
 
         if self.connection_mode == ConnectionMode.EXTERNAL_IP:
-            cmd = f"podman run -it --replace --rm -p {self.port} --name={self.pod_name} {tftbase.get_tft_test_image()} {th_cmd}"
+            pull_policy = ""
+            if tftbase.get_tft_image_pull_policy() == "Always":
+                pull_policy = " --pull=always"
+
+            cmd = f"podman run -it --replace --rm -p {self.port} --name={self.pod_name}{pull_policy} {tftbase.get_tft_test_image()} {th_cmd}"
             cancel_cmd = f"podman rm --force {self.pod_name}"
         else:
             self.setup_pod()


### PR DESCRIPTION
- don't use `podman run --init` with our recent test image `quay.io/wizhao/tft-tools:latest`, which already sets the ENTRYPOINT to `/usr/bin/container-entry-point.sh`.
- honor `TFT_IMAGE_PULL_POLICY` for `podman run`.