### PR TITLE
[th/k8sclient-oc-debug] add K8sClient.oc_debug() helper

### DIFF
--- a/k8sClient.py
+++ b/k8sClient.py
@@ -2,6 +2,7 @@ import json
 import kubernetes  # type: ignore
 import logging
 import os
+import random
 import shlex
 import sys
 import typing
@@ -137,3 +138,73 @@ class K8sClient:
             return None
 
         return data
+
+    def oc_debug(
+        self,
+        cmd: str | Iterable[str],
+        *,
+        node_name: str,
+        test_image: str,
+        namespace: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+    ) -> host.Result:
+        container_name = f"ocp-tft-debug-{node_name}-{random.randint(0, 2**64-1):016x}"
+        # We use `kubectl debug` and not `oc debug`. There are thus some differences.
+        #
+        # Optimally, we would use "--profile=sysadmin". But that is too new, so
+        # we cannot use it and have no CAP_SYS_CHROOT.  That means, `cmd`
+        # cannot be `chroot /host crictl ...` but needs to be
+        # `/host/usr/bin/crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ...`.
+        #
+        # Also, unlike `oc debug`, we need an "--image", which the caller must specify.
+        #
+        # Also, we must specify a namespace. And the container will linger around afterwards,
+        # so we need to delete it (below).
+        result = self.oc(
+            [
+                "debug",
+                "-q",
+                "-ti",
+                "--profile=general",
+                f"--container={container_name}",
+                f"--image={test_image}",
+                f"node/{node_name}",
+                "--",
+                *self._get_oc_cmd(cmd),
+            ],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        # We have to find and delete the pods we just created. As we used
+        # a unique {container_name}, we can search for that.
+        pod_names = []
+        pdict = self.oc_get(
+            "pods",
+            may_fail=True,
+            namespace=namespace,
+        )
+        pdict_items = []
+        if pdict is not None:
+            try:
+                pdict_items = list(pdict["items"])
+            except Exception:
+                pass
+        for pdict_item in pdict_items:
+            try:
+                for c in pdict_item["spec"]["containers"]:
+                    if c["name"] == container_name:
+                        pod_names.append(pdict_item["metadata"]["name"])
+                        break
+            except Exception:
+                pass
+        for pod_name in pod_names:
+            self.oc(
+                ["delete", "--wait=false", f"pod/{pod_name}"],
+                may_fail=True,
+                namespace=namespace,
+            )
+
+        return result


### PR DESCRIPTION
`K8sClient.oc_debug()` calls `kubectl debug` to execute a command on a node.

I initially added this for https://github.com/wizhaoredhat/ocp-traffic-flow-tests/pull/105 , however, it has the downside that it needs to spin up a new pod (so the entire command takes about 2 seconds). If you already have a priviledged pod running that can access the resources you want (e.g. `/host` or the main netns), then a plain `kubectl exec` is going to be faster, and thus preferable. However, that does require you to first start a pod (and maybe clean it up later). So there is more setup involved with that approach, and it's only faster because you only need to start/delete the pod once (instead of every `kubectl debug` call).

Still, as this code was already written, I think it's useful helper to have in the `k8sClient.py` toolbox. For that reason, I'd like to merge this, even if there currently are no user of it.

This boils down to my view of `{logger,host,common,netdev}.py` not only having a purpose for the current ocp-tft code, but to be a toolbox of some python code that is useful in the larger context (e.g. this code shoud be re-used at other places -- maybe via copy+paste). If you disagree with that view, then merging this patch makes no sense, because there is no user.

I also don't want to throw away the effort of getting it right once (even if it turned out, to not use it for the purpose where I wrote it).