### PR TITLE
[th/serial-expect] common: add common.Serial class for a simple minicom+pexpect

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,6 +41,7 @@ RUN /opt/pyvenv3.11/bin/python -m pip install \
         dataclasses \
         jc \
         jinja2 \
+        pyserial \
         pytest
 RUN ln -s /opt/pyvenv3.11/bin/python /usr/bin/python-pyvenv3.11
 

--- a/ktoolbox/test_common.py
+++ b/ktoolbox/test_common.py
@@ -496,3 +496,13 @@ def test_etc_hosts_update() -> None:
 172.131.100.100 marvell-dpu-42 dpu2
 """
     )
+
+
+def test_serial() -> None:
+    try:
+        import serial
+    except ModuleNotFoundError:
+        pytest.skip("pyserial module not available")
+
+    with pytest.raises(serial.serialutil.SerialException):
+        common.Serial("")

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,5 @@
 
 [mypy-jc]
 ignore_missing_imports = True
+[mypy-serial]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyYAML==6.0.1
-jinja2
-jc
 dataclasses
+jc
+jinja2
+pyserial


### PR DESCRIPTION
Previously, we use minicom for opening serial ports. That was nice, because then we can use pexpect for some simple terminal interface navigation.

The problem is that minicom requires a TTY, otherwise it fails with "No cursor motion capability (cm)".

That means, if you run `podman run` without "-t"/"--tty" or `ssh HOST CMD`, you cannot easily use minicom inside the command. Maybe we could wrap minicom inside a tool that creates a tty (tmux?), but that seems cumbersome as well. Instead, use pyserial to operate the serial port.

The downside is that we no longer have a command line tool, and we cannot use pexpect anymore. Hence, implement some simple expect(). This should be sufficient for our use case, and should be easy to extend.

Add the class to ktoolbox.common. Note that the pyserial dependency is only necessary when instantiating a ktoolbox.common.Serial() class.

Also note that the class operates on str instead of bytes. But you should be able to handle any binary data with "errors='surrogatepairs'".