### PR TITLE
[th/cleanup-error-logging] cleanup the error handling with host.Host.run()

### DIFF
--- a/host.py
+++ b/host.py
@@ -301,6 +301,11 @@ class Host(ABC):
             raise decode_exception
 
         if die_on_error and not result_success:
+            import traceback
+
+            logger.error(
+                f"FATAL ERROR. BACKTRACE:\n{''.join(traceback.format_stack())}"
+            )
             sys.exit(-1)
 
         if str_result is not None:

--- a/host.py
+++ b/host.py
@@ -46,7 +46,7 @@ class BaseResult(ABC, typing.Generic[T]):
         return self.returncode == 0
 
     def debug_str(self) -> str:
-        if self.returncode == 0:
+        if self.success:
             status = "succcess"
         else:
             status = f"failed ({self.returncode})"

--- a/host.py
+++ b/host.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import os
 import shlex
@@ -12,6 +13,7 @@ from collections.abc import Iterable
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
+from typing import Callable
 from typing import Optional
 
 from logger import logger
@@ -41,15 +43,27 @@ class BaseResult(ABC, typing.Generic[T]):
     err: T
     returncode: int
 
+    # In most cases, "success" is the same as checking for returncode zero.  In
+    # some cases, it can be overwritten to be of a certain value.
+    forced_success: Optional[bool] = dataclasses.field(default=None, kw_only=True)
+
     @property
     def success(self) -> bool:
+        if self.forced_success is not None:
+            return self.forced_success
         return self.returncode == 0
 
     def debug_str(self) -> str:
-        if self.success:
-            status = "succcess"
+        if self.forced_success is None or self.forced_success == (self.returncode == 0):
+            if self.success:
+                status = "success"
+            else:
+                status = f"failed (exit {self.returncode})"
         else:
-            status = f"failed ({self.returncode})"
+            if self.forced_success:
+                status = f"success [forced] (exit {self.returncode})"
+            else:
+                status = "failed [forced] (exit 0)"
 
         out = ""
         if self.out:
@@ -96,6 +110,7 @@ class Host(ABC):
         log_level: int = logging.DEBUG,
         log_level_result: Optional[int] = None,
         log_level_fail: Optional[int] = None,
+        check_success: Optional[Callable[[Result], bool]] = None,
         die_on_error: bool = False,
         decode_errors: Optional[str] = None,
     ) -> Result:
@@ -112,6 +127,7 @@ class Host(ABC):
         log_level: int = logging.DEBUG,
         log_level_result: Optional[int] = None,
         log_level_fail: Optional[int] = None,
+        check_success: Optional[Callable[[BinResult], bool]] = None,
         die_on_error: bool = False,
         decode_errors: Optional[str] = None,
     ) -> BinResult:
@@ -127,6 +143,9 @@ class Host(ABC):
         log_level: int = logging.DEBUG,
         log_level_result: Optional[int] = None,
         log_level_fail: Optional[int] = None,
+        check_success: Optional[
+            Callable[[Result], bool] | Callable[[BinResult], bool]
+        ] = None,
         die_on_error: bool = False,
         decode_errors: Optional[str] = None,
     ) -> Result | BinResult:
@@ -195,15 +214,37 @@ class Host(ABC):
                 str_result = bin_result.decode(errors="replace")
                 unexpected_binary = True
 
+        if check_success is None:
+            result_success = bin_result.success
+        else:
+            result_success = True
+            if text:
+                str_check = typing.cast(Callable[[Result], bool], check_success)
+                if str_result is None:
+                    # This can only happen in text mode when the caller specified
+                    # a "decode_errors" that resulted in a "decode_exception".
+                    # The function will raise an exception, and we won't call
+                    # the check_success() handler.
+                    #
+                    # Avoid this by using text=False or a "decode_errors" value
+                    # that does not fail.
+                    result_success = False
+                elif not str_check(str_result):
+                    result_success = False
+            else:
+                bin_check = typing.cast(Callable[[BinResult], bool], check_success)
+                if not bin_check(bin_result):
+                    result_success = False
+
         status_msg = ""
-        if log_level_fail is not None and not bin_result.success:
+        if log_level_fail is not None and not result_success:
             result_log_level = log_level_fail
         elif log_level_result is not None:
             result_log_level = log_level_result
         else:
             result_log_level = log_level
 
-        if die_on_error and not bin_result.success:
+        if die_on_error and not result_success:
             if result_log_level < logging.ERROR:
                 result_log_level = logging.ERROR
             status_msg += " [FATAL]"
