### PR TITLE
[th/fix-get-device-info] netdev: fix get_device_infos() to not iterate duplicate uplink_reps

### DIFF
--- a/netdev.py
+++ b/netdev.py
@@ -816,7 +816,7 @@ def get_device_infos(with_ethtool: bool = True) -> list[dict[str, Any]]:
         result.append(res)
 
     uplink_reps: list[str] = sorted(
-        common.iter_filter_none(x1.get("uplink_rep_ifname") for x1 in result)
+        set(common.iter_filter_none(x1.get("uplink_rep_ifname") for x1 in result))
     )
 
     for uplink_rep_ifname in uplink_reps:


### PR DESCRIPTION
Fixes: cf5bfb6e5924 ('netdev: add helper methods for reading sysctl values')