### PR TITLE
[th/generate-eval-config] add new tool for generating eval-config thresholds

### DIFF
--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -4,7 +4,8 @@ IPERF_TCP:
     Normal:
       threshold: 18
     Reverse:
-      threshold: 18
+      threshold_rx: 18
+      threshold_tx: 18
   - id: 2 # POD_TO_POD_DIFF_NODE
     Normal:
       threshold: 18

--- a/eval-config.yaml
+++ b/eval-config.yaml
@@ -1,294 +1,291 @@
-# Use `generate_eval_config.py` to update the configuration based on earlier
-# runs.
 IPERF_TCP:
-  - id: 1 # POD_TO_POD_SAME_NODE
-    Normal:
-      threshold: 18
-    Reverse:
-      threshold_rx: 18
-      threshold_tx: 18
-  - id: 2 # POD_TO_POD_DIFF_NODE
+  - id: POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 3 # POD_TO_HOST_SAME_NODE
+  - id: POD_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 4 # POD_TO_HOST_DIFF_NODE
+  - id: POD_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: POD_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 13 # HOST_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 14 # HOST_TO_HOST_DIFF_NODE
+  - id: HOST_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 15 # HOST_TO_POD_SAME_NODE
+  - id: HOST_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 16 # HOST_TO_POD_DIFF_NODE
+  - id: HOST_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: HOST_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 25 # POD_TO_EXTERNAL
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
-      threshold: 10
-  - id: 26 # HOST_TO_EXTERNAL
+      threshold: 18
+  - id: POD_TO_EXTERNAL
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+  - id: HOST_TO_EXTERNAL
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
 IPERF_UDP:
-  - id: 1 # POD_TO_POD_SAME_NODE
+  - id: POD_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 2 # POD_TO_POD_DIFF_NODE
+  - id: POD_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 3 # POD_TO_HOST_SAME_NODE
+  - id: POD_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 4 # POD_TO_HOST_DIFF_NODE
+  - id: POD_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 13 # HOST_TO_HOST_SAME_NODE
+  - id: HOST_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 14 # HOST_TO_HOST_DIFF_NODE
+  - id: HOST_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 15 # HOST_TO_POD_SAME_NODE
+  - id: HOST_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 16 # HOST_TO_POD_DIFF_NODE
+  - id: HOST_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 25 # POD_TO_EXTERNAL
+  - id: POD_TO_EXTERNAL
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 26 # HOST_TO_EXTERNAL
+  - id: HOST_TO_EXTERNAL
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
     Normal:
       threshold: 5
     Reverse:

--- a/evalConfig.py
+++ b/evalConfig.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import typing
 import yaml
 
 from collections.abc import Mapping
@@ -8,6 +9,7 @@ from typing import Any
 from typing import Optional
 
 from ktoolbox import common
+from ktoolbox import kyaml
 from ktoolbox.common import StructParseBase
 from ktoolbox.common import StructParseParseContext
 from ktoolbox.common import strict_dataclass
@@ -225,3 +227,12 @@ class Config(StructParseBase):
 
     def serialize(self) -> dict[str, Any]:
         return {k.name: v.serialize() for k, v in self.configs.items()}
+
+    def serialize_to_file(
+        self,
+        filename: str | pathlib.Path | typing.IO[str],
+    ) -> None:
+        kyaml.dump(
+            self.serialize(),
+            filename,
+        )

--- a/evalConfig.py
+++ b/evalConfig.py
@@ -18,6 +18,7 @@ from ktoolbox.common import strict_dataclass
 import testType
 import tftbase
 
+from tftbase import Bitrate
 from tftbase import TestCaseType
 from tftbase import TestType
 
@@ -73,9 +74,21 @@ class TestItem(StructParseBase):
     threshold_rx: Optional[float]
     threshold_tx: Optional[float]
 
+    def _post_check(self) -> None:
+        object.__setattr__(
+            self,
+            "_bitrate",
+            Bitrate(rx=self.threshold_rx, tx=self.threshold_tx),
+        )
+
     @property
     def has_thresholds(self) -> bool:
         return self.threshold_rx is not None or self.threshold_tx is not None
+
+    @property
+    def bitrate(self) -> Bitrate:
+        bitrate: Bitrate = getattr(self, "_bitrate")
+        return bitrate
 
     def get_threshold(
         self,

--- a/evalConfig.py
+++ b/evalConfig.py
@@ -37,7 +37,10 @@ class TestItem(StructParseBase):
         )
 
     def serialize(self) -> dict[str, Any]:
-        return {"threshold": self.threshold}
+        t = self.threshold
+        if t == int(t):
+            t = int(t)
+        return {"threshold": t}
 
 
 @strict_dataclass

--- a/evalConfig.py
+++ b/evalConfig.py
@@ -50,10 +50,14 @@ class TestCaseData(StructParseBase):
     normal: TestItem
     reverse: TestItem
 
-    def get_threshold(self, *, is_reverse: bool) -> float:
+    def get_item(
+        self,
+        *,
+        is_reverse: bool,
+    ) -> TestItem:
         if is_reverse:
-            return self.reverse.threshold
-        return self.normal.threshold
+            return self.reverse
+        return self.normal
 
     @staticmethod
     def parse(pctx: StructParseParseContext) -> "TestCaseData":
@@ -239,3 +243,18 @@ class Config(StructParseBase):
             self.serialize(),
             filename,
         )
+
+    def get_item(
+        self,
+        *,
+        test_type: TestType,
+        test_case_id: TestCaseType,
+        is_reverse: bool,
+    ) -> Optional[TestItem]:
+        test_type_data = self.configs.get(test_type)
+        if test_type_data is None:
+            return None
+        test_case_data = test_type_data.test_cases.get(test_case_id)
+        if test_case_data is None:
+            return None
+        return test_case_data.get_item(is_reverse=is_reverse)