@@ -225,6 +266,22 @@ class Host(ABC):
             if result_log_level < logging.ERROR:
                 result_log_level = logging.ERROR
 
+        if str_result is not None:
+            if result_success != str_result.success:
+                str_result = Result(
+                    out=str_result.out,
+                    err=str_result.err,
+                    returncode=str_result.returncode,
+                    forced_success=result_success,
+                )
+        if result_success != bin_result.success:
+            bin_result = BinResult(
+                out=bin_result.out,
+                err=bin_result.err,
+                returncode=bin_result.returncode,
+                forced_success=result_success,
+            )
+
         if is_binary:
             # Note that we log the output as binary if either "text=False" or if
             # the output was not valid utf-8. In the latter case, we will still
@@ -243,7 +300,7 @@ class Host(ABC):
         if decode_exception:
             raise decode_exception
 
-        if die_on_error and not bin_result.success:
+        if die_on_error and not result_success:
             sys.exit(-1)
 
         if str_result is not None:

--- a/k8sClient.py
+++ b/k8sClient.py
@@ -75,11 +75,13 @@ class K8sClient:
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
+        check_success: typing.Optional[typing.Callable[[host.Result], bool]] = None,
         namespace: typing.Optional[str] = None,
     ) -> host.Result:
         return host.local.run(
             self._get_oc_cmd_full(cmd=cmd, namespace=namespace),
             die_on_error=die_on_error,
+            check_success=check_success,
             log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
         )
 

--- a/task.py
+++ b/task.py
@@ -406,14 +406,14 @@ class Task(ABC):
         out_file_yaml = "./manifests/yamls/svc-cluster-ip.yaml"
 
         self.render_file("Cluster IP Service", in_file_template, out_file_yaml)
-        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if not r.success:
-            if "already exists" not in r.err:
-                logger.error(r)
-                sys.exit(-1)
-
+        self.run_oc(
+            f"apply -f {out_file_yaml}",
+            check_success=lambda r: r.success or "already exists" in r.err,
+            die_on_error=True,
+        )
         return self.run_oc(
-            "get service tft-clusterip-service -o=jsonpath='{.spec.clusterIP}'"
+            "get service tft-clusterip-service -o=jsonpath='{.spec.clusterIP}'",
+            die_on_error=True,
         ).out
 
     def create_node_port_service(self, nodeport: int) -> str:
@@ -428,14 +428,14 @@ class Task(ABC):
         self.render_file(
             "Node Port Service", in_file_template, out_file_yaml, template_args
         )
-        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if not r.success:
-            if "already exists" not in r.err:
-                logger.error(r)
-                sys.exit(-1)
-
+        self.run_oc(
+            f"apply -f {out_file_yaml}",
+            check_success=lambda r: r.success or "already exists" in r.err,
+            die_on_error=True,
+        )
         return self.run_oc(
-            "get service tft-nodeport-service -o=jsonpath='{.spec.clusterIP}'"
+            "get service tft-nodeport-service -o=jsonpath='{.spec.clusterIP}'",
+            die_on_error=True,
         ).out
 
     def create_ingress_multi_network_policy(self, ingressPort: int) -> str:
@@ -453,14 +453,14 @@ class Task(ABC):
             out_file_yaml,
             template_args,
         )
-        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if not r.success:
-            if "already exists" not in r.err:
-                logger.info(r)
-                sys.exit(-1)
-
+        self.run_oc(
+            f"apply -f {out_file_yaml}",
+            check_success=lambda r: r.success or "already exists" in r.err,
+            die_on_error=True,
+        )
         return self.run_oc(
-            "get multi-networkpolicies allow-ingress-mnp", die_on_error=True
+            "get multi-networkpolicies allow-ingress-mnp",
+            die_on_error=True,
         ).out
 
     def create_egress_multi_network_policy(self, egressPort: int) -> str:
@@ -478,14 +478,14 @@ class Task(ABC):
             out_file_yaml,
             template_args,
         )
-        r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if not r.success:
-            if "already exists" not in r.err:
-                logger.info(r)
-                sys.exit(-1)
-
+        self.run_oc(
+            f"apply -f {out_file_yaml}",
+            check_success=lambda r: r.success or "already exists" in r.err,
+            die_on_error=True,
+        )
         return self.run_oc(
-            "get multi-networkpolicies allow-egress-mnp", die_on_error=True
+            "get multi-networkpolicies allow-egress-mnp",
+            die_on_error=True,
         ).out
 
     def start_setup(self) -> None:

