### PR TITLE
[th/rework-register-modules] rework how TestTypeHandler and pluginbase.Plugin modules register

### DIFF
--- a/pluginMeasureCpu.py
+++ b/pluginMeasureCpu.py
@@ -37,7 +37,7 @@ class PluginMeasureCpu(pluginbase.Plugin):
         ]
 
 
-plugin = PluginMeasureCpu()
+plugin = pluginbase.register_plugin(PluginMeasureCpu())
 
 
 class TaskMeasureCPU(PluginTask):

--- a/pluginMeasurePower.py
+++ b/pluginMeasurePower.py
@@ -40,7 +40,7 @@ class PluginMeasurePower(pluginbase.Plugin):
         ]
 
 
-plugin = PluginMeasurePower()
+plugin = pluginbase.register_plugin(PluginMeasurePower())
 
 
 def _extract(ipmitool_output: str) -> Optional[int]:

--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -136,7 +136,7 @@ class PluginValidateOffload(pluginbase.Plugin):
         ]
 
 
-plugin = PluginValidateOffload()
+plugin = pluginbase.register_plugin(PluginValidateOffload())
 
 
 class TaskValidateOffload(PluginTask):

--- a/testTypeHttp.py
+++ b/testTypeHttp.py
@@ -30,7 +30,7 @@ class TestTypeHandlerHttp(TestTypeHandler):
         return (s, c)
 
 
-test_type_handler_http = TestTypeHandlerHttp()
+TestTypeHandler.register_test_type(TestTypeHandlerHttp())
 
 
 class HttpServer(task.ServerTask):

--- a/testTypeIperf.py
+++ b/testTypeIperf.py
@@ -64,8 +64,8 @@ class TestTypeHandlerIperf(TestTypeHandler):
         return False
 
 
-test_type_handler_iperf_tcp = TestTypeHandlerIperf(TestType.IPERF_TCP)
-test_type_handler_iperf_udp = TestTypeHandlerIperf(TestType.IPERF_UDP)
+TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_TCP))
+TestTypeHandler.register_test_type(TestTypeHandlerIperf(TestType.IPERF_UDP))
 
 
 class IperfServer(task.ServerTask):

--- a/testTypeNetPerf.py
+++ b/testTypeNetPerf.py
@@ -71,10 +71,8 @@ class TestTypeHandlerNetPerf(TestTypeHandler):
         return (s, c)
 
 
-test_type_handler_netperf_tcp_stream = TestTypeHandlerNetPerf(
-    TestType.NETPERF_TCP_STREAM
-)
-test_type_handler_netperf_tcp_rr = TestTypeHandlerNetPerf(TestType.NETPERF_TCP_RR)
+TestTypeHandler.register_test_type(TestTypeHandlerNetPerf(TestType.NETPERF_TCP_STREAM))
+TestTypeHandler.register_test_type(TestTypeHandlerNetPerf(TestType.NETPERF_TCP_RR))
 
 
 class NetPerfServer(task.ServerTask):

--- a/testTypeSimple.py
+++ b/testTypeSimple.py
@@ -28,7 +28,7 @@ class TestTypeHandlerSimple(TestTypeHandler):
         return (s, c)
 
 
-test_type_handler_simple = TestTypeHandlerSimple()
+TestTypeHandler.register_test_type(TestTypeHandlerSimple())
 
 CMD_SIMPLE_TCP_SERVER_CLIENT = "simple-tcp-server-client"
 


### PR DESCRIPTION
I think this approach is simpler. That is, it's harder to get wrong and it's fewer lines of code.

That's interesting, when we add more test-types or plugins.