### PR TITLE
[th/netdev-special-ifnames] fix handling special interface names and non-Ethernet addresses

### DIFF
--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -129,6 +129,13 @@ def validate_ethaddr(ethaddr: Union[str, bytes]) -> str:
     return ethaddr.lower()
 
 
+def validate_ethaddr_or_none(ethaddr: Union[str, bytes]) -> Optional[str]:
+    try:
+        return validate_ethaddr(ethaddr)
+    except ValueError:
+        return None
+
+
 def pciaddr_get_func_address(pciaddr: Optional[Union[str, bytes]]) -> Optional[int]:
     # https://github.com/k8snetworkplumbingwg/sriovnet/blob/master/sriovnet_switchdev.go#L172
     if pciaddr is None:
@@ -254,11 +261,11 @@ def ip_links_parse(
 
             address = e.get("address")
             if address is not None:
-                address = validate_ethaddr(address)
+                address = validate_ethaddr_or_none(address)
 
             permaddr = e.get("permaddr")
             if permaddr is not None:
-                permaddr = validate_ethaddr(permaddr)
+                permaddr = validate_ethaddr_or_none(permaddr)
 
             entry = IPRouteLinkEntry(
                 ifindex=e["ifindex"],
@@ -386,10 +393,7 @@ def ethtool_permaddr(
     if permaddr is None:
         return None
 
-    try:
-        return validate_ethaddr(permaddr)
-    except Exception:
-        return None
+    return validate_ethaddr_or_none(permaddr)
 
 
 @strict_dataclass

--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -554,7 +554,13 @@ def get_ifnames() -> list[str]:
         ifs1 = os.listdir(b"/sys/class/net/")
     except Exception:
         return []
-    return sorted(common.iter_filter_none(validate_ifname(i) for i in ifs1))
+
+    def _validate(ifname: bytes) -> Optional[str]:
+        if not os.path.islink(b"/sys/class/net/" + ifname):
+            return None
+        return validate_ifname_or_none(ifname)
+
+    return sorted(common.iter_filter_none(_validate(i) for i in ifs1))
 
 
 def get_pciaddrs() -> list[str]:

--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -134,7 +134,9 @@ def validate_pciaddr(pciaddr: Union[str, bytes]) -> str:
     return pciaddr
 
 
-_ethaddr_re = re.compile("^[0-9a-fA-F:]+$")
+_ethaddr_re = re.compile(
+    "^([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?)$"
+)
 
 
 def validate_ethaddr(ethaddr: Union[str, bytes]) -> str:
@@ -149,11 +151,22 @@ def validate_ethaddr(ethaddr: Union[str, bytes]) -> str:
             )
     elif not isinstance(ethaddr, str):
         raise TypeError(f"Ethernet address of unexpected type {type(ethaddr)}")
-    if not _ethaddr_re.search(ethaddr):
+    m = _ethaddr_re.search(ethaddr)
+    if not m:
         raise ValueError(
             f"Ethernet address contains invalid characters ({repr(ethaddr)})"
         )
-    return ethaddr.lower()
+
+    def _normalize_hex(s: str) -> str:
+        s = s.lower()
+        if len(s) == 1:
+            return "0" + s
+        return s
+
+    ethaddr2 = ":".join(_normalize_hex(m.group(i)) for i in range(1, 7))
+    if ethaddr2 == ethaddr:
+        return ethaddr
+    return ethaddr2
 
 
 def validate_ethaddr_or_none(ethaddr: Union[str, bytes]) -> Optional[str]:


### PR DESCRIPTION
- netdev: fix handling non-ethernet addresses in netdev.ip_links()
- netdev: add option to reject reserved names in netdev.normalize_ifname()
- netdev: filter out special files from netdev.get_ifnames()
- netdev: tighten up regular expression for netdev.validate_ethaddr()
