### PR TITLE
[th/cleanup-shebang] all: use shebang "#!/usr/bin/env python3" for python scripts

### DIFF
--- a/print_results.py
+++ b/print_results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/scripts/simple-tcp-server-client.py
+++ b/scripts/simple-tcp-server-client.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os


### PR DESCRIPTION
This seems best. It will honor virtual environments and pick up the right python from the path. Also be explicit about using python3, when we consider that on Fedora we don't have /usr/bin/python unless we install "python-unversioned-command" package.