--- a/evaluator.py
+++ b/evaluator.py
@@ -37,9 +37,11 @@ class Evaluator:
             is_reverse=flow_test.tft_metadata.reverse,
         )
 
-        bitrate_threshold: Optional[float] = None
+        bitrate_threshold_rx: Optional[float] = None
+        bitrate_threshold_tx: Optional[float] = None
         if item is not None:
-            bitrate_threshold = item.get_threshold()
+            bitrate_threshold_rx = item.get_threshold(rx=True)
+            bitrate_threshold_tx = item.get_threshold(tx=True)
 
         success = True
         msg: Optional[str] = None
@@ -49,15 +51,19 @@ class Evaluator:
                 msg = f"Run failed: {flow_test.msg}"
             else:
                 msg = "Run failed for unspecified reason"
-        elif not flow_test.bitrate_gbps.is_passing(bitrate_threshold):
+        elif not flow_test.bitrate_gbps.is_passing(bitrate_threshold_rx, rx=True):
             success = False
-            msg = f"Run succeeded but {flow_test.bitrate_gbps} is below threshold {bitrate_threshold}"
+            msg = f"Run succeeded but {flow_test.bitrate_gbps} is below RX threshold {bitrate_threshold_rx}"
+        elif not flow_test.bitrate_gbps.is_passing(bitrate_threshold_tx, tx=True):
+            success = False
+            msg = f"Run succeeded but {flow_test.bitrate_gbps} is below TX threshold {bitrate_threshold_tx}"
 
         return flow_test.clone(
             eval_result=tftbase.EvalResult(
                 success=success,
                 msg=msg,
-                bitrate_threshold=bitrate_threshold,
+                bitrate_threshold_rx=bitrate_threshold_rx,
+                bitrate_threshold_tx=bitrate_threshold_tx,
             ),
         )
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -2,8 +2,8 @@
 
 import argparse
 import logging
+import pathlib
 import sys
-import yaml
 
 from pathlib import Path
 from typing import Optional
@@ -22,24 +22,12 @@ logger = logging.getLogger("tft." + __name__)
 
 
 class Evaluator:
-    def __init__(self, config_path: Optional[str]):
-        if not config_path:
-            eval_config = evalConfig.Config.parse(None)
-        else:
-            try:
-                with open(config_path, encoding="utf-8") as file:
-                    c = yaml.safe_load(file)
-            except Exception as e:
-                raise RuntimeError(f"Failure reading {repr(config_path)}: {e}")
+    eval_config: evalConfig.Config
 
-            try:
-                eval_config = evalConfig.Config.parse(c)
-            except ValueError as e:
-                raise ValueError(f"Failure parsing {repr(config_path)}: {e}")
-            except Exception as e:
-                raise RuntimeError(f"Failure loading {repr(config_path)}: {e}")
-
-        self.eval_config = eval_config
+    def __init__(self, config: Optional[evalConfig.Config | str | pathlib.Path]):
+        if not isinstance(config, evalConfig.Config):
+            config = evalConfig.Config.parse_from_file(config)
+        self.eval_config = config
 
     def eval_flow_test_output(self, flow_test: FlowTestOutput) -> FlowTestOutput:
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -39,7 +39,7 @@ class Evaluator:
 
         bitrate_threshold: Optional[float] = None
         if item is not None:
-            bitrate_threshold = item.threshold
+            bitrate_threshold = item.get_threshold()
 
         success = True
         msg: Optional[str] = None

--- a/evaluator.py
+++ b/evaluator.py
@@ -31,16 +31,15 @@ class Evaluator:
 
     def eval_flow_test_output(self, flow_test: FlowTestOutput) -> FlowTestOutput:
 
-        bitrate_threshold: Optional[float] = None
+        item = self.eval_config.get_item(
+            test_type=flow_test.tft_metadata.test_type,
+            test_case_id=flow_test.tft_metadata.test_case_id,
+            is_reverse=flow_test.tft_metadata.reverse,
+        )
 
-        # We accept a missing eval_config entry.
-        cfg = self.eval_config.configs.get(flow_test.tft_metadata.test_type)
-        if cfg is not None:
-            cfg_test_case = cfg.test_cases.get(flow_test.tft_metadata.test_case_id)
-            if cfg_test_case is not None:
-                bitrate_threshold = cfg_test_case.get_threshold(
-                    is_reverse=flow_test.tft_metadata.reverse
-                )
+        bitrate_threshold: Optional[float] = None
+        if item is not None:
+            bitrate_threshold = item.threshold
 
         success = True
         msg: Optional[str] = None

