### PR TITLE
common: add ExtendedLogger() class

### DIFF
--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -1436,13 +1436,21 @@ def log_argparse_add_argument_verbose(parser: "argparse.ArgumentParser") -> None
     )
 
 
-def log_argparse_add_argument_verbosity(parser: "argparse.ArgumentParser") -> None:
+def log_argparse_add_argument_verbosity(
+    parser: "argparse.ArgumentParser",
+    *,
+    default: Optional[str] = None,
+) -> None:
+    if default is None:
+        msg_default = "default: info, overwrites KTOOLBOX_LOGLEVEL environment"
+    else:
+        msg_default = f"default: {repr(default)}"
     parser.add_argument(
         "-v",
         "--verbosity",
         choices=["debug", "info", "warning", "error", "critical"],
-        default=None,
-        help="Set the logging level (default: info, overwrites KTOOLBOX_LOGLEVEL environment). Set KTOOLBOX_ALL_LOGGERS to configure all loggers.",
+        default=default,
+        help=f"Set the logging level ({msg_default}). Set KTOOLBOX_ALL_LOGGERS to configure all loggers.",
     )
 
 

--- a/ktoolbox/test_logger.py
+++ b/ktoolbox/test_logger.py
@@ -1,0 +1,27 @@
+import logging
+
+from . import common
+
+
+def test_logger_1() -> None:
+    name = "foo.1"
+    logger = common.ExtendedLogger(name)
+    assert isinstance(logger, logging.Logger)
+    assert isinstance(logger, common.ExtendedLogger)
+    assert logger.name == name
+    assert logger.wrapped_logger is logging.getLogger(name)
+
+    common.log_config_logger(logging.DEBUG, logger)
+    assert logger.level == logging.DEBUG
+    assert logger.wrapped_logger.level == logging.DEBUG
+
+    common.log_config_logger(logging.INFO, logger, logger.wrapped_logger)
+    assert logger.level == logging.INFO
+    assert logger.wrapped_logger.level == logging.INFO
+    assert logging.getLogger(name).level == logging.INFO
+
+    assert logger.handlers is logger.wrapped_logger.handlers
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], common._LogHandler)
+
+    logger.info(f"test {name}")


### PR DESCRIPTION
The benefit of an ExtendedLogger instance is that it provides additional convenience methods (currently only `error_and_exit()`).

All other Logger methods are delegated to the wrapped logger instance. As the method `error_and_exit()` is stateless, there is no difference between using the extended logger or the wrapped logger.

Hence, with

    ext_logger = common.ExtendedLogger("foo")
    real_logger = logging.getLogger("foo")

calling a method like `debug()` will yield the same result. That is a promise.

The benefit here is that the extended logger has convenience methods on top. While the user does not get access to them via `logging.getLogger()`, they can create (and cache) an `ExtendedLogger` instance for that. The linter will nicely understand when you may call `logger.error_and_exit()`.