### PR TITLE
[th/flake8-dict-from-keys] netdev: fix flake8 warnings by using dict.fromkeys()

### DIFF
--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -580,7 +580,7 @@ def get_pciaddrs() -> list[str]:
     path = "/sys/bus/pci/devices/"
     pcis = os.listdir(path)
     pcis = [validate_pciaddr(p) for p in pcis if os.path.exists(path + p + "/net/")]
-    pcis2 = {k: None for k in pcis}
+    pcis2 = dict.fromkeys(pcis)
     return list(pcis2)
 
 
@@ -782,7 +782,7 @@ def get_device_infos(with_ethtool: bool = True) -> list[dict[str, Any]]:
     devices: set[tuple[Optional[str], Optional[str]]] = set()
 
     link_infos: dict[str, Optional[IPRouteLinkEntry]]
-    link_infos = {ifname: None for ifname in get_ifnames()}
+    link_infos = dict.fromkeys(get_ifnames())
     link_infos.update((lnk.ifname, lnk) for lnk in ip_links())
 
     ifnames_tmp = set(link_infos)


### PR DESCRIPTION
Version 7.1.1 (flake8-comprehensions: 3.15.0, mccabe: 0.7.0, pycodestyle: 2.12.1, pyflakes: 3.2.0) CPython 3.11.9 on Linux
```
./ktoolbox/netdev.py:583:13: C420 Unnecessary dict comprehension - rewrite using dict.fromkeys().
./ktoolbox/netdev.py:785:18: C420 Unnecessary dict comprehension - rewrite using dict.fromkeys().
```