--- a/generate_eval_config.py
+++ b/generate_eval_config.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+import sys
+
+from collections.abc import Iterable
+from typing import Any
+from typing import Optional
+
+from ktoolbox import common
+
+import tftbase
+
+from evalConfig import Config
+from evalConfig import EvalIdentity
+from tftbase import Bitrate
+from tftbase import TftResults
+
+
+logger = logging.getLogger("tft." + __name__)
+
+
+def load_config(config: Optional[str]) -> Optional[Config]:
+    if not config:
+        return None
+    return Config.parse_from_file(config)
+
+
+@common.iter_tuplify
+def load_logs(
+    logs: Iterable[str],
+    *,
+    skip_invalid_logs: bool = False,
+) -> Iterable[TftResults]:
+    for log in list(logs):
+        try:
+            tft_results = TftResults.parse_from_file(log)
+        except Exception as e:
+            if not skip_invalid_logs:
+                raise
+            # Failures are not fatal here. That is because the output format is
+            # not stable, so if we change the format, we may be unable to parse
+            # certain older logs. Skip.
+            logger.warning(f"Skip invalid file {repr(log)}: {e}")
+            continue
+        yield tft_results
+
+
+def collect_all_bitrates(
+    config: Optional[Config],
+    all_tft_results: Iterable[TftResults],
+) -> dict[EvalIdentity, list[Bitrate]]:
+    result: dict[EvalIdentity, list[Bitrate]]
+
+    if config is not None:
+        result = {ei: [] for ei in config.get_items()}
+    else:
+        result = {}
+
+    for tft_results in all_tft_results:
+        for tft_result in tft_results:
+            if not tft_result.eval_all_success:
+                # This result is not valid. We don't consider it for
+                # calculating the new thresholds.
+                #
+                # Note that this also includes eval_success fields, that is the
+                # result of a previous evaluation (with another eval-config).
+                # If you don't want that, run first ./evaluator.py on the
+                # input file with an empty eval-config, to clean out all
+                # previous evaluations.
+                continue
+            flow_test = tft_result.flow_test
+            ei = EvalIdentity.from_metadata(flow_test.tft_metadata)
+            lst = result.get(ei)
+            if lst is None:
+                if config is not None:
+                    # we only collect the items that we have in config too. Don't create a new one.
+                    continue
+                lst = []
+                result[ei] = lst
+            lst.append(flow_test.bitrate_gbps)
+    return result
+
+
+def calc_mean_stddev(data: list[float]) -> tuple[float, float]:
+    mean = sum(data) / len(data)
+    variance = sum((x - mean) ** 2 for x in data) / (len(data))
+    stddev: float = variance**0.5
+    return mean, stddev
+
+
+def accumulate_rate(
+    rate: Iterable[Optional[float]],
+    *,
+    quorum: int,
+) -> Optional[float]:
+    data = [x for x in rate if x is not None]
+
+    if not data or len(data) < quorum:
+        return None
+
+    mean, stddev = calc_mean_stddev(data)
+
+    # Filter out outliers outside 3 stddev.
+    data2 = [x for x in data if x > mean - 3 * stddev and x < mean + 3 * stddev]
+
+    if not data2 or len(data2) < quorum:
+        return None
+
+    mean, stddev = calc_mean_stddev(data2)
+
+    return max(
+        mean - 2.0 * stddev,
+        mean * 0.8,
+    )
+
+
+def accumulate_bitrates(
+    bitrates: list[Bitrate],
+    *,
+    quorum: int,
+) -> Bitrate:
+    rx = accumulate_rate((bitrate.rx for bitrate in bitrates), quorum=quorum)
+    tx = accumulate_rate((bitrate.tx for bitrate in bitrates), quorum=quorum)
+    return Bitrate(rx=rx, tx=tx)
+
+
+def _tighten_rate(
+    a: Optional[float], *, base: Optional[float], tighten_only: bool
+) -> Optional[float]:
+    if base is None:
+        return None
+    if a is None:
+        return base
+    if tighten_only:
+        return max(a, base)
+    return a
+
+
+@common.iter_dictify
+def accumulate_all_bitrates(
+    config: Optional[Config],
+    all_bitrates: dict[EvalIdentity, list[Bitrate]],
+    *,
+    tighten_only: bool,
+    quorum: int,
+) -> Iterable[tuple[EvalIdentity, Bitrate]]:
+    if config is not None:
+        assert list(all_bitrates) == list(config.get_items())
+    for ei, bitrates in all_bitrates.items():
+        bitrate = accumulate_bitrates(bitrates, quorum=quorum)
+        if config is not None:
+            item = config.get_item_for_id(ei)
+            assert item is not None
+            bitrate2 = item.bitrate
+
+            rx = _tighten_rate(bitrate.rx, base=bitrate2.rx, tighten_only=tighten_only)
+            tx = _tighten_rate(bitrate.tx, base=bitrate2.tx, tighten_only=tighten_only)
+            bitrate = Bitrate(rx=rx, tx=tx)
+        yield ei, bitrate
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Tool to generate eval-config.yaml TFT Flow test results"
+    )
+    parser.add_argument(
+        "logs",
+        nargs="*",
+        help="Result file from ocp-traffic-flow-tests.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output file to write new eval-config.yaml to.",
+    )
+    parser.add_argument(
+        "-S",
+        "--skip-invalid-logs",
+        action="store_true",
+        help='If set any invalid "--logs" files are ignored. This is useful because the output format is not stable, so your last logs might have been generated with an incompatible version and we want to skip those errors.',
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="For overwriting output file if it exists.",
+    )
+    parser.add_argument(
+        "-Q",
+        "--quorum",
+        default=0,
+        type=int,
+        help="If specified, require at least that many successful measurements for calculating a new threshold.",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        help="The base eval-config. If given, the result will contain all the entries from this input file. Values are updated with the measurementns from the logs.",
+    )
+    parser.add_argument(
+        "-T",
+        "--tighten-only",
+        action="store_true",
+        help="With '--config' the values are only updated if they tighten/lower the thresholds.",
+    )
+    common.log_argparse_add_argument_verbose(parser)
+
+    args = parser.parse_args()
+
+    common.log_config_logger(args.verbose, "tft", "ktoolbox")
+
+    if args.tighten_only and not args.config:
+        logger.error(
+            'Option "--tighten-only" requires a "--config" base configuration.'
+        )
+        sys.exit(4)
+
+    return args
+
+
+def log_data(
+    config: Optional[Config],
+    all_bitrates: dict[EvalIdentity, list[Bitrate]],
+    new_bitrates: dict[EvalIdentity, Bitrate],
+) -> None:
+    for ei, bitrates in all_bitrates.items():
+        config_bitrate: Optional[Bitrate] = None
+        if config is not None:
+            item = common.unwrap(config.get_item_for_id(ei))
+            config_bitrate = item.bitrate
+        new_bitrate = new_bitrates.get(ei)
+
+        if config is None:
+            msg = f"new={Bitrate.get_pretty_str(new_bitrate)}"
+        else:
+            msg = f"config={Bitrate.get_pretty_str(config_bitrate)}"
+            if config_bitrate != new_bitrate:
+                msg += f" ; new={Bitrate.get_pretty_str(new_bitrate)}"
+
+        bitrates_msg = (
+            "[rx=["
+            + ",".join(str(r.rx) for r in bitrates)
+            + "],tx=["
+            + ",".join(str(r.tx) for r in bitrates)
+            + "]]"
+        )
+        logger.debug(f"{ei.pretty_str}: {msg} ; bitrates={bitrates_msg}")
+
+
+def bitrate_to_yaml(bitrate: Bitrate) -> dict[str, Any]:
+    dd: dict[str, Any] = {}
+    common.dict_add_optional(dd, "threshold_rx", bitrate.rx)
+    common.dict_add_optional(dd, "threshold_tx", bitrate.tx)
+    return dd
+
+
+def generate_result_config(
+    config: Optional[Config],
+    bitrates: dict[EvalIdentity, Bitrate],
+) -> Config:
+    new_config: dict[str, list[dict[str, Any]]] = {}
+    handled: set[EvalIdentity] = set()
+    for ei in bitrates:
+        ei, ei_reverse = ei.both_directions()
+
+        if ei in handled:
+            continue
+        handled.add(ei)
+
+        if config is not None:
+            assert config.get_item_for_id(ei) or config.get_item_for_id(ei_reverse)
+
+        bitrate = bitrates.get(ei, Bitrate.NA)
+        bitrate_reverse = bitrates.get(ei_reverse, Bitrate.NA)
+
+        if config is None and bitrate.is_na and bitrate_reverse.is_na:
+            continue
+
+        lst = new_config.get(ei.test_type.name)
+        if lst is None:
+            lst = []
+            new_config[ei.test_type.name] = lst
+
+        list_entry: dict[str, Any] = {
+            "id": ei.test_case_id.name,
+        }
+        if not bitrate.is_na:
+            list_entry["Normal"] = bitrate_to_yaml(bitrate)
+        if not bitrate_reverse.is_na:
+            list_entry["Reverse"] = bitrate_to_yaml(bitrate_reverse)
+
+        lst.append(list_entry)
+
+    # Normalize the generated dictionary by sorting.
+    for lst in new_config.values():
+        lst.sort(key=lambda x: tftbase.TestCaseType[x["id"]].value)
+    keys = [
+        tftbase.TestType(n)
+        for n in sorted(tftbase.TestType[n].value for n in new_config)
+    ]
+    new_config = {test_type.name: new_config[test_type.name] for test_type in keys}
+
+    return Config.parse(new_config)
+
+
+def write_to_file(
+    config: Config,
+    *,
+    output: Optional[str],
+    force: bool,
+) -> None:
+
+    if not output:
+        config.serialize_to_file(sys.stdout)
+        return
+
+    if not force and os.path.exists(output):
+        logger.error(
+            f"The output file {repr(output)} already exists. Run with '--force' to overwrite"
+        )
+        sys.exit(55)
+
+    config.serialize_to_file(output)
+
+
+def main() -> None:
+    args = parse_args()
+
+    config = load_config(args.config)
+
+    all_tft_results = load_logs(
+        args.logs,
+        skip_invalid_logs=args.skip_invalid_logs,
+    )
+
+    all_bitrates = collect_all_bitrates(config, all_tft_results)
+
+    new_bitrates = accumulate_all_bitrates(
+        config,
+        all_bitrates,
+        tighten_only=args.tighten_only,
+        quorum=args.quorum,
+    )
+
+    log_data(config, all_bitrates, new_bitrates)
+
+    result_config = generate_result_config(config, new_bitrates)
+
+    write_to_file(
+        result_config,
+        output=args.output,
+        force=args.force or args.config == args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/generate-eval-config-output0.yaml
+++ b/tests/generate-eval-config-output0.yaml
@@ -1,294 +1,291 @@
-# Use `generate_eval_config.py` to update the configuration based on earlier
-# runs.
 IPERF_TCP:
-  - id: 1 # POD_TO_POD_SAME_NODE
-    Normal:
-      threshold: 18
-    Reverse:
-      threshold_rx: 18
-      threshold_tx: 18
-  - id: 2 # POD_TO_POD_DIFF_NODE
+  - id: POD_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 3 # POD_TO_HOST_SAME_NODE
+  - id: POD_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 4 # POD_TO_HOST_DIFF_NODE
+  - id: POD_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: POD_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 13 # HOST_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 14 # HOST_TO_HOST_DIFF_NODE
+  - id: HOST_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 15 # HOST_TO_POD_SAME_NODE
+  - id: HOST_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 16 # HOST_TO_POD_DIFF_NODE
+  - id: HOST_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: HOST_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 18
-  - id: 25 # POD_TO_EXTERNAL
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 18
     Reverse:
-      threshold: 10
-  - id: 26 # HOST_TO_EXTERNAL
+      threshold: 18
+  - id: POD_TO_EXTERNAL
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+  - id: HOST_TO_EXTERNAL
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
-  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
     Normal:
       threshold: 18
     Reverse:
       threshold: 10
 IPERF_UDP:
-  - id: 1 # POD_TO_POD_SAME_NODE
+  - id: POD_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 2 # POD_TO_POD_DIFF_NODE
+  - id: POD_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 3 # POD_TO_HOST_SAME_NODE
+  - id: POD_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 4 # POD_TO_HOST_DIFF_NODE
+  - id: POD_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 5 # POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 6 # POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 7 # POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 8 # POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 9 # POD_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 10 # POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 11 # POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 12 # POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 13 # HOST_TO_HOST_SAME_NODE
+  - id: HOST_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 14 # HOST_TO_HOST_DIFF_NODE
+  - id: HOST_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 15 # HOST_TO_POD_SAME_NODE
+  - id: HOST_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 16 # HOST_TO_POD_DIFF_NODE
+  - id: HOST_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 17 # HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 18 # HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 19 # HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 20 # HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 21 # HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 22 # HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 23 # HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 24 # HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 25 # POD_TO_EXTERNAL
+  - id: POD_TO_EXTERNAL
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 26 # HOST_TO_EXTERNAL
+  - id: HOST_TO_EXTERNAL
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 27 # POD_TO_POD_2ND_INTERFACE_SAME_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 28 # POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
     Normal:
       threshold: 5
     Reverse:
       threshold: 5
-  - id: 29 # POD_TO_POD_MULTI_NETWORK_POLICY
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
     Normal:
       threshold: 5
     Reverse:

--- a/tests/generate-eval-config-output1.yaml
+++ b/tests/generate-eval-config-output1.yaml
@@ -1,0 +1,119 @@
+IPERF_TCP:
+  - id: POD_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 20.167733333333334
+      threshold_tx: 20.222933333333334
+    Reverse:
+      threshold_rx: 21.877333333333333
+      threshold_tx: 21.817600000000002
+  - id: POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.4632
+      threshold_tx: 14.498400000000002
+    Reverse:
+      threshold_rx: 14.380000000000003
+      threshold_tx: 14.3476
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 37.126
+      threshold_tx: 37.3305
+    Reverse:
+      threshold_rx: 37.846
+      threshold_tx: 37.853
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.462000000000002
+      threshold_tx: 14.496800000000002
+    Reverse:
+      threshold_rx: 14.288800000000002
+      threshold_tx: 14.257600000000004
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 21.8175
+      threshold_tx: 21.8155
+    Reverse:
+      threshold_rx: 17.419
+      threshold_tx: 17.322999999999997
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 38.0935
+      threshold_tx: 38.2985
+    Reverse:
+      threshold_rx: 41.898
+      threshold_tx: 41.672999999999995
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.504399999999999
+      threshold_tx: 14.539200000000001
+    Reverse:
+      threshold_rx: 14.2616
+      threshold_tx: 14.2296
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 37.85750000000001
+      threshold_tx: 38.061
+    Reverse:
+      threshold_rx: 42.116
+      threshold_tx: 41.892
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 14.416
+      threshold_tx: 14.4512
+    Reverse:
+      threshold_rx: 14.149600000000001
+      threshold_tx: 14.1188
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 11.697000000000001
+      threshold_tx: 11.698500000000001
+    Reverse:
+      threshold_rx: 9.874000000000002
+      threshold_tx: 9.8472
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.7625
+      threshold_tx: 20.754500000000004
+    Reverse:
+      threshold_rx: 21.0064
+      threshold_tx: 20.9484
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.293000000000003
+      threshold_tx: 23.291999999999998
+    Reverse:
+      threshold_rx: 21.233499999999996
+      threshold_tx: 21.236
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 12.1365
+      threshold_tx: 12.200000000000001
+    Reverse:
+      threshold_rx: 9.7588
+      threshold_tx: 9.732400000000002
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.368000000000002
+      threshold_tx: 20.425200000000004
+    Reverse:
+      threshold_rx: 22.5945
+      threshold_tx: 22.605499999999996
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.3125
+      threshold_tx: 23.3415
+    Reverse:
+      threshold: 21.496
+  - id: POD_TO_EXTERNAL
+    Normal:
+      threshold_rx: 13.128680000000001
+      threshold_tx: 13.15728
+    Reverse:
+      threshold_rx: 13.15476
+      threshold_tx: 13.128640000000003
+  - id: HOST_TO_EXTERNAL
+    Normal:
+      threshold_rx: 13.14088
+      threshold_tx: 13.169799999999999
+    Reverse:
+      threshold_rx: 13.17192
+      threshold_tx: 13.14536

--- a/tests/generate-eval-config-output2.yaml
+++ b/tests/generate-eval-config-output2.yaml
@@ -1,0 +1,325 @@
+IPERF_TCP:
+  - id: POD_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 20.167733333333334
+      threshold_tx: 20.222933333333334
+    Reverse:
+      threshold_rx: 21.877333333333333
+      threshold_tx: 21.817600000000002
+  - id: POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.4632
+      threshold_tx: 14.498400000000002
+    Reverse:
+      threshold_rx: 14.380000000000003
+      threshold_tx: 14.3476
+  - id: POD_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 37.126
+      threshold_tx: 37.3305
+    Reverse:
+      threshold_rx: 37.846
+      threshold_tx: 37.853
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.462000000000002
+      threshold_tx: 14.496800000000002
+    Reverse:
+      threshold_rx: 14.288800000000002
+      threshold_tx: 14.257600000000004
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 21.8175
+      threshold_tx: 21.8155
+    Reverse:
+      threshold_rx: 17.419
+      threshold_tx: 17.322999999999997
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 38.0935
+      threshold_tx: 38.2985
+    Reverse:
+      threshold_rx: 41.898
+      threshold_tx: 41.672999999999995
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 14.504399999999999
+      threshold_tx: 14.539200000000001
+    Reverse:
+      threshold_rx: 14.2616
+      threshold_tx: 14.2296
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 37.85750000000001
+      threshold_tx: 38.061
+    Reverse:
+      threshold_rx: 42.116
+      threshold_tx: 41.892
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 14.416
+      threshold_tx: 14.4512
+    Reverse:
+      threshold_rx: 14.149600000000001
+      threshold_tx: 14.1188
+  - id: HOST_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 11.697000000000001
+      threshold_tx: 11.698500000000001
+    Reverse:
+      threshold_rx: 9.874000000000002
+      threshold_tx: 9.8472
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.7625
+      threshold_tx: 20.754500000000004
+    Reverse:
+      threshold_rx: 21.0064
+      threshold_tx: 20.9484
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.293000000000003
+      threshold_tx: 23.291999999999998
+    Reverse:
+      threshold_rx: 21.233499999999996
+      threshold_tx: 21.236
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold_rx: 12.1365
+      threshold_tx: 12.200000000000001
+    Reverse:
+      threshold_rx: 9.7588
+      threshold_tx: 9.732400000000002
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.368000000000002
+      threshold_tx: 20.425200000000004
+    Reverse:
+      threshold_rx: 22.5945
+      threshold_tx: 22.605499999999996
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.3125
+      threshold_tx: 23.3415
+    Reverse:
+      threshold: 21.496
+  - id: POD_TO_EXTERNAL
+    Normal:
+      threshold_rx: 13.128680000000001
+      threshold_tx: 13.15728
+    Reverse:
+      threshold_rx: 13.15476
+      threshold_tx: 13.128640000000003
+  - id: HOST_TO_EXTERNAL
+    Normal:
+      threshold_rx: 13.14088
+      threshold_tx: 13.169799999999999
+    Reverse:
+      threshold_rx: 13.17192
+      threshold_tx: 13.14536
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+IPERF_UDP:
+  - id: POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/tests/generate-eval-config-output3.yaml
+++ b/tests/generate-eval-config-output3.yaml
@@ -1,0 +1,310 @@
+IPERF_TCP:
+  - id: POD_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 20.167733333333334
+      threshold_tx: 20.222933333333334
+    Reverse:
+      threshold_rx: 21.877333333333333
+      threshold_tx: 21.817600000000002
+  - id: POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 37.126
+      threshold_tx: 37.3305
+    Reverse:
+      threshold_rx: 37.846
+      threshold_tx: 37.853
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 21.8175
+      threshold_tx: 21.8155
+    Reverse:
+      threshold: 18
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold_rx: 38.0935
+      threshold_tx: 38.2985
+    Reverse:
+      threshold_rx: 41.898
+      threshold_tx: 41.672999999999995
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 37.85750000000001
+      threshold_tx: 38.061
+    Reverse:
+      threshold_rx: 42.116
+      threshold_tx: 41.892
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.7625
+      threshold_tx: 20.754500000000004
+    Reverse:
+      threshold_rx: 21.0064
+      threshold_tx: 20.9484
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.293000000000003
+      threshold_tx: 23.291999999999998
+    Reverse:
+      threshold_rx: 21.233499999999996
+      threshold_tx: 21.236
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 18
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold_rx: 20.368000000000002
+      threshold_tx: 20.425200000000004
+    Reverse:
+      threshold_rx: 22.5945
+      threshold_tx: 22.605499999999996
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold_rx: 23.3125
+      threshold_tx: 23.3415
+    Reverse:
+      threshold: 21.496
+  - id: POD_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold_rx: 13.15476
+      threshold_tx: 13.128640000000003
+  - id: HOST_TO_EXTERNAL
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold_rx: 13.17192
+      threshold_tx: 13.14536
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
+    Normal:
+      threshold: 18
+    Reverse:
+      threshold: 10
+IPERF_UDP:
+  - id: POD_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_CLUSTER_IP_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_POD_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_POD_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_HOST_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_NODE_PORT_TO_HOST_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: HOST_TO_EXTERNAL
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_2ND_INTERFACE_SAME_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_2ND_INTERFACE_DIFF_NODE
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5
+  - id: POD_TO_POD_MULTI_NETWORK_POLICY
+    Normal:
+      threshold: 5
+    Reverse:
+      threshold: 5

--- a/tests/input1-RESULTS
+++ b/tests/input1-RESULTS
@@ -419,7 +419,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -783,7 +784,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -1206,8 +1208,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.925, rx=13.868) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.925, rx=13.868) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -1570,8 +1573,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.495, rx=13.547) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.495, rx=13.547) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -1995,7 +1999,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -2359,7 +2364,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -2782,8 +2788,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.852, rx=13.795) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.852, rx=13.795) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -3146,8 +3153,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.297, rx=13.347) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.297, rx=13.347) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -3571,7 +3579,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -3935,7 +3944,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -4359,7 +4369,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -4723,7 +4734,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -5147,7 +5159,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -5511,7 +5524,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -5934,8 +5948,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.972, rx=13.915) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.972, rx=13.915) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -6298,8 +6313,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.186, rx=13.236) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.186, rx=13.236) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -6723,7 +6739,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -7087,7 +7104,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -7510,8 +7528,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.675, rx=13.618) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.675, rx=13.618) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -7874,8 +7893,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.075, rx=13.124) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.075, rx=13.124) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -8299,7 +8319,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -8663,7 +8684,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -9086,8 +9108,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=12.276, rx=12.228) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=12.276, rx=12.228) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -9450,8 +9473,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.792, rx=13.845) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.792, rx=13.845) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -9875,7 +9899,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -10239,7 +10264,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -10663,7 +10689,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -11027,7 +11054,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -11451,7 +11479,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -11815,7 +11844,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -12238,8 +12268,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=12.237, rx=12.189) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=12.237, rx=12.189) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -12602,8 +12633,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=13.842, rx=13.895) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=13.842, rx=13.895) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -13027,7 +13059,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -13391,7 +13424,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -13815,7 +13849,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -14179,7 +14214,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -14602,8 +14638,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=9.3752, rx=9.3357) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=9.3752, rx=9.3357) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -14966,8 +15003,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=9.3376, rx=9.3729) is below threshold 10.0",
-          "bitrate_threshold": 10.0
+          "msg": "Run succeeded but Bitrate(tx=9.3376, rx=9.3729) is below RX threshold 10.0",
+          "bitrate_threshold_rx": 10.0,
+          "bitrate_threshold_tx": 10.0
         }
       },
       "plugins": []
