### PR TITLE
Update traffic flow test tool to have sriov pod yaml use secondary network

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ tft:
           - name: (15)
           - name: (15)
         secondary_network_nad: "(16)"
-kubeconfig: (17)
-kubeconfig_infra: (17)
+	resource_name: "(17)"
+kubeconfig: (18)
+kubeconfig_infra: (18)
 ```
 
 1. "name" - This is the name of the test. Any string value to identify the test.
@@ -100,8 +101,10 @@ kubeconfig_infra: (17)
     | measure_cpu      | Measure CPU Usage    |
     | measure_power    | Measure Power Usage  |
     | validate_offload | Verify OvS Offload   |
-16. "secondary_network_nad" - The name of the secondary network for multi-homing and multi-networkpolicies tests.
-17. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
+16. "secondary_network_nad" - (Optional) - The name of the secondary network for multi-homing and multi-networkpolicies tests. For tests except 27-29, the primary network will be used if unspecified (the default which is None). For mandatory tests 27-29 it defaults to "ocp-secondary" if not set.
+17. "resource_name" - (Optional) - The resource name for tests that require resource limit and requests to be set. This field is optional and will default to None if not set, but if secondary network nad is defined, traffic flow test
+tool will try to autopopulate resource_name based on the secondary+network_nad provided.
+18. "kubeconfig", "kubeconfig_infra": if set to non-empty strings, then these are the KUBECONFIG
   files. "kubeconfig_infra" must be set for DPU cluster mode. If both are empty, the configs
   are detected based on the files we find at /root/kubeconfig.*.
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,10 @@ tft:
           - name: measure_cpu
           - name: measure_power
           - name: validate_offload
-        # Secondary network is required for tests 27, 28 and 29
-        # secondary_network_nad: "default/ocp-secondary"
+        # (Optional) Secondary network is required for tests 27-29. For these tests, it is mandatory; if not specified, it will default to "ocp-secondary." For other tests, 
+        # the secondary network is optional. If it is undefined, the tests will default to using the primary network.
+        # (Optional) Define the resource name for SRIOV pods, where the resource requests and limits are configured. Defaults to None if not set. If the user specified the secondary nad 
+        # it will try to autopopulate the resource name based on the nad. 
+        # resource_name: "openshift.io/dpu"
 kubeconfig:
 kubeconfig_infra:

--- a/manifests/sriov-pod.yaml.j2
+++ b/manifests/sriov-pod.yaml.j2
@@ -3,8 +3,9 @@ kind: Pod
 metadata:
   namespace: {{ name_space }}
   name: {{ pod_name }}
-  annotations:
-    v1.multus-cni.io/default-network: {{ default_network }}
+  annotations: {% if not use_secondary_network %}
+    v1.multus-cni.io/default-network: {{ default_network }} {% else %}
+    k8s.v1.cni.cncf.io/networks: {{ secondary_network_nad }} {% endif %}
   labels:
     tft-tests: "{{ index }}"
     tft-port: "{{ port }}"
@@ -16,4 +17,9 @@ spec:
     image: {{ test_image }}
     command: {{ command }}
     args: {{ args }}
-    imagePullPolicy: {{ image_pull_policy }}
+    imagePullPolicy: {{ image_pull_policy }} {% if use_secondary_network and resource_name %}
+    resources:
+      requests:
+        {{ resource_name }}: '1'
+      limits:
+        {{ resource_name }}: '1' {% endif %}


### PR DESCRIPTION
We need to be able to test out pod2pod traffic on IPUs. Currently the dpu-operator does not deploy a webhook,so we are modifying the SRIOV pod yaml to be able to use secondary network nad and also have resource requests and limits added to the SRIOV pod if the secondary_network_nad is present.  In addition network-attachment-definition no longer by default should contain the namespace. 

In order to use this feature,

1. add `secondary_network_nad` to the yaml. 
2. `resource_name` is optional, you can set it if you would like. Otherwise the program does fetch it for us.
3. run standard pod to pod traffic on an IPU cluster. Populate config file as normal.
4. Pods will properly pass traffic through the secondary network. 

Jira issue: https://issues.redhat.com/browse/IIC-193