### PR TITLE
[th/print-results-improvements] rework how print_results.py shows the result

### DIFF
--- a/pluginValidateOffload.py
+++ b/pluginValidateOffload.py
@@ -112,7 +112,7 @@ def check_no_traffic_on_vf_rep(
             return f"missing ethtool output for {direction}"
         return None
     if end - start >= VF_REP_TRAFFIC_THRESHOLD:
-        return "traffic on VF rep detected"
+        return f"traffic on VF rep detected for {repr(direction)} ({end-start} packets is higher than threshold {VF_REP_TRAFFIC_THRESHOLD})"
     return None
 
 

--- a/pluginbase.py
+++ b/pluginbase.py
@@ -74,6 +74,8 @@ class Plugin(ABC):
             tft_metadata=md,
             plugin_name=self.PLUGIN_NAME,
             success=plugin_output.success,
+            msg=plugin_output.err_msg,
+            plugin_output=plugin_output,
         )
 
 

--- a/tftbase.py
+++ b/tftbase.py
@@ -221,24 +221,6 @@ class TestMetadata:
 
 @strict_dataclass
 @dataclass(frozen=True, kw_only=True)
-class PluginResult:
-    """Result of a single plugin from a given run
-
-    Attributes:
-        plugin_name: the plugin
-        test_id: TestCaseType enum representing the type of traffic test (i.e. POD_TO_POD_SAME_NODE <1> )
-        test_type: TestType enum representing the traffic protocol (i.e. iperf_tcp)
-        reverse: Specify whether test is client->server or reversed server->client
-        success: boolean representing whether the test passed or failed
-    """
-
-    tft_metadata: TestMetadata
-    plugin_name: str
-    success: bool
-
-
-@strict_dataclass
-@dataclass(frozen=True, kw_only=True)
 class BaseOutput:
     success: bool = True
     msg: Optional[str] = None
@@ -345,6 +327,26 @@ class TestResult:
     msg: Optional[str] = None
     bitrate_gbps: Bitrate
     bitrate_threshold: Optional[float]
+
+
+@strict_dataclass
+@dataclass(frozen=True, kw_only=True)
+class PluginResult:
+    """Result of a single plugin from a given run
+
+    Attributes:
+        plugin_name: the plugin
+        test_id: TestCaseType enum representing the type of traffic test (i.e. POD_TO_POD_SAME_NODE <1> )
+        test_type: TestType enum representing the traffic protocol (i.e. iperf_tcp)
+        reverse: Specify whether test is client->server or reversed server->client
+        success: boolean representing whether the test passed or failed
+    """
+
+    tft_metadata: TestMetadata
+    plugin_name: str
+    success: bool
+    msg: Optional[str]
+    plugin_output: PluginOutput
 
 
 @strict_dataclass

--- a/tftbase.py
+++ b/tftbase.py
@@ -358,6 +358,96 @@ class TestResultCollection:
     plugin_failing: list[PluginResult]
 
 
+@common.strict_dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True, unsafe_hash=True)
+class GroupedResult:
+    tft_metadata: TestMetadata
+    test_results: list[TestResult] = dataclasses.field(
+        default_factory=list,
+        compare=False,
+    )
+    plugin_results: list[PluginResult] = dataclasses.field(
+        default_factory=list,
+        compare=False,
+    )
+
+    @property
+    def results_all_good(self) -> bool:
+        return all(test_result.success for test_result in self.test_results)
+
+    @property
+    def plugins_all_good(self) -> bool:
+        return all(plugin_result.success for plugin_result in self.plugin_results)
+
+    @property
+    def all_good(self) -> bool:
+        return self.results_all_good and self.plugins_all_good
+
+    @staticmethod
+    def _dict_get_or_default(
+        grouped_results: dict[TestMetadata, "GroupedResult"],
+        tft_metadata: TestMetadata,
+    ) -> "GroupedResult":
+        grouped_result = grouped_results.get(tft_metadata, None)
+        if grouped_result is None:
+            grouped_result = GroupedResult(tft_metadata=tft_metadata)
+            grouped_results[tft_metadata] = grouped_result
+        return grouped_result
+
+    @staticmethod
+    def _build_list(
+        test_results: TestResultCollection,
+    ) -> list["GroupedResult"]:
+        grouped_results: dict[TestMetadata, GroupedResult] = {}
+        for test_result in test_results.passing + test_results.failing:
+            grouped_result = GroupedResult._dict_get_or_default(
+                grouped_results,
+                test_result.tft_metadata,
+            )
+            grouped_result.test_results.append(test_result)
+        for plugin_result in test_results.plugin_passing + test_results.plugin_failing:
+            grouped_result = GroupedResult._dict_get_or_default(
+                grouped_results,
+                plugin_result.tft_metadata,
+            )
+            grouped_result.plugin_results.append(plugin_result)
+
+        return list(grouped_results.values())
+
+    @staticmethod
+    def _split_list(grouped_results: list["GroupedResult"]) -> tuple[
+        list["GroupedResult"],
+        list["GroupedResult"],
+    ]:
+        result_success = [
+            group_result for group_result in grouped_results if group_result.all_good
+        ]
+        result_failed = [
+            group_result
+            for group_result in grouped_results
+            if not group_result.all_good
+        ]
+
+        def _key_fcn(gr: GroupedResult) -> int:
+            if gr.results_all_good:
+                if gr.plugins_all_good:
+                    return 4
+                return 3
+            return 2
+
+        result_failed.sort(key=_key_fcn)
+
+        return result_success, result_failed
+
+    @staticmethod
+    def grouped_from(test_results: TestResultCollection) -> tuple[
+        list["GroupedResult"],
+        list["GroupedResult"],
+    ]:
+        lst = GroupedResult._build_list(test_results)
+        return GroupedResult._split_list(lst)
+
+
 class TestCaseTypInfo(typing.NamedTuple):
     connection_mode: ConnectionMode
     is_same_node: bool


### PR DESCRIPTION
an attempt to make the results easier to read

- for `validate_offload` plugin, give a better error reason that shows the passed traffic and threshold.
- in `PluginResult` (which is also persisted to JSON), show the `msg` on failure and the full `plugin_result` details.
- rework how `print_result.sh` shows the output. In particular, print the plugin result. Also, if a plugin indicates failure, the entire run is marked as failed.

Related to https://issues.redhat.com/browse/NHE-1153 , but does not fully fix it.