--- a/task.py
+++ b/task.py
@@ -135,7 +135,7 @@ class TaskOperation:
 
         try:
             result = self._thread_action()
-        except Exception as e:
+        except BaseException as e:
             import traceback
 
             logger.error(f"thread[{self.log_name}]: action raised exception {e}")

--- a/task.py
+++ b/task.py
@@ -405,7 +405,7 @@ class Task(ABC):
 
         self.render_file("Cluster IP Service", in_file_template, out_file_yaml)
         r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if r.returncode != 0:
+        if not r.success:
             if "already exists" not in r.err:
                 logger.error(r)
                 sys.exit(-1)
@@ -427,7 +427,7 @@ class Task(ABC):
             "Node Port Service", in_file_template, out_file_yaml, template_args
         )
         r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if r.returncode != 0:
+        if not r.success:
             if "already exists" not in r.err:
                 logger.error(r)
                 sys.exit(-1)
@@ -452,7 +452,7 @@ class Task(ABC):
             template_args,
         )
         r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if r.returncode != 0:
+        if not r.success:
             if "already exists" not in r.err:
                 logger.info(r)
                 sys.exit(-1)
@@ -477,7 +477,7 @@ class Task(ABC):
             template_args,
         )
         r = self.run_oc(f"apply -f {out_file_yaml}", may_fail=True)
-        if r.returncode != 0:
+        if not r.success:
             if "already exists" not in r.err:
                 logger.info(r)
                 sys.exit(-1)
@@ -731,7 +731,7 @@ class ServerTask(Task, ABC):
             r = self.run_oc(
                 f"wait --for=condition=ready pod/{self.pod_name} --timeout=1m"
             )
-        if not r or r.returncode != 0:
+        if not r or not r.success:
             logger.error(f"Failed to start server: {r.err}")
             sys.exit(-1)
 
@@ -880,7 +880,7 @@ class ClientTask(Task, ABC):
 
         for _ in range(5):
             ret = self.lh.run(cmd)
-            if ret.returncode == 0:
+            if ret.success:
                 ip_address = ret.out.strip()
                 if ip_address:
                     logger.debug(f"get_podman_ip({pod_name}) found: {ip_address}")

--- a/task.py
+++ b/task.py
@@ -330,12 +330,14 @@ class Task(ABC):
         *,
         may_fail: bool = False,
         die_on_error: bool = False,
+        check_success: Optional[Callable[[host.Result], bool]] = None,
         namespace: Optional[str] | common._MISSING_TYPE = common.MISSING,
     ) -> host.Result:
         return self.client.oc(
             cmd,
             may_fail=may_fail,
             die_on_error=die_on_error,
+            check_success=check_success,
             namespace=self._get_run_oc_namespace(namespace),
         )
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -409,6 +409,37 @@ def test_host_various_results() -> None:
     assert binres == host.BinResult(b"foo:\xc5x", b"", 0)
 
 
+def test_host_check_success() -> None:
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 0)
+    assert res.success
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.out != "foo")
+    assert res == host.Result("foo", "", 0, forced_success=False)
+    assert not res.success
+
+    binres = host.local.run(
+        "echo -n foo", text=False, check_success=lambda r: r.out != b"foo"
+    )
+    assert binres == host.BinResult(b"foo", b"", 0, forced_success=False)
+    assert not binres.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 74)
+    assert not res.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.out == "foo")
+    assert res == host.Result("foo", "", 74, forced_success=True)
+    assert res.success
+
+    binres = host.local.run(
+        "echo -n foo; exit 74", text=False, check_success=lambda r: r.out == b"foo"
+    )
+    assert binres == host.BinResult(b"foo", b"", 74, forced_success=True)
+    assert binres.success
+
+
 def test_host_file_exists() -> None:
     assert host.local.file_exists(__file__)
     assert host.Host.file_exists(host.local, __file__)

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -25,7 +25,7 @@ class TrafficFlowTests:
                                         pod-security.kubernetes.io/enforce-version=v1.24 \
                                         security.openshift.io/scc.podSecurityLabelSync=false"
         )
