### PR TITLE
[th/delete-ignore-noexist] prevent error message in logfile when deleting non-existing `multi-networkpolicies`

### DIFF
--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -183,6 +183,7 @@ class BinResult(BaseResult[bytes]):
             self.out.decode(errors=errors),
             self.err.decode(errors=errors),
             self.returncode,
+            forced_success=self.forced_success,
         )
 
     def dup_with_forced_success(self, forced_success: bool) -> "BinResult":

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
+from typing import AnyStr
 from typing import Callable
 from typing import Optional
 from typing import Union
@@ -84,22 +85,19 @@ def _unique_log_id() -> int:
         return _unique_log_id_value
 
 
-T = typing.TypeVar("T", str, bytes)
-
-
 @dataclass(frozen=True)
-class _BaseResult(ABC, typing.Generic[T]):
+class _BaseResult(ABC, typing.Generic[AnyStr]):
     # _BaseResult only exists to have the first 3 parameters positional
     # arguments and the subsequent parameters (in BaseResult) marked as
     # KW_ONLY_DATACLASS. Once we no longer support Python 3.9, the classes
     # can be merged.
-    out: T
-    err: T
+    out: AnyStr
+    err: AnyStr
     returncode: int
 
 
 @dataclass(frozen=True, **KW_ONLY_DATACLASS)
-class BaseResult(_BaseResult[T]):
+class BaseResult(_BaseResult[AnyStr]):
     # In most cases, "success" is the same as checking for returncode zero.  In
     # some cases, it can be overwritten to be of a certain value.
     forced_success: Optional[bool] = dataclasses.field(
@@ -144,15 +142,18 @@ class BaseResult(_BaseResult[T]):
     def match(
         self,
         *,
-        out: Optional[Union[T, re.Pattern[T]]] = None,
-        err: Optional[Union[T, re.Pattern[T]]] = None,
+        out: Optional[Union[AnyStr, re.Pattern[AnyStr]]] = None,
+        err: Optional[Union[AnyStr, re.Pattern[AnyStr]]] = None,
         returncode: Optional[int] = None,
     ) -> bool:
         if returncode is not None:
             if self.returncode != returncode:
                 return False
 
-        def _check(val: T, compare: Optional[Union[T, re.Pattern[T]]]) -> bool:
+        def _check(
+            val: AnyStr,
+            compare: Optional[Union[AnyStr, re.Pattern[AnyStr]]],
+        ) -> bool:
             if compare is None:
                 return True
             if isinstance(compare, re.Pattern):

--- a/ktoolbox/k8sClient.py
+++ b/ktoolbox/k8sClient.py
@@ -201,3 +201,16 @@ class K8sClient:
             )
 
         return result
+
+    @staticmethod
+    def check_success_delete_ignore_noexist(
+        resource_type: str,
+    ) -> typing.Callable[[host.Result], bool]:
+        return lambda r: (
+            r.returncode == 0
+            or r.match(
+                out="",
+                err=f'error: the server doesn\'t have a resource type "{resource_type}"\n',
+                returncode=1,
+            )
+        )

--- a/ktoolbox/test_common.py
+++ b/ktoolbox/test_common.py
@@ -321,7 +321,7 @@ def test_strict_dataclass() -> None:
     C7([])
     C7([TstPodInfo("name", TstPodType.NORMAL, True, 5)])
     with pytest.raises(TypeError):
-        C7([TstPodInfo("name", TstPodType.NORMAL, True, 5), None])  # type:ignore
+        C7([TstPodInfo("name", TstPodType.NORMAL, True, 5), None])  # type: ignore
 
     @common.strict_dataclass
     @dataclasses.dataclass
@@ -1194,7 +1194,7 @@ def test_structparse_pop_objlist_as_dict() -> None:
         typing.assert_type(val2, dict[str, str])
 
     with pytest.raises(RuntimeError):
-        common.structparse_pop_objlist_to_dict(  # type:ignore
+        common.structparse_pop_objlist_to_dict(  # type: ignore
             {"foo": [0, 1, 2]},
             "path",
             "foo",

--- a/trafficFlowTests.py
+++ b/trafficFlowTests.py
@@ -33,20 +33,18 @@ class TrafficFlowTests:
 
     def _cleanup_previous_testspace(self, cfg_descr: ConfigDescriptor) -> None:
         namespace = cfg_descr.get_tft().namespace
+        client = cfg_descr.tc.client_tenant
         logger.info(
             f"Cleaning pods, services and multi-networkpolicies with label tft-tests in namespace {namespace}"
         )
-        cfg_descr.tc.client_tenant.oc(
-            "delete pods -l tft-tests",
-            namespace=namespace,
-        )
-        cfg_descr.tc.client_tenant.oc(
-            "delete services -l tft-tests",
-            namespace=namespace,
-        )
-        cfg_descr.tc.client_tenant.oc(
+        client.oc("delete pods -l tft-tests", namespace=namespace)
+        client.oc("delete services -l tft-tests", namespace=namespace)
+        client.oc(
             "delete multi-networkpolicies -l tft-tests",
             namespace=namespace,
+            check_success=client.check_success_delete_ignore_noexist(
+                "multi-networkpolicies"
+            ),
         )
 
         logger.info(


### PR DESCRIPTION
During cleanup, we always call `kubectl --kubeconfig /root/kubeconfig.nicmodecluster -n default delete multi-networkpolicies -l tft-tests`. But for most test cases we won't have such a resource, so the command fails.

Since `k8sClient.oc()` by default has `may_fail=False`, this results in an error in the log:

```
2024-09-16 20:19:03.270 INFO    [th:140347998742336]: Cleaning pods, services and multi-networkpolicies with label tft-tests in namespace default
2024-09-16 20:19:04.467 ERROR   [th:140347998742336]: cmd[8435;localhost]: └──> 'kubectl --kubeconfig /root/kubeconfig.nicmodecluster -n default delete multi-networkpolicies -l tft-tests': failed (exit 1); err='error: the server doesn\'t have a resource type "multi-networkpolicies"\n'
```

It's important that the log file is not spammed with error messages for things that are no errors. Do something about that.


See: https://net-hw-ci-jenkins-csb-nst.apps.ocp-c1.prod.psi.redhat.com/view/Custom%20OVNK8%20Testing%20(NIC%20Mode)/job/99_Lab227_New_OVN_Traffic_Flow/189/consoleFull