@@ -15390,8 +15428,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=9.4165, rx=9.3762) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=9.4165, rx=9.3762) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": []
@@ -15754,8 +15793,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=9.3784, rx=9.4138) is below threshold 10.0",
-          "bitrate_threshold": 10.0
+          "msg": "Run succeeded but Bitrate(tx=9.3784, rx=9.4138) is below RX threshold 10.0",
+          "bitrate_threshold_rx": 10.0,
+          "bitrate_threshold_tx": 10.0
         }
       },
       "plugins": []

--- a/tests/input6-RESULTS
+++ b/tests/input6-RESULTS
@@ -999,7 +999,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -1960,7 +1961,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -3101,7 +3103,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -4062,7 +4065,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -5203,7 +5207,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -6164,7 +6169,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -7305,7 +7311,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -8266,7 +8273,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -9407,7 +9415,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -10349,7 +10358,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -11471,7 +11481,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -12413,7 +12424,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -13535,7 +13547,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -14496,7 +14509,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -15637,7 +15651,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -16598,7 +16613,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -17739,7 +17755,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -18700,7 +18717,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -19841,7 +19859,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -20802,7 +20821,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -21943,7 +21963,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -22885,7 +22906,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -24006,8 +24028,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=11.891, rx=11.874) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=11.891, rx=11.874) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -24948,8 +24971,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=10.826, rx=10.84) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=10.826, rx=10.84) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -26071,7 +26095,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -26994,7 +27019,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -28097,7 +28123,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -29020,7 +29047,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -30123,7 +30151,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -31065,7 +31094,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -32186,8 +32216,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=12.311, rx=12.294) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=12.311, rx=12.294) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -33128,8 +33159,9 @@
         },
         "eval_result": {
           "success": false,
-          "msg": "Run succeeded but Bitrate(tx=10.489, rx=10.502) is below threshold 18.0",
-          "bitrate_threshold": 18.0
+          "msg": "Run succeeded but Bitrate(tx=10.489, rx=10.502) is below RX threshold 18.0",
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -34251,7 +34283,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -35174,7 +35207,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -36277,7 +36311,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -37200,7 +37235,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -38303,7 +38339,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -39226,7 +39263,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 10.0
+          "bitrate_threshold_rx": 10.0,
+          "bitrate_threshold_tx": 10.0
         }
       },
       "plugins": [
@@ -40329,7 +40367,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 18.0
+          "bitrate_threshold_rx": 18.0,
+          "bitrate_threshold_tx": 18.0
         }
       },
       "plugins": [
@@ -41252,7 +41291,8 @@
         "eval_result": {
           "success": true,
           "msg": null,
-          "bitrate_threshold": 10.0
+          "bitrate_threshold_rx": 10.0,
+          "bitrate_threshold_tx": 10.0
         }
       },
       "plugins": [

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -342,3 +342,17 @@ def test_generate_eval_config(tmp_path: pathlib.Path) -> None:
         tmp_file,
     )
     _assert_filecmp(tmp_file, _test_file("generate-eval-config-output3.yaml"))