-        if r.returncode != 0:
+        if not r.success:
             logger.error(r)
             raise Exception(
                 f"configure_namespace(): Failed to label namespace {namespace}"
@@ -36,7 +36,7 @@ class TrafficFlowTests:
         namespace = cfg_descr.get_tft().namespace
         logger.info(f"Cleaning pods with label tft-tests in namespace {namespace}")
         r = cfg_descr.tc.client_tenant.oc(f"delete pods -n {namespace} -l tft-tests")
-        if r.returncode != 0:
+        if not r.success:
             logger.error(r)
             raise Exception("cleanup_previous_testspace(): Failed to delete pods")
         logger.info(f"Cleaned pods with label tft-tests in namespace {namespace}")
@@ -44,7 +44,7 @@ class TrafficFlowTests:
         r = cfg_descr.tc.client_tenant.oc(
             f"delete services -n {namespace} -l tft-tests"
         )
-        if r.returncode != 0:
+        if not r.success:
             logger.error(r)
             raise Exception("cleanup_previous_testspace(): Failed to delete services")
         logger.info(f"Cleaned services with label tft-tests in namespace {namespace}")

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import task
 
 from pathlib import Path
@@ -20,48 +21,38 @@ class TrafficFlowTests:
     def _configure_namespace(self, cfg_descr: ConfigDescriptor) -> None:
         namespace = cfg_descr.get_tft().namespace
         logger.info(f"Configuring namespace {namespace}")
-        r = cfg_descr.tc.client_tenant.oc(
+        cfg_descr.tc.client_tenant.oc(
             f"label ns --overwrite {namespace} pod-security.kubernetes.io/enforce=privileged \
                                         pod-security.kubernetes.io/enforce-version=v1.24 \
-                                        security.openshift.io/scc.podSecurityLabelSync=false"
+                                        security.openshift.io/scc.podSecurityLabelSync=false",
+            die_on_error=True,
         )
-        if not r.success:
-            logger.error(r)
-            raise Exception(
-                f"configure_namespace(): Failed to label namespace {namespace}"
-            )
-        logger.info(f"Configured namespace {namespace}")
 
     def _cleanup_previous_testspace(self, cfg_descr: ConfigDescriptor) -> None:
         namespace = cfg_descr.get_tft().namespace
-        logger.info(f"Cleaning pods with label tft-tests in namespace {namespace}")
-        r = cfg_descr.tc.client_tenant.oc(f"delete pods -n {namespace} -l tft-tests")
-        if not r.success:
-            logger.error(r)
-            raise Exception("cleanup_previous_testspace(): Failed to delete pods")
-        logger.info(f"Cleaned pods with label tft-tests in namespace {namespace}")
-        logger.info(f"Cleaning services with label tft-tests in namespace {namespace}")
-        r = cfg_descr.tc.client_tenant.oc(
-            f"delete services -n {namespace} -l tft-tests"
-        )
-        if not r.success:
-            logger.error(r)
-            raise Exception("cleanup_previous_testspace(): Failed to delete services")
-        logger.info(f"Cleaned services with label tft-tests in namespace {namespace}")
         logger.info(
-            f"Cleaning multi-networkpolicies with label tft-tests in namespace {namespace}"
+            f"Cleaning pods, services and multi-networkpolicies with label tft-tests in namespace {namespace}"
         )
-        r = cfg_descr.tc.client_tenant.oc(
-            f"delete multi-networkpolicies -n {namespace} -l tft-tests"
+        cfg_descr.tc.client_tenant.oc(
+            "delete pods -l tft-tests",
+            namespace=namespace,
         )
-        logger.info(
-            f"Cleaned multi-networkpolicies with label tft-tests in namespace {namespace}"
+        cfg_descr.tc.client_tenant.oc(
+            "delete services -l tft-tests",
+            namespace=namespace,
         )
+        cfg_descr.tc.client_tenant.oc(
+            "delete multi-networkpolicies -l tft-tests",
+            namespace=namespace,
+        )
+
         logger.info(
             f"Cleaning external containers {task.EXTERNAL_PERF_SERVER} (if present)"
         )
-        cmd = f"podman rm --force --time 10 {task.EXTERNAL_PERF_SERVER}"
-        host.local.run(cmd)
+        host.local.run(
+            f"podman rm --force --time 10 {task.EXTERNAL_PERF_SERVER}",
+            log_level_fail=logging.WARN,
+        )
 
     def _create_log_paths_from_tests(self, test: testConfig.ConfTest) -> Path:
         log_path = test.logs


### PR DESCRIPTION
Extend `host.Host.run()` with a `check_success` callback. This allows to categorize the `Result` as success/failure, beyond that `returncode==0` check. The benefit is that `host.Host.run()` already makes an effort to provide useful logs with the result, and indicating whether the result is a success/failure will affect the error level and message. It also means, the caller does not need to invest effort to log failures, because the logging that was done automatically is already useful.