### PR TITLE
[th/firewall-doc] document firewall methods and minor improvements

### DIFF
--- a/ktoolbox/firewall.py
+++ b/ktoolbox/firewall.py
@@ -69,8 +69,8 @@ def nft_call(
     data: str,
     rsh: host.Host = host.local,
     *,
-    nft_cmd: str = "nft",
-) -> bool:
+    nft_cmd: str = "nft -f -",
+) -> host.Result:
     """
     Calls a subprocess (via rsh.run()) with `nft -f -`. Data is fed into
     stdin of the nft process.
@@ -78,8 +78,8 @@ def nft_call(
     Args:
         data: the data for nft. Use for example nft_data_masquerade_up() to generate it.
         rsh: the Host instance one which to call nft.
-        nft_cmd: if given, the "nft" command. Defaults to "nft".
+        nft_cmd: defaults to "nft -f -". This is a shell script that receives data on stdin.
+            Note that if you set this, you must make sure that this is the full shell script
+            that does something similar as "nft -f -".
     """
-    return rsh.run(
-        f"printf '%s' {shlex.quote(data)} | {shlex.quote(nft_cmd)} -f -"
-    ).success
+    return rsh.run(f"printf '%s' {shlex.quote(data)} | {{ {nft_cmd} ; }}")

--- a/ktoolbox/firewall.py
+++ b/ktoolbox/firewall.py
@@ -30,6 +30,22 @@ def nft_data_masquerade_up(
     subnet: str,
     ifname: str,
 ) -> str:
+    """
+    Generate the input for `nft -f -` to setup masquerading. It only creates
+    a string. Pass this to nft_call().
+
+    Args:
+        table_name: the nft table to use. All changes are solely in this table, and you
+          can discard the changes by deleting this table (see also, nft_data_masquerade_down()).
+        subnet: the IPv4 subnet to masquerade. This is the range of the IP addresses of the clients that want
+          to do SNAT.
+        ifname: the interface to which the clients that want dynamic SNAT to be done. This is not the
+          WAN interface, instead, masquerading detects the external IP address automatically.
+
+    Example:
+
+        nft_call(nft_data_masquerade_up(table_name="mytable", subnet="192.168.5.0/24", ifname="eth2"))
+    """
     # Taken from NetworkManager:
     # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/8488162d1069defada6be0666175ffd10f333f9d/src/core/nm-firewall-utils.c#L688
     return _nft_cmd_table(up=True, family="ip", table_name=table_name) + (
@@ -55,6 +71,15 @@ def nft_call(
     *,
     nft_cmd: str = "nft",
 ) -> bool:
+    """
+    Calls a subprocess (via rsh.run()) with `nft -f -`. Data is fed into
+    stdin of the nft process.
+
+    Args:
+        data: the data for nft. Use for example nft_data_masquerade_up() to generate it.
+        rsh: the Host instance one which to call nft.
+        nft_cmd: if given, the "nft" command. Defaults to "nft".
+    """
     return rsh.run(
         f"printf '%s' {shlex.quote(data)} | {shlex.quote(nft_cmd)} -f -"
     ).success

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -112,6 +112,9 @@ class BaseResult(_BaseResult[T]):
             return self.forced_success
         return self.returncode == 0
 
+    def __bool__(self) -> bool:
+        return self.success
+
     def debug_str(self, *, with_output: bool = True) -> str:
         if self.forced_success is None or self.forced_success == (self.returncode == 0):
             if self.success:

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -226,6 +226,7 @@ def test_host_check_success() -> None:
     res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.success)
     assert res == host.Result("foo", "", 74)
     assert not res.success
+    assert not res
 
     res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.out == "foo")
     assert res == host.Result("foo", "", 74, forced_success=True)
@@ -236,6 +237,7 @@ def test_host_check_success() -> None:
     )
     assert binres == host.BinResult(b"foo", b"", 74, forced_success=True)
     assert binres.success
+    assert binres
 
 
 def test_host_file_exists() -> None:


### PR DESCRIPTION
Commits:

- host: let host.Result evaluate in a boolean context
- firewall: add docs for nft_data_masquerade_up() and nft_call()
- firewall: return host.Result from firewall.nft_call() and take shell script


Add doc since the usage may not be obvious. Also, add a unit test, which might help to see the usage.