+
+
+def test_eval_config_yaml(tmp_path: pathlib.Path) -> None:
+
+    tmp_file = tmp_path / "tmp-eval-config1.yaml"
+
+    _run_generate_eval_config(
+        [
+            "--config",
+            EVAL_CONFIG_FILE,
+        ],
+        tmp_file,
+    )
+    _assert_filecmp(tmp_file, EVAL_CONFIG_FILE)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -112,7 +112,7 @@ def test_eval_config(test_eval_config: str) -> None:
     assert (
         c.configs[TestType.IPERF_UDP]
         .test_cases[TestCaseType.HOST_TO_NODE_PORT_TO_HOST_SAME_NODE]
-        .normal.threshold
+        .normal.get_threshold()
         == 5
     )
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -145,8 +145,8 @@ def test_eval_config(test_eval_config: str) -> None:
     assert c3.serialize_json() == json.dumps(
         {
             "id": "POD_TO_HOST_DIFF_NODE",
-            "Normal": {"threshold": 5.0},
-            "Reverse": {"threshold": 5.0},
+            "Normal": {"threshold": 5},
+            "Reverse": {"threshold": 5},
         }
     )
     assert c3.yamlpath == ".IPERF_UDP[3]"

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -109,6 +109,20 @@ def test_eval_config(test_eval_config: str) -> None:
 
     c = evalConfig.Config.parse(conf_dict)
 
