### PR TITLE
[th/host-run-log] host: log the repr() of the command

### DIFF
--- a/host.py
+++ b/host.py
@@ -156,7 +156,7 @@ class Host(ABC):
         if log_level >= 0:
             logger.log(
                 log_level,
-                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: call `{cmd}`",
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: call {repr(cmd)}",
             )
 
         bin_result = self._run(
@@ -294,7 +294,7 @@ class Host(ABC):
         if result_log_level >= 0:
             logger.log(
                 result_log_level,
-                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: └──> `{cmd}`:{status_msg} {debug_str}",
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: └──> {repr(cmd)}:{status_msg} {debug_str}",
             )
 
         if decode_exception:


### PR DESCRIPTION
Our logging lines should not span multiple lines, it makes reading the logs harder. Hence, don't print the literal command line but repr(cmd). This nicely quotes and escapes special characters, including newlines.

The downside is, you may no longer be able to copy+paste the log content into the terminal. You would have instead to first paste it into a python REPL, to get the real string. Can't have it all.

Before:
```
  $ python -c 'import nhebase.host as h; h.local.run("echo \"hi\nfoo\"")'
  2024-08-06 15:17:16.199 DEBUG   [th:140078254828416]: cmd[1;localhost]: call `echo "hi
  foo"`
  2024-08-06 15:17:16.201 DEBUG   [th:140078254828416]: cmd[1;localhost]: └──> `echo "hi
  foo"`: success; out='hi\nfoo\n'
```
After:
```
  $ python -c 'import nhebase.host as h; h.local.run("echo \"hi\nfoo\"")'
  2024-08-06 15:17:28.037 DEBUG   [th:140419558554496]: cmd[1;localhost]: call 'echo "hi\nfoo"'
  2024-08-06 15:17:28.038 DEBUG   [th:140419558554496]: cmd[1;localhost]: └──> 'echo "hi\nfoo"': success; out='hi\nfoo\n'
```