### PR TITLE
[th/host-run-cwd] fix handling `cwd` option with `host.Host.run()`

### DIFF
--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -480,10 +480,10 @@ class LocalHost(Host):
                 env=full_env,
                 cwd=cwd,
             )
-        except FileNotFoundError as e:
+        except Exception as e:
             # We get an FileNotFoundError if cwd directory does not exist or if
-            # the binary does not exist (with shell=False). And maybe there are
-            # other cases where we might get exceptions.
+            # the binary does not exist (with shell=False). We get a PermissionError
+            # if we don't have permissions.
             #
             # Generally, we don't want to report errors via exceptions, because
             # you won't get the same exception with shell=True. Instead, we

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -92,9 +92,15 @@ def _prepare_run(
             if v is not None:
                 cmd2.append(f"{k}={v}")
 
+    if cwd is not None:
+        # sudo's "--chdir" option often does not work based on the sudo
+        # configuration.  Instead, change the directory inside the shell
+        # script.
+        cmd = f"cd {shlex.quote(cwd)} || exit 1 ; {_cmd_to_shell(cmd)}"
+
     cmd2.extend(_cmd_to_argv(cmd))
 
-    return tuple(cmd2), None, cwd
+    return tuple(cmd2), None, None
 
 
 def _unique_log_id() -> int:

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -166,6 +166,15 @@ def test_cwd() -> None:
     assert res.returncode == 1
     assert "/usr/bin/does/not/exist" in res.err
 
+    res = host.local.run("pwd", cwd="/root")
+    if res == host.Result("/root\n", "", 0):
+        # We have permissions to access the directory.
+        pass
+    else:
+        assert res.out == ""
+        assert res.returncode == 1
+        assert "/root" in res.err
+
 
 def test_sudo() -> None:
     skip_without_sudo(host.local)

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -209,3 +209,6 @@ def test_sudo() -> None:
     assert res.out == ""
     assert res.returncode == 1
     assert "/usr/bin/does/not/exist" in res.err
+
+    res = rsh.run("pwd", cwd="/root")
+    assert res == host.Result("/root\n", "", 0)


### PR DESCRIPTION
Fix:

- don't raise an exception if we lack permission for cwd directory (instead, report a failed `Result()`)

- with `sudo=True`, change to `cwd` directory inside a shell script. That way, we evaluate the directory in the context of the sudo user, and not the calling user (who might not have permissions).