### PR TITLE
[th/requirements-pyyaml] requirements: accept PyYAML>=6.0.1

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,7 +22,7 @@ jobs:
         python -m pip install flake8
         python -m pip install mypy
         python -m pip install pytest
-        python -m pip install types-PyYAML
+        python -m pip install types-PyYAML>=6.0.1
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |
@@ -56,7 +56,7 @@ jobs:
         python -m pip install flake8
         python -m pip install mypy
         python -m pip install pytest
-        python -m pip install types-PyYAML
+        python -m pip install types-PyYAML>=6.0.1
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |

--- a/Containerfile
+++ b/Containerfile
@@ -37,7 +37,7 @@ RUN dnf install \
 RUN python3.11 -m venv /opt/pyvenv3.11
 RUN /opt/pyvenv3.11/bin/python -m pip install --upgrade pip
 RUN /opt/pyvenv3.11/bin/python -m pip install \
-        PyYAML==6.0.1 \
+        PyYAML>=6.0.1 \
         dataclasses \
         jc \
         jinja2 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==6.0.1
+PyYAML>=6.0.1
 dataclasses
 jc
 jinja2


### PR DESCRIPTION
Newer PyYAML is fine too (even better). Otherwise, we would need to update the desired, required version over time.