+    item = (
+        c.configs[TestType.IPERF_UDP]
+        .test_cases[TestCaseType.HOST_TO_NODE_PORT_TO_HOST_SAME_NODE]
+        .normal
+    )
+
+    assert item is c.get_item(
+        test_type=TestType.IPERF_UDP,
+        test_case_id=TestCaseType.HOST_TO_NODE_PORT_TO_HOST_SAME_NODE,
+        is_reverse=False,
+    )
+    assert item.get_threshold() == 5
+    assert item.bitrate == tftbase.Bitrate(rx=5, tx=5)
+
     assert (
         c.configs[TestType.IPERF_UDP]
         .test_cases[TestCaseType.HOST_TO_NODE_PORT_TO_HOST_SAME_NODE]

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -64,6 +64,13 @@ TEST_EVAL_CONFIG_FILES = [
 ]
 
 
+def _assert_filecmp(file1: str | pathlib.Path, file2: str | pathlib.Path) -> None:
+    assert filecmp.cmp(
+        file1,
+        file2,
+    ), f"{repr(str(file1))} does not match {repr(str(file2))}"
+
+
 def _run_subprocess(
     command: list[str],
     **kwargs: Any,
@@ -217,10 +224,7 @@ def test_output_list_parse(
         assert all(isinstance(o, tftbase.TftResult) for o in test_collection1)
 
         if test_input_file.expected_outputfile is not None:
-            assert filecmp.cmp(
-                outputfile,
-                _test_file(test_input_file.expected_outputfile),
-            ), f"{repr(outputfile)} does not match {repr(_test_file(test_input_file.expected_outputfile))}"
+            _assert_filecmp(outputfile, _test_file(test_input_file.expected_outputfile))
 
         res = _run_print_results(outputfile)
         assert res.returncode in (0, 1)

--- a/tests/test_tftbase.py
+++ b/tests/test_tftbase.py
@@ -117,3 +117,19 @@ def test_iperf_output() -> None:
 
 def test_test_case_typ_infos() -> None:
     assert list(tftbase._test_case_typ_infos) == list(TestCaseType)
+
+
+def test_eval_binary_opt_in() -> None:
+
+    assert tftbase.eval_binary_opt_in(None, None) == (True, True)
+
+    assert tftbase.eval_binary_opt_in(False, None) == (False, True)
+    assert tftbase.eval_binary_opt_in(None, False) == (True, False)
+    assert tftbase.eval_binary_opt_in(True, None) == (True, False)
+    assert tftbase.eval_binary_opt_in(None, True) == (False, True)
+
+    assert tftbase.eval_binary_opt_in(False, False) == (False, False)
+    assert tftbase.eval_binary_opt_in(True, True) == (True, True)
+
+    assert tftbase.eval_binary_opt_in(True, False) == (True, False)
+    assert tftbase.eval_binary_opt_in(False, True) == (False, True)

--- a/tft.py
+++ b/tft.py
@@ -71,7 +71,7 @@ def main() -> None:
     )
     tft = TrafficFlowTests()
 
-    evaluator = Evaluator(config_path=tc.evaluator_config)
+    evaluator = Evaluator(tc.evaluator_config)
 
     for cfg_descr in ConfigDescriptor(tc).describe_all_tft():
         tft.test_run(cfg_descr, evaluator)

--- a/tftbase.py
+++ b/tftbase.py
@@ -71,6 +71,30 @@ TFT_TESTS = "tft-tests"
 T = typing.TypeVar("T")
 
 
+def eval_binary_opt_in(
+    a: Optional[bool],
+    b: Optional[bool],
+) -> tuple[bool, bool]:
+    if a is None and b is None:
+        # If both are unset, we return True,True
+        return True, True
+
+    # Normalize values to a Optional[bool].
+    if a is not None:
+        a = bool(a)
+    if b is not None:
+        b = bool(b)
+
+    # if one of the arguments is unset, it's the opposite
+    # of the other.
+    if a is None:
+        a = not b
+    if b is None:
+        b = not a
+
+    return a, b
+
+
 class ClusterMode(Enum):
     SINGLE = 1
     DPU = 3
@@ -171,15 +195,16 @@ class Bitrate:
         self,
         threshold: Optional[float],
         *,
-        tx: bool = False,
-        rx: bool = False,
+        rx: Optional[bool] = None,
+        tx: Optional[bool] = None,
     ) -> bool:
         if threshold is None:
             return True
-        if tx or not rx:
+        rx, tx = eval_binary_opt_in(rx, tx)
+        if tx:
             if self.tx is not None and self.tx < threshold:
                 return False
-        if rx or not tx:
+        if rx:
             if self.rx is not None and self.rx < threshold:
                 return False
         return True

--- a/tftbase.py
+++ b/tftbase.py
@@ -191,6 +191,10 @@ class Bitrate:
         if not self._valid_x(self.rx):
             raise ValueError("rx is not a valid bitrange")
 
+    @property
+    def is_na(self) -> bool:
+        return self.tx is None and self.rx is None
+
     def is_passing(
         self,
         threshold: Optional[float],
@@ -208,6 +212,16 @@ class Bitrate:
             if self.rx is not None and self.rx < threshold:
                 return False
         return True
+
+    @property
+    def pretty_str(self) -> str:
+        return f"[rx={self.rx},tx={self.tx}]"
+
+    @staticmethod
+    def get_pretty_str(bitrate: Optional["Bitrate"]) -> str:
+        if bitrate is None:
+            return "None"
+        return bitrate.pretty_str
 
 
 Bitrate.NA = Bitrate()

--- a/tftbase.py
+++ b/tftbase.py
@@ -248,7 +248,8 @@ class TestMetadata:
 class EvalResult:
     success: bool
     msg: Optional[str] = None
-    bitrate_threshold: Optional[float] = None
+    bitrate_threshold_rx: Optional[float] = None
+    bitrate_threshold_tx: Optional[float] = None
 
 
 @strict_dataclass


### PR DESCRIPTION
We had a similar tool, however that bitrot and no longer worked. It was
dropped in [1].

Bring something similar back, but it's also quite different.

The tool now takes a list of previous runs. It computes a new threshold
and writes an "eval-config.yaml".

It can also take an existing configuration with the "--config" option.
In that case it will keep the entries from the configuration and only
update the thresholds. With "--tigthen-only", it will only lower the
thresholds, not increase them.

This is an initial approach to answer [2]. Probably there are still
places to improve later. This is added now, so we have a place for doing
such improvements.

[1] https://github.com/wizhaoredhat/ocp-traffic-flow-tests/commit/137b00dcfb4025ab23011d21cb0860c73da922d2
[2] https://issues.redhat.com/browse/NHE-774
