### PR TITLE
[th/unwrap] common: add unwrap() helper

### DIFF
--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -135,6 +135,19 @@ def iter_filter_none(lst: Iterable[Optional[T]]) -> Iterable[T]:
             yield v
 
 
+def unwrap(val: Optional[T], *, or_else: Optional[T] = None) -> T:
+    # Like Rust's unwrap. Get the value or die (with an exception).
+    #
+    # The error message here is not good, so this function
+    # is more for asserting (and shutting up the type checker)
+    # when we expect that the value is not set.
+    if val is None:
+        if or_else is not None:
+            return or_else
+        raise ValueError("Unexpected optional value unset")
+    return val
+
+
 def enum_convert(
     enum_type: Type[E],
     value: Any,


### PR DESCRIPTION
This behaves similar to Rust's unwrap() (hence the name).

It's really only useful for assertion use when we require that the value is set.

In that case, the linter might complain if we use the value as Optional[T].

This is thus both a runtime assertion and to make the linter happy, in one.

Note that the generated error message is not very good because there is no context for a better message (though, you get the backtrace, so it's not horrible). That is why it's only for assertion use.