### PR TITLE
[th/mypy-files] mymp: set "files=." in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,8 @@
 [mypy]
+strict = true
+files = .
 
 [mypy-jc]
-ignore_missing_imports = True
+ignore_missing_imports = true
 [mypy-serial]
-ignore_missing_imports = True
+ignore_missing_imports = true


### PR DESCRIPTION
Previously, the right way to run mypy was `mypy --strict .`. Set those
options in "mypy.ini" file. You can still override it on the command
line.
