### PR TITLE
[th/structparse-pop] common,testConfig: add helper methods for parsing simple type in testConfig

### DIFF
--- a/evalConfig.py
+++ b/evalConfig.py
@@ -5,8 +5,6 @@ from typing import Any
 from ktoolbox import common
 from ktoolbox.common import StructParseBase
 from ktoolbox.common import strict_dataclass
-from ktoolbox.common import structparse_check_empty_dict
-from ktoolbox.common import structparse_check_strdict
 
 import testType
 
@@ -21,15 +19,8 @@ class TestItem(StructParseBase):
 
     @staticmethod
     def parse(yamlidx: int, yamlpath: str, arg: Any) -> "TestItem":
-        vdict = structparse_check_strdict(arg, yamlpath)
-
-        v = vdict.pop("threshold", None)
-        try:
-            threshold = float(v)
-        except ValueError:
-            raise ValueError(f"{yamlpath}.threshold: expected a number but got {v}")
-
-        structparse_check_empty_dict(vdict, yamlpath)
+        with common.structparse_with_strdict(arg, yamlpath) as varg:
+            threshold = common.structparse_pop_float(*varg.for_key("threshold"))
 
         return TestItem(
             yamlidx=yamlidx,
@@ -55,18 +46,22 @@ class TestCaseData(StructParseBase):
 
     @staticmethod
     def parse(yamlidx: int, yamlpath: str, arg: Any) -> "TestCaseData":
-        vdict = structparse_check_strdict(arg, yamlpath)
+        with common.structparse_with_strdict(arg, yamlpath) as varg:
 
-        v = vdict.pop("id", None)
-        try:
-            test_case_type = common.enum_convert(TestCaseType, v)
-        except ValueError:
-            raise ValueError(f'{yamlpath}.id: invalid value "{v}"')
+            test_case_type = common.structparse_pop_enum(
+                *varg.for_key("id"),
+                enum_type=TestCaseType,
+            )
 
-        normal = TestItem.parse(0, f"{yamlpath}.Normal", vdict.pop("Normal", None))
-        reverse = TestItem.parse(0, f"{yamlpath}.Reverse", vdict.pop("Reverse", None))
+            normal = common.structparse_pop_obj(
+                *varg.for_key("Normal"),
+                construct=TestItem.parse,
+            )
 
-        structparse_check_empty_dict(vdict, yamlpath)
+            reverse = common.structparse_pop_obj(
+                *varg.for_key("Reverse"),
+                construct=TestItem.parse,
+            )
 
         return TestCaseData(
             yamlidx=yamlidx,
@@ -97,7 +92,7 @@ class TestTypeData(StructParseBase):
             test_type = common.enum_convert(TestType, key)
         except Exception:
             raise ValueError(
-                f"{yamlpath_base}.[{yamlidx}].: expects a test type as key like iperf-tcp but got {key}"
+                f'"{yamlpath_base}.[{yamlidx}]": expects a test type as key like iperf-tcp but got {key}'
             )
 
         yamlpath = f"{yamlpath_base}.{test_type.name}"
@@ -106,17 +101,17 @@ class TestTypeData(StructParseBase):
             test_type_handler = testType.TestTypeHandler.get(test_type)
         except Exception:
             raise ValueError(
-                f'{yamlpath}: test type "{test_type}" has no handler implementation'
+                f'"{yamlpath}": test type "{test_type}" has no handler implementation'
             )
 
         if not isinstance(arg, list):
             raise ValueError(f'"{yamlpath}": expects a list of test cases')
         test_cases = {}
-        for yamlidx2, arg in enumerate(arg):
-            c = TestCaseData.parse(yamlidx2, f"{yamlpath}[{yamlidx}]", arg)
+        for yamlidx2, arg2 in enumerate(arg):
+            c = TestCaseData.parse(yamlidx2, f"{yamlpath}[{yamlidx}]", arg2)
             if c.test_case_type in test_cases:
                 raise ValueError(
-                    f"{yamlpath}[{yamlidx2}]: duplicate key {c.test_case_type.name}"
+                    f'"{yamlpath}[{yamlidx2}]": duplicate key {c.test_case_type.name}'
                 )
             test_cases[c.test_case_type] = c
 
@@ -140,7 +135,7 @@ class Config(StructParseBase):
     @staticmethod
     def parse(arg: Any) -> "Config":
         yamlpath = ""
-        vdict = structparse_check_strdict(arg, yamlpath)
+        vdict = common.structparse_check_strdict(arg, yamlpath)
 
         configs = {}
 
@@ -153,7 +148,7 @@ class Config(StructParseBase):
             )
             if c.test_type in configs:
                 raise ValueError(
-                    f"{yamlpath}.[{yamlidx2}]: duplicate key {c.test_type.name}"
+                    f'"{yamlpath}.[{yamlidx2}]": duplicate key {c.test_type.name}'
                 )
             configs[c.test_type] = c
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,5 @@ files = .
 ignore_missing_imports = true
 [mypy-serial]
 ignore_missing_imports = true
+[mypy-pytest]
+ignore_missing_imports = true


### PR DESCRIPTION
Our input configuration is YAML, and we parse it into a `TestConfig` class. The configuration contains many simple types (`str`, `int`, `bool`, `Enum`), which should be handled in a similar fashion.

Add helper methods for handling such types and use them. The benefit is that how to handle a `str`, `int`, `bool`, `Enum` is now a common receipt instead of reimplemented at different places.

There are still complex properties that require specific code for parsing and validating them.

Note that the `common.structparse_pop_*()` methods accept a "default" argument. If the argument is missing, the parameter is mandatory. If it's given, it can be an `Optional[T]` to also return `None` for missing keys. In any case, mypy will understand depending on the "default" argument whether the function returns a `T` or `Union[None, T]`.