### PR TITLE
[th/fix-log-config] common: improve log_config_logger() for multiple calls

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -176,7 +176,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_loggers(args.verbose, "tft", "ktoolbox")
+    common.log_config_logger(args.verbose, "tft", "ktoolbox")
 
     if not Path(args.config).exists():
         logger.error(f"No config file found at {args.config}, exiting")

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def parse_args() -> argparse.Namespace:
 
     args = parser.parse_args()
 
-    common.log_config_loggers(args.verbosity, "tft", "ktoolbox")
+    common.log_config_logger(args.verbosity, "tft", "ktoolbox")
 
     if not Path(args.config).exists():
         raise ValueError("Must provide a valid config.yaml file (see config.yaml)")

--- a/print_results.py
+++ b/print_results.py
@@ -47,7 +47,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    common.log_config_loggers(args.verbose, "tft", "ktoolbox")
+    common.log_config_logger(args.verbose, "tft", "ktoolbox")
 
     test_results = read_test_result(args.result)
 


### PR DESCRIPTION
- previously, common.log_config_loggers() would each time add a new handler. That meant, if you call configure logger more than once, multiple handlers are added and multiple lines are printed.

  This is not uncommon, because we might want initially setup one logging level, then read further configuration, and reconfigure the loggers with the new level.

  Instead, the handler that we add now has a particular internal type common._LogHandler. If such a handler is already registered, subsequent calls will not create a new handler but simply reconfigure the existing one.

- rename common.log_config_loggers() to common.log_config_logger(). While the function takes a variadic list of loggers as argument to configure any number of loggers, this seems the better name. This means to merge common.log_config_logger() and common.log_config_loggers(). There is now only one variant that supports both use cases.