### PR TITLE
[th/gitignore-swp] gitignore: ignore "*.swp" files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Swap files from vim
+*.swp
+
 ft-logs


### PR DESCRIPTION
temporary files created by VIM while editing a file. Ignore them.