### PR TITLE
[th/containerfile-workdir] Containerfile: set default workdir to "/opt/ocp-tft" and install nftables

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -60,5 +60,6 @@ COPY ./scripts/simple-tcp-server-client.py /usr/bin/simple-tcp-server-client
 
 COPY ./images/container-entry-point.sh /usr/bin/container-entry-point.sh
 
+WORKDIR /opt/ocp-tft
 ENTRYPOINT ["/usr/bin/container-entry-point.sh"]
 CMD ["/usr/bin/sleep", "infinity"]

--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,7 @@ RUN dnf install \
         nc \
         net-tools \
         netperf \
+        nftables \
         pciutils \
         procps-ng \
         python3 \


### PR DESCRIPTION
these two things seem potentially useful to have in our container.

- install `nftables`. It adds 1.4MB, but IMO size of the container is not a major goal, but being useful is.
- set `WORDIR /opt/ocp-tft`. This way, we can directly `python -c "import ...` our Python code. It's more useful than `/` as working directory.