### PR TITLE
[th/github-cleanup-install] github: cleanup pip modules in ".github/workflows/lint-test.yml"

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -18,11 +18,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install black mypy pytest
-        python -m pip install -r requirements.txt
+        python -m pip install black
         python -m pip install flake8
+        python -m pip install mypy
+        python -m pip install pytest
         python -m pip install types-PyYAML
-        python -m pip install jc
+        python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |
        black --version
@@ -36,6 +37,6 @@ jobs:
        mypy --version
        mypy --strict --config-file mypy.ini .
     - name: Run tests with Pytest
-      run: | 
+      run: |
        pytest --version
        pytest


### PR DESCRIPTION
We already install "jc" via "requirements.txt" file.