### PR TITLE
[th/remote-host] add host.RemoteHost for running commands via SSH/paramiko

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,6 +23,7 @@ jobs:
         python -m pip install mypy
         python -m pip install pytest
         python -m pip install types-PyYAML>=6.0.1
+        python -m pip install types-paramiko
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |
@@ -57,6 +58,7 @@ jobs:
         python -m pip install mypy
         python -m pip install pytest
         python -m pip install types-PyYAML>=6.0.1
+        python -m pip install types-paramiko
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |

--- a/Containerfile
+++ b/Containerfile
@@ -41,6 +41,7 @@ RUN /opt/pyvenv3.11/bin/python -m pip install \
         dataclasses \
         jc \
         jinja2 \
+        paramiko \
         pyserial \
         pytest
 RUN ln -s /opt/pyvenv3.11/bin/python /usr/bin/python-pyvenv3.11

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -83,7 +83,7 @@ def _prepare_run(
             cwd,
         )
 
-    cmd2 = ["sudo"]
+    cmd2 = ["sudo", "-n"]
 
     if env:
         for k, v in env.items():

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -182,6 +182,14 @@ class BinResult(BaseResult[bytes]):
             self.returncode,
         )
 
+    @staticmethod
+    def internal_failure(msg: str) -> "BinResult":
+        return BinResult(
+            b"",
+            (INTERNAL_ERROR_PREFIX + msg).encode(errors="surrogateescape"),
+            INTERNAL_ERROR_RETURNCODE,
+        )
+
 
 class Host(ABC):
     def __init__(
@@ -497,11 +505,7 @@ class LocalHost(Host):
             #
             # Usually we avoid creating an artificial BinResult. In this case
             # there is no choice.
-            return BinResult(
-                b"",
-                (INTERNAL_ERROR_PREFIX + str(e)).encode(errors="surrogateescape"),
-                INTERNAL_ERROR_RETURNCODE,
-            )
+            return BinResult.internal_failure(str(e))
 
         return BinResult(res.stdout, res.stderr, res.returncode)
 

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -154,6 +154,11 @@ def test_result_typing() -> None:
         host.BinResult(b"out", b"err", 0, True)
 
 
+def test_env() -> None:
+    res = host.local.run('echo ">>$FOO<<"', env={"FOO": "xx1"})
+    assert res == host.Result(">>xx1<<\n", "", 0)
+
+
 def test_cwd() -> None:
     res = host.local.run("pwd", cwd="/usr/bin")
     assert res == host.Result("/usr/bin\n", "", 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dataclasses
 jc
 jinja2
 pyserial
+paramiko


### PR DESCRIPTION
Add a `host.RemoteHost` class that implements the `host.Host` API (in particular, the `host.Host.run()` method). In general, the API should behave very similar whether you run `host.LocalHost().run()` or `host.RemoteHost("localhost", ...).run()`. In particular, the arguments `env`, `cwd`, `sudo` should work in a very similar manner whether you run locally or remotely.

`host.RemoteHost` is mostly stateless and immutable. It has some internal state (the paramiko client), but that is per-thread (thread-local storage) and hidden from the user.

Also add a `log_lineoutput:bool` argument to `Host.run()`. When set to True, we won't log stdout/stderr at the end, but rather line by line. That is useful for long-running commands that print their progress (for example `rsh.run("dnf upgrade -y", log_lineoutput=True)`). It is also what CDA's `host.Host._run_remote()` always does (but not `host.Host._run_local()`).